### PR TITLE
specify only start when seeking a region

### DIFF
--- a/modules/Bio/EnsEMBL/IO/TabixParser.pm
+++ b/modules/Bio/EnsEMBL/IO/TabixParser.pm
@@ -69,7 +69,11 @@ sub seek {
   ## Check for both possible versions of chromosome name
   foreach ($chrom, "chr$chrom")
   {
-    $self->{iterator} = $self->{tabix_file}->query("$chrom:$start-$end") ;
+    if ($end) {
+      $self->{iterator} = $self->{tabix_file}->query("$chrom:$start-$end");
+    } else {
+      $self->{iterator} = $self->{tabix_file}->query("$chrom:$start");
+    }
     last if $self->{iterator};
   }
 


### PR DESCRIPTION
I would like to be able to seek the whole content of a VCF file using the TabixParser. Can we support chr:start next to chr:start-end? It is supported by Bio/DB/HTS/Tabix.pm. The code change is a suggestion. We can do this in a different way if preferred.
