### PR TITLE
Keeping core API dependencies to a minimum

### DIFF
--- a/modules/Bio/EnsEMBL/IO/ColumnBasedParser.pm
+++ b/modules/Bio/EnsEMBL/IO/ColumnBasedParser.pm
@@ -28,7 +28,7 @@ package Bio::EnsEMBL::IO::ColumnBasedParser;
 use strict;
 use warnings;
 
-use Bio::EnsEMBL::Utils::Exception qw/throw/;
+use Carp;
 
 use base qw/Bio::EnsEMBL::IO::TextParser/;
 
@@ -94,7 +94,7 @@ sub get_fields {
 =cut
 
 sub set_fields {
-    throw("Method not implemented. This is really important");
+    confess("Method not implemented. This is really important");
 }
 
 =head2 get_minimum_column_count

--- a/modules/Bio/EnsEMBL/IO/HubParser.pm
+++ b/modules/Bio/EnsEMBL/IO/HubParser.pm
@@ -19,6 +19,7 @@ limitations under the License.
 package Bio::EnsEMBL::IO::HubParser;
 
 use strict;
+use warnings;
 
 sub new {
   my ($class, %args) = @_;

--- a/modules/Bio/EnsEMBL/IO/Parser.pm
+++ b/modules/Bio/EnsEMBL/IO/Parser.pm
@@ -39,8 +39,7 @@ package Bio::EnsEMBL::IO::Parser;
 use strict;
 use warnings;
 
-use Bio::EnsEMBL::Utils::Exception qw/throw/;
-use Bio::EnsEMBL::Utils::Scalar qw/assert_ref/;
+use Carp;
 use Bio::EnsEMBL::IO::Utils;
 
 =head2 new
@@ -158,7 +157,7 @@ sub metadataChanged {
 =cut
 
 sub seek {
-    throw("Method not implemented. Might not be applicable to your file format.");
+    confess("Method not implemented. Might not be applicable to your file format.");
 }
 
 =head2 read_block
@@ -171,7 +170,7 @@ sub seek {
 =cut
 
 sub read_block {
-    throw("Method not implemented. This is really important");
+    confess("Method not implemented. This is really important");
 }
 
 =head2 is_metadata
@@ -184,7 +183,7 @@ sub read_block {
 =cut
 
 sub is_metadata {
-    throw("Method not implemented. This is really important");
+    confess("Method not implemented. This is really important");
 }
 
 =head2 read_metadata
@@ -198,7 +197,7 @@ sub is_metadata {
 =cut
 
 sub read_metadata {
-    throw("Method not implemented. This is really important");
+    confess("Method not implemented. This is really important");
 }
 
 =head2 read_record
@@ -211,7 +210,7 @@ sub read_metadata {
 =cut
 
 sub read_record {
-    throw("Method not implemented. This is really important");
+    confess("Method not implemented. This is really important");
 }
 
 =head2 open
@@ -223,7 +222,7 @@ sub read_record {
 =cut
 
 sub open {
-    throw("Method not implemented. This is really important");
+    confess("Method not implemented. This is really important");
 }
 
 
@@ -236,7 +235,7 @@ sub open {
 =cut
 
 sub close {
-    throw("Method not implemented. This is really important");
+    confess("Method not implemented. This is really important");
 }
 
 =head2 open_as

--- a/modules/Bio/EnsEMBL/IO/Parser/BLASTFormatter.pm
+++ b/modules/Bio/EnsEMBL/IO/Parser/BLASTFormatter.pm
@@ -106,8 +106,7 @@ package Bio::EnsEMBL::IO::Parser::BLASTFormatter;
 
 use strict;
 use warnings;
-use Data::Dumper;
-use Bio::EnsEMBL::Utils::Exception qw/throw/;
+use Carp;
 
 use base qw/Bio::EnsEMBL::IO::ColumnBasedParser/;
 our ($AUTOLOAD);
@@ -132,17 +131,17 @@ sub open {
   my $class = ref($caller) || $caller;
  
   defined $filename or 
-    throw "Must provide name of the file to parse";
+    confess "Must provide name of the file to parse";
   -e $filename and -f $filename or
-    throw "Check file $filename exists and is readable";
+    confess "Check file $filename exists and is readable";
 
   defined $format or 
-    throw "Must provide format used to produce blast formatted output";
+    confess "Must provide format used to produce blast formatted output";
 
-  $format =~ /^(\d+)/ or throw "Invalid output format, must begin with number";
+  $format =~ /^(\d+)/ or confess "Invalid output format, must begin with number";
   my $alignment_view_option = $1;
   $alignment_view_option == 6 || $alignment_view_option == 7 || $alignment_view_option == 10 or 
-    throw "Invalid alignment view option: must be either 6, 7 or 10";
+    confess "Invalid alignment view option: must be either 6, 7 or 10";
 
   $format =~ s/^\d+?//;
   $format =~ s/^\s+?//;
@@ -183,7 +182,7 @@ sub open {
 sub set_fields {
   my $self = shift;
   my $format = $self->{params}{format_specifier};
-  defined $format or throw "Undefined BLAST output format";
+  defined $format or confess "Undefined BLAST output format";
   
   $self->{fields} = [ split /\s+/, $format ];
 
@@ -234,10 +233,10 @@ sub AUTOLOAD {
   $method =~ /get_(.+?)$/ unless $1;
   my $attr = $1;
   
-  throw("Invalid attribute method: ->$method()") 
+  confess("Invalid attribute method: ->$method()") 
     unless exists $self->{fields_index}{$attr};
   
-  throw "Cannot get attribute $attr, record is empty"
+  confess "Cannot get attribute $attr, record is empty"
     unless $self->{record};
 
   return $self->_trim($self->{record}[$self->{fields_index}{$attr}]);

--- a/modules/Bio/EnsEMBL/IO/Parser/BaseVCF4.pm
+++ b/modules/Bio/EnsEMBL/IO/Parser/BaseVCF4.pm
@@ -36,7 +36,7 @@ package Bio::EnsEMBL::IO::Parser::BaseVCF4;
 
 use strict;
 use warnings;
-use Bio::EnsEMBL::Utils::Exception qw(warning);
+use Carp;
 
 use base qw/Bio::EnsEMBL::IO::ColumnBasedParser/;
 
@@ -72,7 +72,7 @@ sub read_metadata {
         $version =~ /(\d+)\.(\d+)/;
         my ($parser_version_major, $parser_version_minor) = ($1, $2);
         
-        die "The VCF file format version $f_version is not compatible with the parser version (VCF v$version)" if ($file_version_major != $parser_version_major) || ($file_version_major == $parser_version_major && $parser_version_major < $file_version_major);
+        confess "The VCF file format version $f_version is not compatible with the parser version (VCF v$version)" if ($file_version_major != $parser_version_major) || ($file_version_major == $parser_version_major && $parser_version_major < $file_version_major);
         #warn "VCF file version $f_version may be incompatible with parser version $version" if ($file_version_major == $parser_version_major && $parser_version_minor != $file_version_minor);
       }
       else {
@@ -614,7 +614,7 @@ sub get_metadata_description {
   my $id   = shift;
   
   if (!defined($type) || !defined($id)) {
-    warning("You need to provide a meta type (e.g. 'INFO') and a meta entry ID (e.g. 'AA')");
+    carp("You need to provide a meta type (e.g. 'INFO') and a meta entry ID (e.g. 'AA')");
     return undef;
   }
   
@@ -787,7 +787,7 @@ sub _get_sample_index_list {
       }
 
       # it won't be much use if none of the sample names you gave appear in the file
-      throw("ERROR: No valid sample IDs given") unless scalar @limit;
+      confess("ERROR: No valid sample IDs given") unless scalar @limit;
     }
 
     # key the hash on the reference of the list
@@ -816,7 +816,7 @@ sub get_samples_info {
   if(defined($key)) {
     my %tmp = map {$formats->[$_] => $_} (0..$#{$formats});
     $format_index = $tmp{$key};
-    throw("ERROR: Key '$key' not found in format string ".join("|", @$formats)) unless defined($format_index);
+    confess("ERROR: Key '$key' not found in format string ".join("|", @$formats)) unless defined($format_index);
   }
 
   foreach my $sample (@{$self->get_raw_samples_info($sample_ids)}) {

--- a/modules/Bio/EnsEMBL/IO/Parser/BigBed.pm
+++ b/modules/Bio/EnsEMBL/IO/Parser/BigBed.pm
@@ -24,6 +24,7 @@ Bio::EnsEMBL::IO::Parser::BigBed - A line-based parser devoted to BigBed
 
 package Bio::EnsEMBL::IO::Parser::BigBed;
 use strict;
+use warnings;
 
 use Bio::DB::BigBed;
 

--- a/modules/Bio/EnsEMBL/IO/Parser/BigWig.pm
+++ b/modules/Bio/EnsEMBL/IO/Parser/BigWig.pm
@@ -24,6 +24,7 @@ Bio::EnsEMBL::IO::Parser::BigWig - A line-based parser devoted to BigWigs
 
 package Bio::EnsEMBL::IO::Parser::BigWig;
 use strict;
+use warnings;
 
 use Bio::DB::BigWig;
 

--- a/modules/Bio/EnsEMBL/IO/Parser/Pairwise.pm
+++ b/modules/Bio/EnsEMBL/IO/Parser/Pairwise.pm
@@ -36,7 +36,6 @@ package Bio::EnsEMBL::IO::Parser::Pairwise;
 
 use strict;
 use warnings;
-use Bio::EnsEMBL::Utils::Exception qw(warning);
 
 use base qw/Bio::EnsEMBL::IO::ColumnBasedParser/;
 

--- a/modules/Bio/EnsEMBL/IO/Parser/PairwiseSimple.pm
+++ b/modules/Bio/EnsEMBL/IO/Parser/PairwiseSimple.pm
@@ -42,7 +42,6 @@ package Bio::EnsEMBL::IO::Parser::PairwiseSimple;
 
 use strict;
 use warnings;
-use Bio::EnsEMBL::Utils::Exception qw(warning);
 
 use base qw/Bio::EnsEMBL::IO::TrackBasedParser/;
 

--- a/modules/Bio/EnsEMBL/IO/Parser/PairwiseTabix.pm
+++ b/modules/Bio/EnsEMBL/IO/Parser/PairwiseTabix.pm
@@ -36,7 +36,6 @@ package Bio::EnsEMBL::IO::Parser::PairwiseTabix;
 
 use strict;
 use warnings;
-use Bio::EnsEMBL::Utils::Exception qw(warning);
 use Bio::EnsEMBL::IO::TabixParser;
 use Bio::EnsEMBL::IO::Parser::Pairwise;
 

--- a/modules/Bio/EnsEMBL/IO/Parser/VCF4.pm
+++ b/modules/Bio/EnsEMBL/IO/Parser/VCF4.pm
@@ -36,7 +36,6 @@ package Bio::EnsEMBL::IO::Parser::VCF4;
 
 use strict;
 use warnings;
-use Bio::EnsEMBL::Utils::Exception qw(warning);
 
 use base qw/Bio::EnsEMBL::IO::Parser::BaseVCF4/;
 

--- a/modules/Bio/EnsEMBL/IO/Parser/VCF4Tabix.pm
+++ b/modules/Bio/EnsEMBL/IO/Parser/VCF4Tabix.pm
@@ -38,7 +38,6 @@ package Bio::EnsEMBL::IO::Parser::VCF4Tabix;
 
 use strict;
 use warnings;
-use Bio::EnsEMBL::Utils::Exception qw(warning);
 use Bio::EnsEMBL::IO::TabixParser;
 use Bio::EnsEMBL::IO::Parser::BaseVCF4;
 

--- a/modules/Bio/EnsEMBL/IO/TabixParser.pm
+++ b/modules/Bio/EnsEMBL/IO/TabixParser.pm
@@ -36,8 +36,7 @@ package Bio::EnsEMBL::IO::TabixParser;
 use strict;
 use warnings;
 
-use Bio::EnsEMBL::Utils::Exception qw/throw/;
-use Bio::EnsEMBL::Utils::Scalar qw/assert_ref/;
+use Carp;
 use Tabix;
 
 use base qw/Bio::EnsEMBL::IO::Parser/;
@@ -49,8 +48,8 @@ sub open {
   my $delimiter = "\t";   
   my $self = $class->SUPER::new(@other_args);
   
-  die "ERROR: tabix does not seem to be in your path - required to parse the file\n" unless `which tabix 2>&1` =~ /tabix$/;
-  die "ERROR: Input file is not bgzipped, cannot use tabix\n" unless $filename =~ /\.gz$/;
+  confess "ERROR: tabix does not seem to be in your path - required to parse the file\n" unless `which tabix 2>&1` =~ /tabix$/;
+  confess "ERROR: Input file is not bgzipped, cannot use tabix\n" unless $filename =~ /\.gz$/;
 	#die "ERROR: Tabix index file $filename.tbi not found, cannot use tabix\n" unless -e $filename.'.tbi';
   
   $self->{record}     = undef;

--- a/modules/Bio/EnsEMBL/IO/TextParser.pm
+++ b/modules/Bio/EnsEMBL/IO/TextParser.pm
@@ -38,8 +38,7 @@ package Bio::EnsEMBL::IO::TextParser;
 use strict;
 use warnings;
 
-use Bio::EnsEMBL::Utils::Exception qw/throw/;
-use Bio::EnsEMBL::Utils::Scalar qw/assert_ref/;
+use Carp;
 
 use base qw/Bio::EnsEMBL::IO::Parser/;
 
@@ -60,7 +59,7 @@ sub open {
     my $self = $class->SUPER::new(@other_args);
     if ($filename) {
       $self->{'filename'} = $filename;
-      CORE::open($self->{'filehandle'}, $filename) || throw("Could not open " . $filename);
+      CORE::open($self->{'filehandle'}, $filename) || confess("Could not open " . $filename);
     }
     return $self;
 }
@@ -81,7 +80,7 @@ sub open_content {
 
     my $self = $class->SUPER::new(@other_args);
     if ($content) {
-      CORE::open($self->{'filehandle'}, '<', \$content) || throw("Could not open in-memory file");
+      CORE::open($self->{'filehandle'}, '<', \$content) || confess("Could not open in-memory file");
     }
     return $self;
 }
@@ -113,7 +112,7 @@ sub read_block {
     if (eof($fh)) {
         $self->{'waiting_block'} = undef;
     } else {
-        $self->{'waiting_block'} = <$fh> || throw ("Error reading file handle: $!");   
+        $self->{'waiting_block'} = <$fh> || confess ("Error reading file handle: $!");   
     }    
 }
 

--- a/modules/Bio/EnsEMBL/IO/TokenBasedParser.pm
+++ b/modules/Bio/EnsEMBL/IO/TokenBasedParser.pm
@@ -40,8 +40,7 @@ package Bio::EnsEMBL::IO::TokenBasedParser;
 use strict;
 use warnings;
 
-use Bio::EnsEMBL::Utils::Exception qw/throw/;
-use Bio::EnsEMBL::Utils::Scalar qw/assert_ref/;
+use Carp;
 
 use base qw/Bio::EnsEMBL::IO::TextParser/;
 
@@ -49,7 +48,7 @@ sub open {
     my ($caller, $filename, $start_tag, $end_tag, @other_args) = @_;
 
     if (! defined $start_tag && ! defined $end_tag) {
-        throw("C'mon, gimme something to work with, you cannot define a TokenBasedParser without tokens!");
+        confess("C'mon, gimme something to work with, you cannot define a TokenBasedParser without tokens!");
     }
 
     my $class = ref($caller) || $caller;

--- a/modules/Bio/EnsEMBL/IO/TrackBasedParser.pm
+++ b/modules/Bio/EnsEMBL/IO/TrackBasedParser.pm
@@ -178,7 +178,7 @@ sub start_new_track {
 sub create_metadata {
   my ($self, $metadata) = @_;
   if (!$metadata || ref($metadata) ne 'HASH' || scalar keys %$metadata < 1) {
-    throw('Metadata not in correct format (hashref)');
+    confess('Metadata not in correct format (hashref)');
   }
 
   ## Save raw metadata to object, as records need it

--- a/modules/Bio/EnsEMBL/IO/Translator.pm
+++ b/modules/Bio/EnsEMBL/IO/Translator.pm
@@ -21,8 +21,6 @@ package Bio::EnsEMBL::IO::Translator;
 use strict;
 use warnings;
 
-use Bio::EnsEMBL::Utils::Exception qw/throw/;
-
 =head2 new
 
     Constructor

--- a/modules/Bio/EnsEMBL/IO/Translator/Feature.pm
+++ b/modules/Bio/EnsEMBL/IO/Translator/Feature.pm
@@ -27,7 +27,7 @@ package Bio::EnsEMBL::IO::Translator::Feature;
 use strict;
 use warnings;
 
-use Bio::EnsEMBL::Utils::Exception qw/throw/;
+use Carp;
 
 use base qw/Bio::EnsEMBL::IO::Translator/;
 

--- a/modules/Bio/EnsEMBL/IO/Translator/Gene.pm
+++ b/modules/Bio/EnsEMBL/IO/Translator/Gene.pm
@@ -27,7 +27,7 @@ package Bio::EnsEMBL::IO::Translator::Gene;
 use strict;
 use warnings;
 
-use Bio::EnsEMBL::Utils::Exception qw/throw/;
+use Carp;
 
 use base qw/Bio::EnsEMBL::IO::Translator::Feature/;
 

--- a/modules/Bio/EnsEMBL/IO/Translator/Transcript.pm
+++ b/modules/Bio/EnsEMBL/IO/Translator/Transcript.pm
@@ -27,7 +27,7 @@ package Bio::EnsEMBL::IO::Translator::Transcript;
 use strict;
 use warnings;
 
-use Bio::EnsEMBL::Utils::Exception qw/throw/;
+use Carp;
 
 use base qw/Bio::EnsEMBL::IO::Translator::Feature/;
 

--- a/modules/Bio/EnsEMBL/IO/Translator/VariationFeature.pm
+++ b/modules/Bio/EnsEMBL/IO/Translator/VariationFeature.pm
@@ -27,7 +27,7 @@ package Bio::EnsEMBL::IO::Translator::VariationFeature;
 use strict;
 use warnings;
 
-use Bio::EnsEMBL::Utils::Exception qw/throw/;
+use Carp;
 
 use base qw/Bio::EnsEMBL::IO::Translator::Feature/;
 

--- a/modules/Bio/EnsEMBL/IO/Writer.pm
+++ b/modules/Bio/EnsEMBL/IO/Writer.pm
@@ -20,9 +20,7 @@ package Bio::EnsEMBL::IO::Writer;
 
 use strict;
 use warnings;
-
-use Bio::EnsEMBL::Utils::IO qw/work_with_file/;
-use Bio::EnsEMBL::Utils::Exception qw/throw/;
+use Carp;
 
 =head2 new
 
@@ -43,7 +41,7 @@ sub new {
   eval "require $parser_class";
 
   if ($@) {
-    throw ("Cannot use $parser_class - format unknown ($@)");
+    confess ("Cannot use $parser_class - format unknown ($@)");
   }
   else {
     my $parser = $parser_class->open();
@@ -112,7 +110,7 @@ sub get_translator_by_type {
     eval "require $trans_class";
 
     if ($@) {
-      throw ("Cannot use $trans_class - data type unknown");
+      confess ("Cannot use $trans_class - data type unknown");
     }
     else {
       $self->{'translator'}{$type} = $trans_class->new($self->species_defs);
@@ -195,11 +193,11 @@ sub output_feature {
 
 sub write {
   my ($self, $content) = @_;
-  work_with_file($self->{'filename'}, '>>', sub{
-    my ($fh) = @_; 
-    print $fh $content; 
-    return;
-  });
+  my $file = $self->{filename};
+  open my $fh, '>>', $file or confess "Cannot open '${file}' for appending: $!";
+  print $fh $content or confess "Cannot write content to '${file}: $!";
+  close $fh or confess "Cannot close '${file}: $!";
+  return;
 }
 
 1;

--- a/modules/t/bed.t
+++ b/modules/t/bed.t
@@ -17,7 +17,6 @@ use warnings;
 
 use Test::More;
 
-use Bio::EnsEMBL::Utils::IO qw( work_with_file );
 use Bio::EnsEMBL::IO::Parser::Bed;
 
 my $test_file = "modules/t/data.bed";

--- a/modules/t/gff3.t
+++ b/modules/t/gff3.t
@@ -17,7 +17,6 @@ use warnings;
 
 use Test::More;
 
-use Bio::EnsEMBL::Utils::IO qw( work_with_file );
 use Bio::EnsEMBL::IO::Parser::GFF3;
 
 my $test_file = "modules/t/data.gff3";

--- a/modules/t/simple_list.t
+++ b/modules/t/simple_list.t
@@ -17,12 +17,11 @@ use warnings;
 
 use Test::More;
 
-use Bio::EnsEMBL::Utils::IO qw( work_with_file );
-use Bio::EnsEMBL::IO::Parser::SimpleList;
+use Bio::EnsEMBL::IO::ListBasedParser;
 
 my $test_file = "modules/t/data.txt";
 
-my $parser = Bio::EnsEMBL::IO::Parser::SimpleList->open($test_file);
+my $parser = Bio::EnsEMBL::IO::ListBasedParser->open($test_file);
 ok ($parser->next(), "Loading first record");
 ok ($parser->get_value() eq 'ENSMUST00000062783');
 ok ($parser->next(), "Loading second record");

--- a/modules/t/vep_input.t
+++ b/modules/t/vep_input.t
@@ -17,7 +17,6 @@ use warnings;
 
 use Test::More;
 
-use Bio::EnsEMBL::Utils::IO qw( work_with_file );
 use Bio::EnsEMBL::IO::Parser::VEP_input;
 
 my $test_file = "modules/t/data.vepi";

--- a/modules/t/vep_output.t
+++ b/modules/t/vep_output.t
@@ -17,7 +17,6 @@ use warnings;
 
 use Test::More;
 
-use Bio::EnsEMBL::Utils::IO qw( work_with_file );
 use Bio::EnsEMBL::IO::Parser::VEP_output;
 
 my $test_file = "modules/t/data.vepo";

--- a/modules/t/writer_snps.t
+++ b/modules/t/writer_snps.t
@@ -17,7 +17,6 @@ use warnings;
 
 use Test::More;
 
-use Bio::EnsEMBL::Utils::IO qw( work_with_file );
 use Bio::EnsEMBL::IO::Writer;
 use Bio::EnsEMBL::Registry;
 


### PR DESCRIPTION
It seems we have others within the team that would like to use ensembl-io but will not because of the core dependency. This commit attempts to

1. Remove any use of Utils::Exception and replace it with Carp
2. Remove any use of Utils::IO work_with_file and replace it with an open
3. Remove any unused/unnecessary imports (there were a lot)

Also this commit pulls up that simple_list.t is no longer a valid test because its dependencies are broken.