### PR TITLE
Extra Genbank parser methods to aid RefSeqGPFFParser 

### DIFF
--- a/modules/Bio/EnsEMBL/IO/Parser/Genbank.pm
+++ b/modules/Bio/EnsEMBL/IO/Parser/Genbank.pm
@@ -108,6 +108,9 @@ sub read_record {
               $self->{'record'}->{'_genebank_id'} = undef;
             }
         }
+        elsif ($field_type eq 'DBSOURCE') {
+            $self->{'record'}->{'_raw_dbsource'} = $field;
+        }
         elsif ($field_type eq 'COMMENT' || $field_type eq 'REFERENCE') {
             # REFERENCE is not used by the genebuild team so it can be "removed"
             push(@{$self->{'record'}->{'_raw_'.lc($field_type)}},  $field.$self->_get_multiline);
@@ -282,6 +285,36 @@ sub get_sequence_version {
     return $self->{'record'}->{'_version'};
 }
 
+=head2 get_dbsource
+
+    Description: Return the dbsource from the GenBank file
+    Returntype : String
+
+=cut
+
+sub get_dbsource {
+    my $self = shift;
+
+    return $self->{'record'}->{'_raw_dbsource'};
+}
+
+=head2 get_dbsource_acc
+
+    Description: Return the dbsource accession from the GenBank file
+    Returntype : String
+
+=cut
+
+sub get_dbsource_acc {
+    my $self = shift;
+
+    return unless $self->{'record'}->{'_raw_dbsource'};
+
+    my ($acc) = $self->{'record'}->{'_raw_dbsource'} =~ /REFSEQ: accession (\S+)/;
+
+    return $acc;
+}
+
 =head2 get_length
 
     Description: Return the length of the sequence
@@ -408,6 +441,51 @@ sub get_taxon_id {
         ($self->{'record'}->{'_taxon_id'}) = $self->{'record'}->{'_raw_features'} =~ /db_xref="taxon:(\d+)/;
     }
     return $self->{'record'}->{'_taxon_id'};
+}
+
+=head2 get_db_xref_list_for_type
+
+    Description: Return the list of db_xrefs for provided type
+    Returntype : Arrayref
+
+=cut
+
+sub get_db_xref_list_for_type {
+    my ($self, $type) = @_;
+
+    my @ids = $self->{'record'}->{'_raw_features'} =~ /db_xref=\"${type}:(.+?)\"/g;
+
+    return \@ids;
+}
+
+=head2 get_protein_id_list
+
+    Description: Return the list of protein_ids
+    Returntype : Arrayref
+
+=cut
+
+sub get_protein_id_list {
+    my ($self) = @_;
+
+    my @ids = $self->{'record'}->{'_raw_features'} =~ /\/protein_id=\"(.+?)\"/g;
+
+    return \@ids;
+}
+
+=head2 get_coded_by_list
+
+    Description: Return the list of protein_ids
+    Returntype : Arrayref
+
+=cut
+
+sub get_coded_by_list {
+    my ($self) = @_;
+
+    my @ids = $self->{'record'}->{'_raw_features'} =~ /\/coded_by=\"(.*?):/g;
+
+    return \@ids;
 }
 
 =head2 get_raw_dblinks

--- a/modules/Bio/EnsEMBL/IO/Parser/Genbank.pm
+++ b/modules/Bio/EnsEMBL/IO/Parser/Genbank.pm
@@ -453,6 +453,7 @@ sub get_taxon_id {
 sub get_db_xref_list_for_type {
     my ($self, $type) = @_;
 
+    return [] unless defined $type;
     my @ids = $self->{'record'}->{'_raw_features'} =~ /db_xref=\"${type}:(.+?)\"/g;
 
     return \@ids;

--- a/modules/t/genbank.t
+++ b/modules/t/genbank.t
@@ -27,9 +27,9 @@ is($parser->get_raw_dblinks,'BioProject: PRJNA30353',"Testing get_raw_dblinks");
 ok($parser->is_circular, "Testing is_circular");
 ok($parser->get_length == length($parser->get_sequence), "Testing length of the sequence");
 is(scalar @{$parser->get_db_xref_list_for_type('GeneID')}, 74, "Testing get_db_xref_list_for_type GeneID");
-is(scalar @{$parser->get_coded_by_list}, 0, "Testing get_coded_by_list");
-is($parser->get_dbsource, undef, "Testing get_dbsource");
-is($parser->get_dbsource_acc, undef, "Testing get_dbsource_acc");
+is(scalar @{$parser->get_coded_by_list}, 0, "Testing get_coded_by_list when absent");
+is($parser->get_dbsource, undef, "Testing get_dbsource when absent");
+is($parser->get_dbsource_acc, undef, "Testing get_dbsource_acc when absent");
 is(scalar @{$parser->get_protein_id_list}, 13, "Testing get_protein_id_list");
 
 my @features = @{ $parser->get_features };
@@ -53,9 +53,11 @@ is($parser->get_taxon_id,'7955',"Testing get_taxon_id");
 cmp_ok($parser->is_circular, '==', 0, "Testing is_circular");
 ok($parser->get_length == length($parser->get_sequence), "Testing length of the sequence");
 is(scalar @{$parser->get_db_xref_list_for_type('GeneID')}, 2, "Testing get_db_xref_list_for_type GeneID");
-is(scalar @{$parser->get_coded_by_list}, 0, "Testing get_coded_by_list");
-is($parser->get_dbsource, undef, "Testing get_dbsource");
-is($parser->get_dbsource_acc, undef, "Testing get_dbsource_acc");
+is(shift @{$parser->get_db_xref_list_for_type('GeneID')}, '566993', "Testing db_xref value");
+is(scalar @{$parser->get_coded_by_list}, 1, "Testing get_coded_by_list");
+is(shift @{$parser->get_coded_by_list}, 'NM_001285679.1', "Testing coded_by value");
+is($parser->get_dbsource, 'REFSEQ: accession NM_001285679.1', "Testing get_dbsource");
+is($parser->get_dbsource_acc, 'NM_001285679.1', "Testing get_dbsource_acc");
 is(scalar @{$parser->get_protein_id_list}, 1, "Testing get_protein_id_list");
 
 @features = @{ $parser->get_features };

--- a/modules/t/genbank.t
+++ b/modules/t/genbank.t
@@ -26,6 +26,11 @@ is($parser->get_taxon_id,'9606',"Testing get_taxon_id");
 is($parser->get_raw_dblinks,'BioProject: PRJNA30353',"Testing get_raw_dblinks");
 ok($parser->is_circular, "Testing is_circular");
 ok($parser->get_length == length($parser->get_sequence), "Testing length of the sequence");
+is(scalar @{$parser->get_db_xref_list_for_type('GeneID')}, 74, "Testing get_db_xref_list_for_type GeneID");
+is(scalar @{$parser->get_coded_by_list}, 0, "Testing get_coded_by_list");
+is($parser->get_dbsource, undef, "Testing get_dbsource");
+is($parser->get_dbsource_acc, undef, "Testing get_dbsource_acc");
+is(scalar @{$parser->get_protein_id_list}, 13, "Testing get_protein_id_list");
 
 my @features = @{ $parser->get_features };
 cmp_ok(scalar @features,'==', 105, "Testing number of features");
@@ -47,6 +52,11 @@ is($parser->get_source,'Danio rerio (zebrafish)',"Testing get_source");
 is($parser->get_taxon_id,'7955',"Testing get_taxon_id");
 cmp_ok($parser->is_circular, '==', 0, "Testing is_circular");
 ok($parser->get_length == length($parser->get_sequence), "Testing length of the sequence");
+is(scalar @{$parser->get_db_xref_list_for_type('GeneID')}, 2, "Testing get_db_xref_list_for_type GeneID");
+is(scalar @{$parser->get_coded_by_list}, 0, "Testing get_coded_by_list");
+is($parser->get_dbsource, undef, "Testing get_dbsource");
+is($parser->get_dbsource_acc, undef, "Testing get_dbsource_acc");
+is(scalar @{$parser->get_protein_id_list}, 1, "Testing get_protein_id_list");
 
 @features = @{ $parser->get_features };
 cmp_ok(scalar @features,'==', 3, "Testing number of features");

--- a/modules/t/input/data.gbk
+++ b/modules/t/input/data.gbk
@@ -1304,6 +1304,7 @@ LOCUS       NM_001100954             558 bp    mRNA    linear   VRT 06-AUG-2017
 DEFINITION  Danio rerio si:dkey-111e8.5 (si:dkey-111e8.5), mRNA.
 ACCESSION   NM_001100954 XM_690278
 VERSION     NM_001100954.1
+DBSOURCE    REFSEQ: accession NM_001285679.1
 KEYWORDS    RefSeq.
 SOURCE      Danio rerio (zebrafish)
   ORGANISM  Danio rerio
@@ -1351,6 +1352,7 @@ FEATURES             Location/Qualifiers
                      /db_xref="ZFIN:ZDB-GENE-060526-192"
      CDS             1..558
                      /gene="si:dkey-111e8.5"
+                     /coded_by="NM_001285679.1:1..381"
                      /codon_start=1
                      /product="uncharacterized protein LOC566993"
                      /protein_id="NP_001094424.1"


### PR DESCRIPTION
Xref RefSeqGPFFParser does the parsing of Genbank files.
Refactoring this Xref parser as part of the xref sprint efforts led to the decision of using an existing genbank parser rather than implementing it again within the RefSeqGPFFParser.

This will obviously be better in terms of future maintainability, and if development efforts are concentrated in one place it will be more efficient.

Some required data was however not very easy to access using the Genbank parser, so this brings new methods that extract that data in an easy way.

No existing functionality has been modified, only new one added.
Tests are included for the new methods.