### PR TITLE
Alter genotype field return type

### DIFF
--- a/modules/Bio/EnsEMBL/IO/Parser/BaseVCF4.pm
+++ b/modules/Bio/EnsEMBL/IO/Parser/BaseVCF4.pm
@@ -653,8 +653,8 @@ sub get_individual_column_indices {
 }
 
 =head2 get_raw_individuals_info
-    Description: Returns the list of individual name concatenated with the content of individual genotype data
-                 e.g. 'NA10000:0|1:44:23'
+    Description: Returns the listref of listrefs of individual name and individual genotype data
+                 e.g. ['NA10000', '0|1:44:23'], ['NA10001', '1|1:34:30']
     Returntype : List reference of strings
     Status     : DEPRECATED
 =cut
@@ -736,8 +736,8 @@ sub get_sample_column_indices {
 }
 
 =head2 get_raw_samples_info
-    Description: Returns the list of sample name concatenated with the content of sample genotype data
-                 e.g. 'NA10000:0|1:44:23'
+    Description: Returns the listref of listrefs of sample name and sample genotype data
+                 e.g. ['NA10000', '0|1:44:23'], ['NA10001', '1|1:34:30']
     Returntype : List reference of strings
 =cut
 
@@ -755,7 +755,7 @@ sub get_raw_samples_info {
   my @index_list = scalar @$limit ? @$limit : ($self->{sample_begin}..(scalar(@{$self->{metadata}{header}}) - 1));
 
   return [
-    map {$self->{metadata}{header}->[$_].':'.$self->{record}[$_]}
+    map {[$self->{metadata}{header}->[$_], $self->{record}[$_]]}
     @index_list
   ];
 }
@@ -819,8 +819,11 @@ sub get_samples_info {
     confess("ERROR: Key '$key' not found in format string ".join("|", @$formats)) unless defined($format_index);
   }
 
-  foreach my $sample (@{$self->get_raw_samples_info($sample_ids)}) {
-    my @sample_data = split(':',$sample);
+  foreach my $tmp_sample_data (@{$self->get_raw_samples_info($sample_ids)}) {
+
+    # first element is sample name, second element is ":"-separated string
+    my @sample_data = shift @$tmp_sample_data;
+    push @sample_data, split(':', $tmp_sample_data->[0]);
 
     # limit to one key
     if(defined($format_index)) {

--- a/modules/t/vcf.t
+++ b/modules/t/vcf.t
@@ -33,11 +33,11 @@ is_deeply($parser->{'record'},\@test_row,"Test basic parsing of a row");
 note "> Testing each column of the row";
 do_the_tests(\@test_row);
 my $index = 0;
-$test_sample = "$inds[$index]:$test_row[9]";
+$test_sample = [$inds[$index], $test_row[9]];
 $ind_info  = $parser->get_raw_individuals_info($inds[$index]);
-ok($test_sample eq $ind_info->[$index], 'Individual data (DEPRECATED)');
+is_deeply($test_sample, $ind_info->[$index], 'Individual data (DEPRECATED)');
 $sample_info = $parser->get_raw_samples_info($inds[$index]);
-ok($test_sample eq $sample_info->[$index], 'Sample data');
+is_deeply($test_sample, $sample_info->[$index], 'Sample data');
 
 
 note "Record 2";
@@ -47,11 +47,11 @@ is_deeply($parser->{'record'},\@test_row,"Test basic parsing of a row");
 note "> Testing each column of the row";
 do_the_tests(\@test_row);
 $index = 1;
-$test_sample = "$inds[$index]:$test_row[10]";
+$test_sample = [$inds[$index], $test_row[10]];
 $ind_info  = $parser->get_raw_individuals_info($inds[$index]);
-ok($test_sample eq $ind_info->[$index], 'Individual data (DEPRECATED)');
+is_deeply($test_sample, $ind_info->[$index], 'Individual data (DEPRECATED)');
 $sample_info = $parser->get_raw_samples_info($inds[$index]);
-ok($test_sample eq $sample_info->[$index], 'Sample data');
+is_deeply($test_sample, $sample_info->[$index], 'Sample data');
 
 
 note "Record 3";
@@ -61,11 +61,11 @@ is_deeply($parser->{'record'},\@test_row,"Test basic parsing of a row");
 note "> Testing each column of the row";
 do_the_tests(\@test_row);
 $index = 2;
-$test_sample = "$inds[$index]:$test_row[11]";
+$test_sample = [$inds[$index], $test_row[11]];
 $ind_info  = $parser->get_raw_individuals_info($inds[$index]);
-ok($test_sample eq $ind_info->[$index], 'Individual data (DEPRECATED)');
+is_deeply($test_sample, $ind_info->[$index], 'Individual data (DEPRECATED)');
 $sample_info  = $parser->get_raw_samples_info($inds[$index]);
-ok($test_sample eq $sample_info->[$index], 'Sample data');
+is_deeply($test_sample, $sample_info->[$index], 'Sample data');
 
 
 note "Record 4";
@@ -75,11 +75,11 @@ is_deeply($parser->{'record'},\@test_row,"Test basic parsing of a row");
 note "> Testing each column of the row";
 do_the_tests(\@test_row);
 $index = 0;
-$test_sample = "$inds[$index]:$test_row[9]";
+$test_sample = [$inds[$index], $test_row[9]];
 $ind_info  = $parser->get_raw_individuals_info($inds[$index]);
-ok($test_sample eq $ind_info->[$index], 'Individual data (DEPRECATED)');
+is_deeply($test_sample, $ind_info->[$index], 'Individual data (DEPRECATED)');
 $sample_info  = $parser->get_raw_samples_info($inds[$index]);
-ok($test_sample eq $sample_info->[$index], 'Sample data');
+is_deeply($test_sample, $sample_info->[$index], 'Sample data');
 
 
 note "Record 5";
@@ -89,11 +89,11 @@ is_deeply($parser->{'record'},\@test_row,"Test basic parsing of a row");
 note "> Testing each column of the row";
 do_the_tests(\@test_row);
 $index = 0;
-$test_sample = "$inds[$index]:$test_row[9]";
+$test_sample = [$inds[$index], $test_row[9]];
 $ind_info  = $parser->get_raw_individuals_info($inds[$index]);
-ok($test_sample eq $ind_info->[$index], 'Individual data (DEPRECATED)');
+is_deeply($test_sample, $ind_info->[$index], 'Individual data (DEPRECATED)');
 $sample_info  = $parser->get_raw_samples_info($inds[$index]);
-ok($test_sample eq $sample_info->[$index], 'Sample data');
+is_deeply($test_sample, $sample_info->[$index], 'Sample data');
 
 print "\n> Testing the getters (only for the last record):\n";
 ok($parser->get_seqname eq '20', 'get_seqname');

--- a/modules/t/vcf_sv.t
+++ b/modules/t/vcf_sv.t
@@ -33,11 +33,11 @@ my @test_row = (qw(1	2827694	rs2376870	CGTGGATGCGGGGAC	C	.	PASS	SVTYPE=DEL;END=2
 is_deeply($parser->{'record'},\@test_row,"Test basic parsing of a row");
 note "> Testing each column of the row";
 do_the_tests(\@test_row);
-$test_sample = "$inds[$index]:$test_row[9]";
+$test_sample = [$inds[$index], $test_row[9]];
 $ind_info  = $parser->get_raw_individuals_info($inds[$index]);
-ok($test_sample eq $ind_info->[$index], 'Individual data (DEPRECATED)');
+is_deeply($test_sample, $ind_info->[$index], 'Individual data (DEPRECATED)');
 $sample_info = $parser->get_raw_samples_info($inds[$index]);
-ok($test_sample eq $sample_info->[$index], 'Sample data');
+is_deeply($test_sample, $sample_info->[$index], 'Sample data');
 
 
 note "Record 2";
@@ -46,11 +46,11 @@ ok ($parser->next(), "Loading second record");
 is_deeply($parser->{'record'},\@test_row,"Test basic parsing of a row");
 note "> Testing each column of the row";
 do_the_tests(\@test_row);
-$test_sample = "$inds[$index]:$test_row[9]";
+$test_sample = [$inds[$index], $test_row[9]];
 $ind_info  = $parser->get_raw_individuals_info($inds[$index]);
-ok($test_sample eq $ind_info->[$index], 'Individual data (DEPRECATED)');
+is_deeply($test_sample, $ind_info->[$index], 'Individual data (DEPRECATED)');
 $sample_info = $parser->get_raw_samples_info($inds[$index]);
-ok($test_sample eq $sample_info->[$index], 'Sample data');
+is_deeply($test_sample, $sample_info->[$index], 'Sample data');
 
 
 note "Record 3";
@@ -59,11 +59,11 @@ ok ($parser->next(), "Loading third record");
 is_deeply($parser->{'record'},\@test_row,"Test basic parsing of a row");
 note "> Testing each column of the row";
 do_the_tests(\@test_row);
-$test_sample = "$inds[$index]:$test_row[9]";
+$test_sample = [$inds[$index], $test_row[9]];
 $ind_info  = $parser->get_raw_individuals_info($inds[$index]);
-ok($test_sample eq $ind_info->[$index], 'Individual data (DEPRECATED)');
+is_deeply($test_sample, $ind_info->[$index], 'Individual data (DEPRECATED)');
 $sample_info = $parser->get_raw_samples_info($inds[$index]);
-ok($test_sample eq $sample_info->[$index], 'Sample data');
+is_deeply($test_sample, $sample_info->[$index], 'Sample data');
 
 
 note "Record 4";
@@ -72,11 +72,11 @@ ok ($parser->next(), "Loading fourth record");
 is_deeply($parser->{'record'},\@test_row,"Test basic parsing of a row");
 note "> Testing each column of the row";
 do_the_tests(\@test_row);
-$test_sample = "$inds[$index]:$test_row[9]";
+$test_sample = [$inds[$index], $test_row[9]];
 $ind_info  = $parser->get_raw_individuals_info($inds[$index]);
-ok($test_sample eq $ind_info->[$index], 'Individual data (DEPRECATED)');
+is_deeply($test_sample, $ind_info->[$index], 'Individual data (DEPRECATED)');
 $sample_info = $parser->get_raw_samples_info($inds[$index]);
-ok($test_sample eq $sample_info->[$index], 'Sample data');
+is_deeply($test_sample, $sample_info->[$index], 'Sample data');
 
 
 note "Record 5";
@@ -85,11 +85,11 @@ ok ($parser->next(), "Loading fifth record");
 is_deeply($parser->{'record'},\@test_row,"Test basic parsing of a row");
 note "> Testing each column of the row";
 do_the_tests(\@test_row);
-$test_sample = "$inds[$index]:$test_row[9]";
+$test_sample = [$inds[$index], $test_row[9]];
 $ind_info  = $parser->get_raw_individuals_info($inds[$index]);
-ok($test_sample eq $ind_info->[$index], 'Individual data (DEPRECATED)');
+is_deeply($test_sample, $ind_info->[$index], 'Individual data (DEPRECATED)');
 $sample_info = $parser->get_raw_samples_info($inds[$index]);
-ok($test_sample eq $sample_info->[$index], 'Sample data');
+is_deeply($test_sample, $sample_info->[$index], 'Sample data');
 
 note "Record 6";
 ok ($parser->next(), "Loading sixth record");
@@ -97,11 +97,11 @@ ok ($parser->next(), "Loading sixth record");
 is_deeply($parser->{'record'},\@test_row,"Test basic parsing of a row");
 note "> Testing each column of the row";
 do_the_tests(\@test_row);
-$test_sample = "$inds[$index]:$test_row[9]";
+$test_sample = [$inds[$index], $test_row[9]];
 $ind_info  = $parser->get_raw_individuals_info($inds[$index]);
-ok($test_sample eq $ind_info->[$index], 'Individual data (DEPRECATED)');
+is_deeply($test_sample, $ind_info->[$index], 'Individual data (DEPRECATED)');
 $sample_info = $parser->get_raw_samples_info($inds[$index]);
-ok($test_sample eq $sample_info->[$index], 'Sample data');
+is_deeply($test_sample, $sample_info->[$index], 'Sample data');
 
 note "Testing the SV specific getters (only for the last record):";
 ok($parser->get_alternative_description('DUP:TANDEM') eq 'Tandem Duplication', 'get_alternative_description');

--- a/modules/t/vcf_tabix.t
+++ b/modules/t/vcf_tabix.t
@@ -36,11 +36,11 @@ note "Testing each column of the row";
 do_the_tests(\@test_row);
 my $index = 0;
 my $row_index = 9 + $index;
-$test_sample = "$inds[$index]:$test_row[$row_index]";
+$test_sample = [$inds[$index], $test_row[$row_index]];
 $ind_info  = $parser->get_raw_individuals_info($inds[$index]);
-ok($test_sample eq $ind_info->[$index], 'Individual data (DEPRECATED)');
+is_deeply($test_sample, $ind_info->[$index], 'Individual data (DEPRECATED)');
 $sample_info = $parser->get_raw_samples_info($inds[$index]);
-ok($test_sample eq $sample_info->[$index], 'Sample data');
+is_deeply($test_sample, $sample_info->[$index], 'Sample data');
 
 
 note "Record 2";
@@ -51,11 +51,11 @@ note "Testing each column of the row";
 do_the_tests(\@test_row);
 $index = 1;
 $row_index = 9 + $index;
-$test_sample = "$inds[$index]:$test_row[$row_index]";
+$test_sample = [$inds[$index], $test_row[$row_index]];
 $ind_info  = $parser->get_raw_individuals_info($inds[$index]);
-ok($test_sample eq $ind_info->[$index], 'Individual data (DEPRECATED)');
+is_deeply($test_sample, $ind_info->[$index], 'Individual data (DEPRECATED)');
 $sample_info = $parser->get_raw_samples_info($inds[$index]);
-ok($test_sample eq $sample_info->[$index], 'Sample data');
+is_deeply($test_sample, $sample_info->[$index], 'Sample data');
 
 
 note "Record 3";
@@ -66,11 +66,11 @@ note "Testing each column of the row";
 do_the_tests(\@test_row);
 $index = 2;
 $row_index = 9 + $index;
-$test_sample = "$inds[$index]:$test_row[$row_index]";
+$test_sample = [$inds[$index], $test_row[$row_index]];
 $ind_info  = $parser->get_raw_individuals_info($inds[$index]);
-ok($test_sample eq $ind_info->[$index], 'Individual data (DEPRECATED)');
+is_deeply($test_sample, $ind_info->[$index], 'Individual data (DEPRECATED)');
 $sample_info = $parser->get_raw_samples_info($inds[$index]);
-ok($test_sample eq $sample_info->[$index], 'Sample data');
+is_deeply($test_sample, $sample_info->[$index], 'Sample data');
 
 
 note "Record 4";
@@ -81,11 +81,11 @@ note "Testing each column of the row";
 do_the_tests(\@test_row);
 $index = 0;
 $row_index = 9 + $index;
-$test_sample = "$inds[$index]:$test_row[$row_index]";
+$test_sample = [$inds[$index], $test_row[$row_index]];
 $ind_info  = $parser->get_raw_individuals_info($inds[$index]);
-ok($test_sample eq $ind_info->[$index], 'Individual data (DEPRECATED)');
+is_deeply($test_sample, $ind_info->[$index], 'Individual data (DEPRECATED)');
 $sample_info = $parser->get_raw_samples_info($inds[$index]);
-ok($test_sample eq $sample_info->[$index], 'Sample data');
+is_deeply($test_sample, $sample_info->[$index], 'Sample data');
 
 
 print "\n> Testing the getters (only for the last record):\n";


### PR DESCRIPTION
get_raw_samples_info() was returning a ":"-delimited string where
the first element was the sample name. This broke downstream methods
when the sample name contained ":", so the method has been changed
to return a listref instead.