### PR TITLE
exclude samples with uncalled genotypes

### DIFF
--- a/modules/Bio/EnsEMBL/IO/Parser/BaseVCF4.pm
+++ b/modules/Bio/EnsEMBL/IO/Parser/BaseVCF4.pm
@@ -864,12 +864,15 @@ sub get_samples_genotypes {
     next if $non_ref_only && $gt =~ /^(0[\\\|\/]?)+$/;
 
     my $phased = ($gt =~ /\|/ ? 1 : 0);
-    $sample_gen{$sample} = join(
+    my $translated_gt = join(
       ($phased ? '|' : '/'),
       map {$alleles[$_]}
       grep {$_ ne '.'}
       split(($phased ? '\|' : '/'), $gt)
     );
+    next if (!$translated_gt);
+    $sample_gen{$sample} = $translated_gt;
+
   }
   return \%sample_gen;
 }


### PR DESCRIPTION
Ignore samples with uncalled genotypes. This came up because of a display error of genotype counts. This is also a post-release for ensembl genomes. (ENSVAR-326)