### PR TITLE
Fix of hard coded test data file paths in tests

### DIFF
--- a/modules/t/bed.t
+++ b/modules/t/bed.t
@@ -19,8 +19,9 @@ use warnings;
 use Test::More;
 
 use Bio::EnsEMBL::IO::Parser::Bed;
+use FindBin;
 
-my $test_file = "modules/t/input/data.bed";
+my $test_file = $FindBin::Bin . '/input/data.bed';
 
 my $parser = Bio::EnsEMBL::IO::Parser::Bed->open($test_file);
 ok ($parser->next(), "Loading first record");

--- a/modules/t/bigbed.t
+++ b/modules/t/bigbed.t
@@ -18,11 +18,13 @@ use warnings;
 
 use Test::More;
 use Bio::EnsEMBL::IO::Parser::BigBed;
+use FindBin;
 
 ######################################################
 ## Test 1
 ######################################################
-my $parser = Bio::EnsEMBL::IO::Parser::BigBed->open('modules/t/input/data.bb');
+my $test_file = $FindBin::Bin . '/input/data.bb';
+my $parser = Bio::EnsEMBL::IO::Parser::BigBed->open($test_file);
 ok($parser->seek(1, 1, 10));
 
 ok($parser->next());

--- a/modules/t/bigwig.t
+++ b/modules/t/bigwig.t
@@ -18,11 +18,13 @@ use warnings;
 
 use Test::More;
 use Bio::EnsEMBL::IO::Parser::BigWig;
+use FindBin;
 
 ######################################################
 ## Test 1
 ######################################################
-my $parser = Bio::EnsEMBL::IO::Parser::BigWig->open("modules/t/input/data-variableStep.bw");
+my $test_file = $FindBin::Bin . '/input/data-variableStep.bw';
+my $parser = Bio::EnsEMBL::IO::Parser::BigWig->open($test_file);
 ok($parser->seek(1, 1, 100));
 
 ok($parser->next);
@@ -47,7 +49,8 @@ $parser->close();
 ######################################################
 ## Test 2
 ######################################################
-$parser = Bio::EnsEMBL::IO::Parser::BigWig->open('modules/t/input/data-fixedStep.bw');
+$test_file = $FindBin::Bin . '/input/data-fixedStep.bw';
+$parser = Bio::EnsEMBL::IO::Parser::BigWig->open($test_file);
 ok($parser->seek(1, 1, 100));
 
 for (my $i = 1; $i < 10; $i ++) {

--- a/modules/t/blast_formatter.t
+++ b/modules/t/blast_formatter.t
@@ -22,9 +22,8 @@ use Test::Exception;
 
 BEGIN { use_ok('Bio::EnsEMBL::IO::Parser::BLASTFormatter'); } 
 
-my $prefix = $FindBin::Bin;
 my $parser;
-my $test_file = "$prefix/input/blast_test.6.default.tab";
+my $test_file = $FindBin::Bin . '/input/blast_test.6.default.tab';
 
 ###########################################
 #
@@ -101,7 +100,7 @@ throws_ok { $parser->get_mismatch() }
 #
 note("Test tabular format with default specifiers");
 $outfmt = 6; # default format specifiers
-$test_file = "$prefix/input/blast_test.6.default.tab";
+$test_file = $FindBin::Bin . '/input/blast_test.6.default.tab';
 $parser = Bio::EnsEMBL::IO::Parser::BLASTFormatter->open($test_file, $outfmt);
 ok($parser->next(), "Loading first record");
 my @expected_record = ( qw/gnl|MYDB|1	gi|405832|gb|U00001.1|HSCDC27	100.00	720	0	0	1	720	1	720	0.0	1330/ );
@@ -135,7 +134,7 @@ ok(!$parser->next(), 'No more records');
 #
 note("Test Compara format specifiers");
 $outfmt = '7 qacc sacc evalue score nident pident qstart qend sstart send length positive ppos qseq sseq';
-$test_file = "$prefix/input/blast_test.7.compara.tab";
+$test_file = $FindBin::Bin . '/input/blast_test.7.compara.tab';
 $parser = Bio::EnsEMBL::IO::Parser::BLASTFormatter->open($test_file, $outfmt);
 ok($parser->next(), 'Loading first record');
 is($parser->get_qacc, 'gnl|MYDB|1', 'Query accession');
@@ -180,7 +179,7 @@ ok(!$parser->next(), 'No more records');
 #
 note("Test Ensembl Web format specifiers");
 $outfmt = '7 qseqid qstart qend sseqid sstart send score evalue pident length qframe sframe';
-$test_file = "$prefix/input/blast_test.7.web.tab";
+$test_file = $FindBin::Bin . '/input/blast_test.7.web.tab';
 $parser = Bio::EnsEMBL::IO::Parser::BLASTFormatter->open($test_file, $outfmt);
 ok($parser->next(), 'Loading first record');
 is($parser->get_qseqid, 'gnl|MYDB|1', 'Query seq-id');
@@ -219,7 +218,7 @@ ok(!$parser->next(), 'No more records');
 #
 note("Test comma-separated format with default specifiers");
 $outfmt = '10';
-$test_file = "$prefix/input/blast_test.10.default.csv";
+$test_file = $FindBin::Bin . '/input/blast_test.10.default.csv';
 $parser = Bio::EnsEMBL::IO::Parser::BLASTFormatter->open($test_file, $outfmt);
 ok($parser->next(), 'Loading first record');
 is($parser->get_qseqid, 'gnl|MYDB|1', 'Query seq-id');

--- a/modules/t/coords.t
+++ b/modules/t/coords.t
@@ -19,8 +19,9 @@ use warnings;
 use Test::More;
 
 use Bio::EnsEMBL::IO::Parser::Coords;
+use FindBin;
 
-my $test_file = "modules/t/input/coords.txt";
+my $test_file = $FindBin::Bin . '/input/coords.txt';
 
 my $parser = Bio::EnsEMBL::IO::Parser::Coords->open($test_file);
 ok ($parser->next(), "Loading first record");

--- a/modules/t/embl.t
+++ b/modules/t/embl.t
@@ -5,8 +5,9 @@ use Test::More;
 use Test::Deep;
 
 use Bio::EnsEMBL::IO::Parser::EMBL;
+use FindBin;
 
-my $test_file = "modules/t/input/data.embl";
+my $test_file = $FindBin::Bin . '/input/data.embl';
 my $parser = Bio::EnsEMBL::IO::Parser::EMBL->open($test_file);
 
 $parser->next;

--- a/modules/t/emf.t
+++ b/modules/t/emf.t
@@ -21,6 +21,7 @@ use Test::More;
 use Test::Warn;
 
 use Bio::EnsEMBL::IO::Parser::EMF;
+use FindBin;
 
 
 ########
@@ -28,7 +29,7 @@ use Bio::EnsEMBL::IO::Parser::EMF;
 ########
 ## Resequencing
 subtest 'EMF Resequencing format', sub {
-	my $test_file = 'modules/t/input/Homo_sapiens.GRCh37.73.resequencing.chromosome.21.emf';
+	my $test_file = $FindBin::Bin . '/input/Homo_sapiens.GRCh37.73.resequencing.chromosome.21.emf';
 	my $parser = Bio::EnsEMBL::IO::Parser::EMF->open($test_file);
 	isa_ok($parser, 'Bio::EnsEMBL::IO::Parser::EMF', "correct class");
 	my $next_record = $parser->next;
@@ -54,7 +55,7 @@ subtest 'EMF Resequencing format', sub {
 
 ## Compara
 subtest 'Compara format', sub {
-	my $test_file = 'modules/t/input/Compara.13_eutherian_mammals_EPO.chr1_26.emf';
+	my $test_file = $FindBin::Bin . '/input/Compara.13_eutherian_mammals_EPO.chr1_26.emf';
 	my $parser = Bio::EnsEMBL::IO::Parser::EMF->open($test_file);	
 	isa_ok($parser, 'Bio::EnsEMBL::IO::Parser::EMF', "correct class");
 	my $next_record = $parser->next;

--- a/modules/t/fasta.t
+++ b/modules/t/fasta.t
@@ -19,8 +19,9 @@ use warnings;
 use Test::More;
 
 use Bio::EnsEMBL::IO::Parser::Fasta;
+use FindBin;
 
-my $test_file = "modules/t/input/data.fasta";
+my $test_file = $FindBin::Bin . '/input/data.fasta';
 
 ######################################################
 ## Test 1

--- a/modules/t/genbank.t
+++ b/modules/t/genbank.t
@@ -5,8 +5,9 @@ use Test::More;
 
 use Bio::EnsEMBL::Utils::IO qw( work_with_file );
 use Bio::EnsEMBL::IO::Parser::Genbank;
+use FindBin;
 
-my $test_file = 'modules/t/input/data.gbk';
+my $test_file = $FindBin::Bin . '/input/data.gbk';
 
 my $parser = Bio::EnsEMBL::IO::Parser::Genbank->open($test_file);
 ok ($parser->next(), "Loading first record");

--- a/modules/t/gff3.t
+++ b/modules/t/gff3.t
@@ -19,9 +19,10 @@ use warnings;
 use Test::More;
 
 use Bio::EnsEMBL::IO::Parser::GFF3;
+use FindBin;
 
-my $test_file = "modules/t/input/data.gff3";
-my $test_with_fasta_file = "modules/t/input/data_with_fasta.gff3";
+my $test_file = $FindBin::Bin . '/input/data.gff3';
+my $test_with_fasta_file = $FindBin::Bin . '/input/data_with_fasta.gff3';
 
 my $parser = Bio::EnsEMBL::IO::Parser::GFF3->open($test_file);
 ## First record

--- a/modules/t/gtf.t
+++ b/modules/t/gtf.t
@@ -32,7 +32,9 @@ use Bio::EnsEMBL::IO::Parser::GTF;
 
 #1	ensembl	CDS	144373415	144373470	.	-	2	gene_id "ENSGALG00000016887"; gene_version "3"; transcript_id "ENSGALT00000027289"; transcript_version "3"; exon_number "21"; gene_source "ensembl"; gene_biotype "protein_coding"; transcript_source "ensembl"; transcript_biotype "protein_coding"; protein_id "ENSGALP00000027238"; protein_version "3";
 
-my $test_file = "modules/t/input/data.gtf";
+use FindBin;
+
+my $test_file = $FindBin::Bin . '/input/data.gtf';
 my $parser    = Bio::EnsEMBL::IO::Parser::GTF->open($test_file);
 
 ## First record

--- a/modules/t/gvf.t
+++ b/modules/t/gvf.t
@@ -18,8 +18,9 @@ use warnings;
 
 use Test::More;
 use Bio::EnsEMBL::IO::Parser::GVF;
+use FindBin;
 
-my $test_file = "modules/t/input/data.gvf";
+my $test_file = $FindBin::Bin . '/input/data.gvf';
 
 my $parser = Bio::EnsEMBL::IO::Parser::GVF->open($test_file);
 

--- a/modules/t/psl.t
+++ b/modules/t/psl.t
@@ -19,8 +19,9 @@ use warnings;
 use Test::More;
 
 use Bio::EnsEMBL::IO::Parser::Psl;
+use FindBin;
 
-my $test_file = "modules/t/input/data.psl";
+my $test_file = $FindBin::Bin . '/input/data.psl';
 
 my $parser = Bio::EnsEMBL::IO::Parser::Psl->open($test_file);
 ok ($parser->next(), "Loading first record");

--- a/modules/t/simple_list.t
+++ b/modules/t/simple_list.t
@@ -20,8 +20,9 @@ use Test::More;
 
 use Bio::EnsEMBL::IO::ListBasedParser;
 use IO::Uncompress::Gunzip qw/$GunzipError/;
+use FindBin;
 
-my $test_file = "modules/t/input/data.txt";
+my $test_file = $FindBin::Bin . '/input/data.txt';
 
 note 'Processing file '.$test_file;
 test_parser($test_file);

--- a/modules/t/vcf.t
+++ b/modules/t/vcf.t
@@ -18,8 +18,9 @@ use warnings;
 
 use Test::More;
 use Bio::EnsEMBL::IO::Parser::VCF4;
+use FindBin;
 
-my $test_file = "modules/t/input/data.vcf";
+my $test_file = $FindBin::Bin . '/input/data.vcf';
 
 my ($test_sample, $sample_info, $ind_info); 
 

--- a/modules/t/vcf_sv.t
+++ b/modules/t/vcf_sv.t
@@ -18,8 +18,9 @@ use warnings;
 
 use Test::More;
 use Bio::EnsEMBL::IO::Parser::VCF4;
+use FindBin;
 
-my $test_file = "modules/t/input/data_sv.vcf";
+my $test_file = $FindBin::Bin . '/input/data_sv.vcf';
 
 my ($test_sample, $sample_info, $ind_info); 
 

--- a/modules/t/vcf_tabix.t
+++ b/modules/t/vcf_tabix.t
@@ -18,8 +18,9 @@ use warnings;
 
 use Test::More;
 use Bio::EnsEMBL::IO::Parser::VCF4Tabix;
+use FindBin;
 
-my $test_file = "modules/t/input/data.vcf.gz";
+my $test_file = $FindBin::Bin . '/input/data.vcf.gz';
 
 my ($test_sample, $sample_info, $ind_info); 
 

--- a/modules/t/vep_input.t
+++ b/modules/t/vep_input.t
@@ -17,10 +17,11 @@ use strict;
 use warnings;
 
 use Test::More;
+use FindBin;
 
 use Bio::EnsEMBL::IO::Parser::VEP_input;
 
-my $test_file = "modules/t/input/data.vepi";
+my $test_file = $FindBin::Bin . '/input/data.vepi';
 
 my $parser = Bio::EnsEMBL::IO::Parser::VEP_input->open($test_file);
 ok ($parser->next(), "Loading first record");

--- a/modules/t/vep_output.t
+++ b/modules/t/vep_output.t
@@ -17,10 +17,11 @@ use strict;
 use warnings;
 
 use Test::More;
+use FindBin;
 
 use Bio::EnsEMBL::IO::Parser::VEP_output;
 
-my $test_file = "modules/t/input/data.vepo";
+my $test_file = $FindBin::Bin . '/input/data.vepo';
 
 my $parser = Bio::EnsEMBL::IO::Parser::VEP_output->open($test_file);
 ok ($parser->next(), "Loading first record");

--- a/modules/t/wig.t
+++ b/modules/t/wig.t
@@ -17,10 +17,11 @@ use strict;
 use warnings;
 
 use Test::More;
+use FindBin;
 
 use Bio::EnsEMBL::IO::Parser::Wig;
 
-my $test_file = "modules/t/input/data.wig";
+my $test_file = $FindBin::Bin . '/input/data.wig';
 
 my $parser = Bio::EnsEMBL::IO::Parser::Wig->open($test_file);
 ok ($parser->next(), "Loading first record");


### PR DESCRIPTION

## Description

Tests used an absolute path for the test files, so if test where run from a different location other than the root of the repo it would fail to find the files.
This changes the path to a relative path, so that it always finds the test files.

## Use case

Tests are sometimes run from locations other than the root of the repo, and it would fail to find the test files.

## Benefits

Path for test files is now always correct.

## Possible Drawbacks

none I can think of.

## Testing

_Have you added/modified unit tests to test the changes?_
yes

_If so, do the tests pass/fail?_
pass

