### PR TITLE
Check response status code instead of message for file fetch requests

### DIFF
--- a/modules/EnsEMBL/Web/File/Utils/URL.pm
+++ b/modules/EnsEMBL/Web/File/Utils/URL.pm
@@ -341,7 +341,7 @@ sub fetch_file {
 
   my $dest     = $args->{'destination_path'} ? $args->{'destination_path'}."$filename" : "/tmp/$filename";
   my $response = $ua->mirror($file_url, $dest);
-  return $dest if ($response->{_msg} eq 'OK');
+  return $dest if ($response->{_rc} == 200);
 
   if($args->{'nice'}) {
      return {'error' => "Cannot download file ($file_url). HTTP request error code ".$response->{_rc}};


### PR DESCRIPTION
This fixes responses that have a message other than 'OK' (e.g. Gatewaying) failing. An example issue is, the Allele Frequency Calculator stopped submitting jobs to the hive as the FTP files fetched for it always return 'Gatewaying' as the reponse message. However, the status code was always 200 and the file was successfully fetched too.