### PR TITLE
call DESTROY to close tabix file

### DIFF
--- a/modules/Bio/EnsEMBL/IO/TabixParser.pm
+++ b/modules/Bio/EnsEMBL/IO/TabixParser.pm
@@ -101,7 +101,7 @@ sub read_block {
 sub close {
   my $self = shift;
   $self->{iterator}->close if $self->{iterator};
-  my $report = $self->{tabix_file}->close;
+  my $report = $self->{tabix_file}->DESTROY;
   return (defined $report) ? 0 : 1;
 }
 


### PR DESCRIPTION
Changes in Bio::DB::HTS::Tabix means the DESTROY function should be called instead of the close to pass Tabix tests.