### PR TITLE
Bio::DB::HTS requirements added to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 
 ## File parsing and writing code for Ensembl
 
-The ensembl-io repo is intended as a shared codebase for handling 
-the parsing and writing of popular biological formats used by Ensembl, 
+The ensembl-io repo is intended as a shared codebase for handling
+the parsing and writing of popular biological formats used by Ensembl,
 such as BED, BigWig and FASTA. For a full list of supported formats,
 see the child objects in modules/Bio/EnsEMBL/IO/Parser/.
 
@@ -16,3 +16,11 @@ website to handle parsing of uploaded data and output of exported data.
 
 All parsers should have associated unit tests, which can also serve as
 simple tutorials on how to use ensembl-io.
+
+### Bio::DB::HTS
+
+Tabix and BAM/CRAM file access requires the Bio::DB::HTS module
+to be installed. For details on how to obtain and install this please
+see [https://github.com/Ensembl/Bio-HTS](https://github.com/Ensembl/Bio-HTS).
+
+Alternatively, Bio::DB::HTS can be installed from CPAN.


### PR DESCRIPTION
Letting the user know Bio::DB::HTS is required in certain situations.