### PR TITLE
Respect the html parameter in trackDb file

### DIFF
--- a/modules/Bio/EnsEMBL/IO/HubParser.pm
+++ b/modules/Bio/EnsEMBL/IO/HubParser.pm
@@ -255,7 +255,11 @@ sub get_tracks {
     # any track which doesn't have any of these is definitely invalid
     if ($tracks{$id}{'type'} || $tracks{$id}{'shortLabel'} || $tracks{$id}{'longLabel'}) {
       $tracks{$id}{'track'}           = $id;
-      $tracks{$id}{'description_url'} = "$url/$id.html" unless $tracks{$id}{'parent'};
+      if($tracks{$id}{'parent'}) {
+        $tracks{$id}{'description_url'} = $tracks{$tracks{$id}{'parent'}}{'html'} ? "$url/$tracks{$tracks{$id}{'parent'}}{'html'}.html" : "$url/$tracks{$tracks{$id}{'parent'}}.html";
+      } else {
+        $tracks{$id}{'description_url'} = $tracks{$id}{'html'} ? "$url/$tracks{$id}{'html'}.html" : "$url/$id.html";
+      }
       
       unless ($tracks{$id}{'type'}) {
         ## Set type based on file extension


### PR DESCRIPTION
I have noticed the UCSC TrackHub specification has a html parameter for the description file URL (see https://genome.ucsc.edu/goldenPath/help/trackDb/trackDbHub.html#html), which appears not to be used by Ensembl.  Instead, Ensembl generates its own description URL based on the track name.

This modification looks for a html parameter before using Ensembl’s default assumed URL.  It also deals with inheritance of the parent's description if a parent value is specified.