### PR TITLE
ENSWEB-1560: Overzealous caching of sample ids.

### DIFF
--- a/modules/Bio/EnsEMBL/IO/Parser/BaseVCF4.pm
+++ b/modules/Bio/EnsEMBL/IO/Parser/BaseVCF4.pm
@@ -766,7 +766,10 @@ sub _get_sample_index_list {
   my $self = shift;
   my $sample_ids = shift;
 
-  if(!exists($self->{_sample_limit_list}->{$sample_ids})) {
+  my $cache_key = $sample_ids;
+  $cache_key = join("\n",sort @$sample_ids) if ref($sample_ids) eq 'ARRAY';
+
+  if(!exists($self->{_sample_limit_list}->{$cache_key})) {
 
     # clear the cache
     $self->{_sample_limit_list} = {};
@@ -788,10 +791,10 @@ sub _get_sample_index_list {
     }
 
     # key the hash on the reference of the list
-    $self->{_sample_limit_list}->{$sample_ids} = [sort {$a <=> $b} @limit];
+    $self->{_sample_limit_list}->{$cache_key} = [sort {$a <=> $b} @limit];
   }
 
-  return $self->{_sample_limit_list}->{$sample_ids};
+  return $self->{_sample_limit_list}->{$cache_key};
 }
 
 =head2 get_samples_info


### PR DESCRIPTION
If an array then key by contents of array not the ref which we might be unlucky and have cached before and it been reused.

This bug affects display of multiple puplation LD views on live site.