### PR TITLE
Add VCF4 format for validation

### DIFF
--- a/modules/Bio/EnsEMBL/IO/Format/VCF4.pm
+++ b/modules/Bio/EnsEMBL/IO/Format/VCF4.pm
@@ -36,7 +36,7 @@ sub new {
   my $self = {
           'name'            => 'VCF4',
           'extensions'      => ['vcf'],
-          'delimiter'       => '\\t|\\s',
+          'delimiter'       => '\\t',
           'can_multitrack'  => 1,
           'can_metadata'    => -1,
           'metadata_info'   => {

--- a/modules/Bio/EnsEMBL/IO/Format/VCF4.pm
+++ b/modules/Bio/EnsEMBL/IO/Format/VCF4.pm
@@ -1,0 +1,110 @@
+=pod
+
+=head1 LICENSE
+
+Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+Copyright [2016-2017] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=head1 NAME
+
+Bio::EnsEMBL::IO::Format::VCF4 - an object that defines and validates VCF4 format
+
+=cut
+
+package Bio::EnsEMBL::IO::Format::VCF4;
+
+use strict;
+use warnings;
+
+use parent qw(Bio::EnsEMBL::IO::Format);
+
+sub new {
+  my $class = shift;
+
+  my $self = {
+          'name'            => 'VCF4',
+          'extensions'      => ['vcf'],
+          'delimiter'       => '\\t|\\s',
+          'can_multitrack'  => 1,
+          'can_metadata'    => -1,
+          'metadata_info'   => {
+              'INFO' => {
+                  'optional'    => 1, 
+                  'validate_as' => 'string'
+              },
+              'FILTER' => {
+                  'optional'    => 1,
+                  'validate_as' => 'string'
+              },
+              'FORMAT' => {
+                  'optional'    => 1, 
+                  'validate_as' => 'string'
+              },
+              'ALT' => {
+                  'optional'    => 1, 
+                  'validate_as' => 'string'
+              },
+              'SAMPLE' => {
+                  'optional'    => 1, 
+                  'validate_as' => 'string'
+              },
+              'PEDIGREE' => {
+                  'optional'    => 1, 
+                  'validate_as' => 'string'
+              }
+          },
+          'field_info'    => {
+              'seqname' => {
+                  'validate_as' => 'string',
+                  'optional'    => 0  
+              },
+              'start' => {
+                  'validate_as' => 'integer',
+                  'optional'    => 0  
+              },
+              'IDs' => {
+                  'validate_as' => 'string',
+                  'optional'    => 0  
+              },
+              'reference' => {
+                  'validate_as' => 'string',
+                  'optional'    => 0  
+              },
+              'alternatives' => {
+                  'validate_as' => 'string',
+                  'optional'    => 0  
+              },
+              'score' => {
+                  'validate_as' => 'string',
+                  'optional'    => 0  
+              },
+              'filter_results' => {
+                  'validate_as' => 'string',
+                  'optional'    => 0  
+              },
+              'info' => {
+                  'validate_as' => 'string',
+                  'optional'    => 0  
+              }
+          },
+          'field_order'   => [qw(seqname start IDs reference alternatives score filter_results info)],
+  };
+
+  bless $self, $class;
+
+  return $self;
+}
+
+1;

--- a/modules/Bio/EnsEMBL/IO/Parser/BaseVCF4.pm
+++ b/modules/Bio/EnsEMBL/IO/Parser/BaseVCF4.pm
@@ -39,9 +39,25 @@ use strict;
 use warnings;
 use Carp;
 
+use Bio::EnsEMBL::IO::Format::VCF4;
+
 use base qw/Bio::EnsEMBL::IO::ColumnBasedParser/;
 
 my $version = 4.2;
+
+=head2 add_format
+
+    Description : Add a format object and configure the parser
+    Returntype  : none
+
+=cut
+
+sub add_format {
+  my $self = shift;
+  my $class = "Bio::EnsEMBL::IO::Format::VCF4";
+  my $format = $class->new();
+  $self->format($format);
+}
 
 sub next {
   my $self = shift;

--- a/modules/Bio/EnsEMBL/IO/Parser/VCF4.pm
+++ b/modules/Bio/EnsEMBL/IO/Parser/VCF4.pm
@@ -45,7 +45,7 @@ sub open {
     my ($caller, $filename, @other_args) = @_;
     my $class = ref($caller) || $caller;
 
-    my $delimiter = "\\t|\\s";
+    my $delimiter = "\\t";
     my $self = $class->SUPER::open($filename, $delimiter, @other_args);
     
     # pre-load peek buffer

--- a/modules/Bio/EnsEMBL/IO/Parser/VCF4.pm
+++ b/modules/Bio/EnsEMBL/IO/Parser/VCF4.pm
@@ -44,13 +44,13 @@ use base qw/Bio::EnsEMBL::IO::Parser::BaseVCF4/;
 sub open {
     my ($caller, $filename, @other_args) = @_;
     my $class = ref($caller) || $caller;
-     
-    my $delimiter = "\t";
+
+    my $delimiter = "\\t|\\s";
     my $self = $class->SUPER::open($filename, $delimiter, @other_args);
     
     # pre-load peek buffer
     $self->next_block();
-    
+
     return $self;
 }
 

--- a/modules/t/vcf.t
+++ b/modules/t/vcf.t
@@ -121,6 +121,10 @@ ok($parser->get_metadata_by_pragma('fileDate') eq '20090805', 'getMetadataByPrag
 ok($parser->get_vcf_version eq 'VCFv4.2', 'getVCFversion');
 ok($parser->get_metadata_description('INFO', 'AA') eq 'Ancestral Allele', 'getMetaDescription'); 
 
+note "> Testing format validation";
+$parser->reset();
+ok ($parser->validate(), "Validating vcf format");
+    
 ok ($parser->close(), "Closing file");
 
 done_testing();

--- a/modules/t/vcf_sv.t
+++ b/modules/t/vcf_sv.t
@@ -113,6 +113,10 @@ ok($parser->get_inner_end == 18665194, 'get_inner_end');
 ok($parser->get_end == 18665204, 'get_end');
 ok($parser->get_outer_end == 18665214, 'get_outer_end');
 
+note "> Testing format validation";
+$parser->reset();
+ok ($parser->validate(), "Validating vcf format");
+
 ok ($parser->close(), "Closing file");
 
 done_testing();


### PR DESCRIPTION
Previoiusly because of the lack of VCF4 format definition, the user upload of VCF
type data (stored in text) could not be validated. This change is intended to add
this missing information so that those VCF records could be validated and parsed.

Also add space as a valid delimiter in addition to tab. I know this is violating
the VCF4.x specs. But I could not get tab delimited VCF record to work. I don't
know why.

Related to ENSEMBL-5050.