### PR TITLE
Genbank has removed GI identifier in the genbank files

### DIFF
--- a/modules/Bio/EnsEMBL/IO/Parser/Genbank.pm
+++ b/modules/Bio/EnsEMBL/IO/Parser/Genbank.pm
@@ -94,7 +94,6 @@ sub read_record {
         elsif ($field_type eq 'VERSION') {
             if ($field =~ /\S+\.(\d+)/) {
                 $self->{'record'}->{'_version'} = $1;
-                $self->{'record'}->{'_genebank_id'} = $2;
             }
             else {
                 $self->{'record'}->{'_version'} = $field;

--- a/modules/Bio/EnsEMBL/IO/Parser/Genbank.pm
+++ b/modules/Bio/EnsEMBL/IO/Parser/Genbank.pm
@@ -470,7 +470,7 @@ sub get_features {
                 push @features,$self->_finish_feature(\%feature, $line_buffer) if %feature;
                 undef %feature;
                 $line_buffer = '';
-                my ($header,$position) = $line =~ /^\s{5}(\w+)\s+(.+)/;
+                my ($header,$position) = $line =~ /^\s{5}(\S+)\s+(.+)/;
                 # Note that position can be complement() and or join(coord1,coord2)
                 %feature = ( header => $header, position => $position);
             } else {

--- a/modules/Bio/EnsEMBL/IO/Parser/Genbank.pm
+++ b/modules/Bio/EnsEMBL/IO/Parser/Genbank.pm
@@ -92,12 +92,15 @@ sub read_record {
             $self->{'record'}->{'_raw_accession'} = $field;
         }
         elsif ($field_type eq 'VERSION') {
-            if ($field =~ /\S+\.(\d+)\s+GI:(\d+)/) {
+            if ($field =~ /\S+\.(\d+)/) {
                 $self->{'record'}->{'_version'} = $1;
                 $self->{'record'}->{'_genebank_id'} = $2;
             }
             else {
                 $self->{'record'}->{'_version'} = $field;
+            }
+            if ($field =~ /GI:(\d+)/) {
+              $self->{'record'}->{'_genebank_id'} = $1;
             }
         }
         elsif ($field_type eq 'COMMENT' || $field_type eq 'REFERENCE') {
@@ -245,7 +248,7 @@ sub get_accession {
 sub get_sequence_name {
     my $self = shift;
 
-    return $self->{'record'}->{'_accession'}.'.'.$self->{'record'}->{'_version'};
+    return $self->get_accession.'.'.$self->{'record'}->{'_version'};
 }
 
 =head2 get_genbank_id

--- a/modules/Bio/EnsEMBL/IO/Parser/Genbank.pm
+++ b/modules/Bio/EnsEMBL/IO/Parser/Genbank.pm
@@ -66,6 +66,9 @@ sub is_metadata {
 sub read_record {
     my $self = shift;
     
+    while (!$self->is_at_beginning_of_record) {
+      $self->next_block;
+    }
     while (!$self->is_at_end_of_record) {
         my ($field_type, $field) = $self->{'current_block'} =~ /^(\w+)\s+(.*)/;
         unless (defined($field_type)) { croak ("Genbank record parsing going badly.\n".$self->{current_block}."\n".$self->{filename}) };

--- a/modules/Bio/EnsEMBL/IO/Parser/Genbank.pm
+++ b/modules/Bio/EnsEMBL/IO/Parser/Genbank.pm
@@ -101,6 +101,9 @@ sub read_record {
             if ($field =~ /GI:(\d+)/) {
               $self->{'record'}->{'_genebank_id'} = $1;
             }
+            else {
+              $self->{'record'}->{'_genebank_id'} = undef;
+            }
         }
         elsif ($field_type eq 'COMMENT' || $field_type eq 'REFERENCE') {
             # REFERENCE is not used by the genebuild team so it can be "removed"

--- a/modules/t/genbank.t
+++ b/modules/t/genbank.t
@@ -32,6 +32,26 @@ my $feature = $features[2];
 is($feature->{gene}->[0],'TRNF','Check correct gene extracted from feature block');
 is_deeply($feature->{db_xref}, ['GeneID:4558','HGNC:7481','MIM:590070'], 'Xrefs extracted from feature are correct');
 
+ok ($parser->next(), "Loading second record");
+is($parser->get_accession,'NM_001100954',"Testing get_accession");
+is($parser->get_sequence_name,'NM_001100954.1',"Testing get_sequence_name");
+is($parser->get_sequence_version,'1',"Testing get_sequence_version");
+is($parser->get_length,'558',"Testing get_length");
+is($parser->get_organism,'Danio rerio',"Testing get_organism");
+is($parser->get_description,'Danio rerio si:dkey-111e8.5 (si:dkey-111e8.5), mRNA.',"Testing get_description with multiline definition");
+is($parser->get_locus_id,'NM_001100954',"Testing get_locus_id");
+is($parser->get_sequence_type,'mRNA',"Testing get_sequence_type");
+is($parser->get_modification_date,'06-AUG-2017',"Testing get_modification_date");
+is($parser->get_source,'Danio rerio (zebrafish)',"Testing get_source");
+is($parser->get_taxon_id,'7955',"Testing get_taxon_id");
+cmp_ok($parser->is_circular, '==', 0, "Testing is_circular");
+ok($parser->get_length == length($parser->get_sequence), "Testing length of the sequence");
+
+@features = @{ $parser->get_features };
+cmp_ok(scalar @features,'==', 3, "Testing number of features");
+$feature = $features[2];
+is($feature->{gene}->[0],'si:dkey-111e8.5','Check correct gene extracted from feature block');
+is_deeply($feature->{db_xref}, ['GeneID:566993','ZFIN:ZDB-GENE-060526-192'], 'Xrefs extracted from feature are correct');
 
 ok ($parser->close(), "Closing file");
 

--- a/modules/t/input/data.gbk
+++ b/modules/t/input/data.gbk
@@ -1300,3 +1300,76 @@ ORIGIN
     16561 atcacgatg
 //
 
+LOCUS       NM_001100954             558 bp    mRNA    linear   VRT 06-AUG-2017
+DEFINITION  Danio rerio si:dkey-111e8.5 (si:dkey-111e8.5), mRNA.
+ACCESSION   NM_001100954 XM_690278
+VERSION     NM_001100954.1
+KEYWORDS    RefSeq.
+SOURCE      Danio rerio (zebrafish)
+  ORGANISM  Danio rerio
+            Eukaryota; Metazoa; Chordata; Craniata; Vertebrata; Euteleostomi;
+            Actinopterygii; Neopterygii; Teleostei; Ostariophysi;
+            Cypriniformes; Cyprinidae; Danio.
+REFERENCE   1  (bases 1 to 558)
+  AUTHORS   Pasquier J, Cabau C, Nguyen T, Jouanno E, Severac D, Braasch I,
+            Journot L, Pontarotti P, Klopp C, Postlethwait JH, Guiguen Y and
+            Bobe J.
+  TITLE     Gene evolution and gene expression after whole genome duplication
+            in fish: the PhyloFish database
+  JOURNAL   BMC Genomics 17, 368 (2016)
+   PUBMED   27189481
+  REMARK    Publication Status: Online-Only
+COMMENT     PREDICTED REFSEQ: This record has not been reviewed and the
+            function is unknown. The reference sequence was derived from
+            BX640520.13.
+            On Mar 7, 2008 this sequence version replaced XM_690278.2.
+
+            ##Evidence-Data-START##
+            CDS exon combination :: GDQH01007158.1, GDQQ01020927.1
+                                    [ECO:0000331]
+            RNAseq introns       :: mixed/partial sample support SAMEA2168446,
+                                    SAMEA2168447 [ECO:0000350]
+            ##Evidence-Data-END##
+PRIMARY     REFSEQ_SPAN         PRIMARY_IDENTIFIER PRIMARY_SPAN        COMP
+            1-13                BX640520.13        784-796
+            14-223              BX640520.13        2305-2514
+            224-408             BX640520.13        2637-2821
+            409-493             BX640520.13        3013-3097
+            494-558             BX640520.13        3192-3256
+FEATURES             Location/Qualifiers
+     source          1..558
+                     /organism="Danio rerio"
+                     /mol_type="mRNA"
+                     /strain="Tuebingen"
+                     /db_xref="taxon:7955"
+                     /chromosome="5"
+                     /map="5"
+     gene            1..558
+                     /gene="si:dkey-111e8.5"
+                     /note="si:dkey-111e8.5"
+                     /db_xref="GeneID:566993"
+                     /db_xref="ZFIN:ZDB-GENE-060526-192"
+     CDS             1..558
+                     /gene="si:dkey-111e8.5"
+                     /codon_start=1
+                     /product="uncharacterized protein LOC566993"
+                     /protein_id="NP_001094424.1"
+                     /db_xref="GeneID:566993"
+                     /db_xref="ZFIN:ZDB-GENE-060526-192"
+                     /translation="MLEKIYYKVMTPKNVEQTALEFEENLKKNIKYVKLKNVERGKKT
+                     REKPSDVHLAFCPVVSRTGTDIDATLKKIKDDTPTILVVLHHTFDTEVVVSNSSTFVA
+                     RENMLVVDCLFYEGKGLLACKKNKEAYKEAAKWLKNRKEAVGNSSRKQDTSSPDVRSS
+                     RNDHNRDERKKPDASKKKKKTCVIL"
+ORIGIN
+        1 atgttggaaa aaatttatta caaagtcatg acacctaaaa atgttgaaca aactgctcta
+       61 gaattcgagg aaaatctaaa aaagaatata aaatatgtta aattaaaaaa tgtggagagg
+      121 ggaaaaaaaa caagagaaaa gcccagtgat gttcacctgg ctttctgtcc ggtagtttct
+      181 cgcactggaa ctgacattga tgcgacactc aagaaaatta aagacgatac accgaccatt
+      241 ttagtggtgc ttcatcacac atttgacact gaggttgttg tgtcaaatag cagtacattt
+      301 gtggcaaggg agaatatgct tgttgttgac tgtctgttct acgagggtaa aggattgctt
+      361 gcctgtaaaa aaaataagga ggcttataaa gaagctgcaa agtggctaaa aaaccgaaag
+      421 gaagctgttg gcaattcaag ccgcaagcag gacacatcct ccccagatgt ccggtctagt
+      481 agaaatgatc ataatagaga tgaacgcaaa aaacctgatg cctccaagaa aaaaaagaaa
+      541 acttgtgtta ttctctga
+//
+


### PR DESCRIPTION
Do not look for GI in VERSION in the first regex. Still looking for GI if line has VERSION
Bug fix: Call get_accession instead of direct hash access to avoid accession to not be initialised