### PR TITLE
Meaningful help on HTTP::Tiny errors.

### DIFF
--- a/modules/EnsEMBL/Web/File/Utils/URL.pm
+++ b/modules/EnsEMBL/Web/File/Utils/URL.pm
@@ -401,7 +401,10 @@ sub _get_http_tiny_error {
   my $response = shift;
 
   return 'timeout' unless $response->{'status'};
-  if ($response->{'status'} >= 400) {
+  if($response->{'status'} == 599) {
+    # HTTP::Tiny errors are reported via code 599.
+    return "Internal: $response->{'content'}";
+  } elsif($response->{'status'} >= 400) {
     return $response->{'status'}.': '.$response->{'reason'};
   }
   return;


### PR DESCRIPTION
HTTP::Tiny uses status code 599 for internal errors and puts a
description in the /body/, not the status line, which uselessly says
"Internal Exception". When reporting errors for status 599, use
content, not status line to report back up the chain.