### PR TITLE
ancestral_allele update

### DIFF
--- a/modules/Bio/EnsEMBL/IO/Translator/SampleGenotypeFeature.pm
+++ b/modules/Bio/EnsEMBL/IO/Translator/SampleGenotypeFeature.pm
@@ -288,8 +288,8 @@ sub ancestral_allele {
   my $self = shift;
   my $object = shift;
   my $info = shift;
-  
-  my $data = $object->variation->ancestral_allele;
+
+  my $data = $object->ancestral_allele;
   return ($data) ? "$info=$data" : undef;
 }
 

--- a/modules/t/test-genome-DBs/homo_sapiens/core/meta.txt
+++ b/modules/t/test-genome-DBs/homo_sapiens/core/meta.txt
@@ -105,3 +105,6 @@
 172	\N	patch	patch_95_96_a.sql|schema_version
 173	\N	patch	patch_96_97_a.sql|schema_version
 174	\N	patch	patch_96_97_b.sql|biotype_so_term
+175	\N	patch	patch_96_97_c.sql|rnaproduct_tables
+176	\N	patch	patch_96_97_d.sql|add_object_type_rnaproduct
+177	\N	patch	patch_96_97_e.sql|add_stable_id_event_type_rnaproduct

--- a/modules/t/test-genome-DBs/homo_sapiens/core/table.sql
+++ b/modules/t/test-genome-DBs/homo_sapiens/core/table.sql
@@ -117,7 +117,7 @@ CREATE TABLE `biotype` (
   `so_term` varchar(1023) DEFAULT NULL,
   PRIMARY KEY (`biotype_id`),
   UNIQUE KEY `name_type_idx` (`name`,`object_type`)
-) ENGINE=MyISAM AUTO_INCREMENT=66 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=88 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `coord_system` (
   `coord_system_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -490,7 +490,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`),
   KEY `species_value_idx` (`species_id`,`meta_value`)
-) ENGINE=MyISAM AUTO_INCREMENT=175 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=178 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `meta_coord` (
   `table_name` varchar(40) COLLATE latin1_bin NOT NULL DEFAULT '',
@@ -539,7 +539,7 @@ CREATE TABLE `misc_set` (
 CREATE TABLE `object_xref` (
   `object_xref_id` int(11) NOT NULL AUTO_INCREMENT,
   `ensembl_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `ensembl_object_type` enum('RawContig','Transcript','Gene','Translation','regulatory_factor','regulatory_feature','Marker') COLLATE latin1_bin NOT NULL DEFAULT 'RawContig',
+  `ensembl_object_type` enum('RawContig','Transcript','Gene','Translation','Operon','OperonTranscript','Marker','RNAProduct') COLLATE latin1_bin NOT NULL,
   `xref_id` int(10) unsigned NOT NULL,
   `linkage_annotation` varchar(255) COLLATE latin1_bin DEFAULT NULL,
   `analysis_id` smallint(5) unsigned DEFAULT NULL,
@@ -716,6 +716,42 @@ CREATE TABLE `repeat_feature` (
   KEY `analysis_idx` (`analysis_id`)
 ) ENGINE=MyISAM AUTO_INCREMENT=922516 DEFAULT CHARSET=latin1 COLLATE=latin1_bin MAX_ROWS=100000000 AVG_ROW_LENGTH=80;
 
+CREATE TABLE `rnaproduct` (
+  `rnaproduct_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `rnaproduct_type_id` smallint(5) unsigned NOT NULL,
+  `transcript_id` int(10) unsigned NOT NULL,
+  `seq_start` int(10) NOT NULL,
+  `start_exon_id` int(10) unsigned DEFAULT NULL,
+  `seq_end` int(10) NOT NULL,
+  `end_exon_id` int(10) unsigned DEFAULT NULL,
+  `stable_id` varchar(128) DEFAULT NULL,
+  `version` smallint(5) unsigned DEFAULT NULL,
+  `created_date` datetime DEFAULT NULL,
+  `modified_date` datetime DEFAULT NULL,
+  PRIMARY KEY (`rnaproduct_id`),
+  KEY `transcript_idx` (`transcript_id`),
+  KEY `stable_id_idx` (`stable_id`,`version`)
+) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+
+CREATE TABLE `rnaproduct_attrib` (
+  `rnaproduct_id` int(10) unsigned NOT NULL DEFAULT '0',
+  `attrib_type_id` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `value` text NOT NULL,
+  UNIQUE KEY `rnaproduct_attribx` (`rnaproduct_id`,`attrib_type_id`,`value`(500)),
+  KEY `type_val_idx` (`attrib_type_id`,`value`(40)),
+  KEY `val_only_idx` (`value`(40)),
+  KEY `rnaproduct_idx` (`rnaproduct_id`)
+) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+
+CREATE TABLE `rnaproduct_type` (
+  `rnaproduct_type_id` smallint(5) unsigned NOT NULL AUTO_INCREMENT,
+  `code` varchar(20) NOT NULL DEFAULT '',
+  `name` varchar(255) NOT NULL DEFAULT '',
+  `description` text,
+  PRIMARY KEY (`rnaproduct_type_id`),
+  UNIQUE KEY `code_idx` (`code`)
+) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+
 CREATE TABLE `seq_region` (
   `seq_region_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
   `name` varchar(255) COLLATE latin1_bin NOT NULL,
@@ -774,7 +810,7 @@ CREATE TABLE `stable_id_event` (
   `new_stable_id` varchar(128) COLLATE latin1_bin DEFAULT NULL,
   `new_version` smallint(6) DEFAULT NULL,
   `mapping_session_id` int(10) NOT NULL DEFAULT '0',
-  `type` enum('gene','transcript','translation') COLLATE latin1_bin NOT NULL DEFAULT 'gene',
+  `type` enum('gene','transcript','translation','rnaproduct') COLLATE latin1_bin NOT NULL,
   `score` float NOT NULL DEFAULT '0',
   UNIQUE KEY `uni_idx` (`mapping_session_id`,`old_stable_id`,`old_version`,`new_stable_id`,`new_version`,`type`),
   KEY `new_idx` (`new_stable_id`),

--- a/modules/t/test-genome-DBs/homo_sapiens/empty/meta.txt
+++ b/modules/t/test-genome-DBs/homo_sapiens/empty/meta.txt
@@ -105,3 +105,6 @@
 154	\N	patch	patch_95_96_a.sql|schema_version
 155	\N	patch	patch_96_97_a.sql|schema_version
 156	\N	patch	patch_96_97_b.sql|biotype_so_term
+157	\N	patch	patch_96_97_c.sql|rnaproduct_tables
+158	\N	patch	patch_96_97_d.sql|add_object_type_rnaproduct
+159	\N	patch	patch_96_97_e.sql|add_stable_id_event_type_rnaproduct

--- a/modules/t/test-genome-DBs/homo_sapiens/empty/table.sql
+++ b/modules/t/test-genome-DBs/homo_sapiens/empty/table.sql
@@ -490,7 +490,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`),
   KEY `species_value_idx` (`species_id`,`meta_value`)
-) ENGINE=MyISAM AUTO_INCREMENT=157 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=160 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `meta_coord` (
   `table_name` varchar(40) COLLATE latin1_bin NOT NULL DEFAULT '',
@@ -539,7 +539,7 @@ CREATE TABLE `misc_set` (
 CREATE TABLE `object_xref` (
   `object_xref_id` int(11) NOT NULL AUTO_INCREMENT,
   `ensembl_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `ensembl_object_type` enum('RawContig','Transcript','Gene','Translation','regulatory_factor','regulatory_feature','Marker') COLLATE latin1_bin NOT NULL DEFAULT 'RawContig',
+  `ensembl_object_type` enum('RawContig','Transcript','Gene','Translation','Operon','OperonTranscript','Marker','RNAProduct') COLLATE latin1_bin NOT NULL,
   `xref_id` int(10) unsigned NOT NULL,
   `linkage_annotation` varchar(255) COLLATE latin1_bin DEFAULT NULL,
   `analysis_id` smallint(5) unsigned DEFAULT NULL,
@@ -716,6 +716,42 @@ CREATE TABLE `repeat_feature` (
   KEY `analysis_idx` (`analysis_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin MAX_ROWS=100000000 AVG_ROW_LENGTH=80;
 
+CREATE TABLE `rnaproduct` (
+  `rnaproduct_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `rnaproduct_type_id` smallint(5) unsigned NOT NULL,
+  `transcript_id` int(10) unsigned NOT NULL,
+  `seq_start` int(10) NOT NULL,
+  `start_exon_id` int(10) unsigned DEFAULT NULL,
+  `seq_end` int(10) NOT NULL,
+  `end_exon_id` int(10) unsigned DEFAULT NULL,
+  `stable_id` varchar(128) DEFAULT NULL,
+  `version` smallint(5) unsigned DEFAULT NULL,
+  `created_date` datetime DEFAULT NULL,
+  `modified_date` datetime DEFAULT NULL,
+  PRIMARY KEY (`rnaproduct_id`),
+  KEY `transcript_idx` (`transcript_id`),
+  KEY `stable_id_idx` (`stable_id`,`version`)
+) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+
+CREATE TABLE `rnaproduct_attrib` (
+  `rnaproduct_id` int(10) unsigned NOT NULL DEFAULT '0',
+  `attrib_type_id` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `value` text NOT NULL,
+  UNIQUE KEY `rnaproduct_attribx` (`rnaproduct_id`,`attrib_type_id`,`value`(500)),
+  KEY `type_val_idx` (`attrib_type_id`,`value`(40)),
+  KEY `val_only_idx` (`value`(40)),
+  KEY `rnaproduct_idx` (`rnaproduct_id`)
+) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+
+CREATE TABLE `rnaproduct_type` (
+  `rnaproduct_type_id` smallint(5) unsigned NOT NULL AUTO_INCREMENT,
+  `code` varchar(20) NOT NULL DEFAULT '',
+  `name` varchar(255) NOT NULL DEFAULT '',
+  `description` text,
+  PRIMARY KEY (`rnaproduct_type_id`),
+  UNIQUE KEY `code_idx` (`code`)
+) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+
 CREATE TABLE `seq_region` (
   `seq_region_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
   `name` varchar(255) COLLATE latin1_bin NOT NULL,
@@ -774,7 +810,7 @@ CREATE TABLE `stable_id_event` (
   `new_stable_id` varchar(128) COLLATE latin1_bin DEFAULT NULL,
   `new_version` smallint(6) DEFAULT NULL,
   `mapping_session_id` int(10) NOT NULL DEFAULT '0',
-  `type` enum('gene','transcript','translation') COLLATE latin1_bin NOT NULL DEFAULT 'gene',
+  `type` enum('gene','transcript','translation','rnaproduct') COLLATE latin1_bin NOT NULL,
   `score` float NOT NULL DEFAULT '0',
   UNIQUE KEY `uni_idx` (`mapping_session_id`,`old_stable_id`,`old_version`,`new_stable_id`,`new_version`,`type`),
   KEY `new_idx` (`new_stable_id`),

--- a/modules/t/test-genome-DBs/homo_sapiens/patch/meta.txt
+++ b/modules/t/test-genome-DBs/homo_sapiens/patch/meta.txt
@@ -110,3 +110,6 @@
 2117	\N	patch	patch_95_96_a.sql|schema_version
 2118	\N	patch	patch_96_97_a.sql|schema_version
 2119	\N	patch	patch_96_97_b.sql|biotype_so_term
+2120	\N	patch	patch_96_97_c.sql|rnaproduct_tables
+2121	\N	patch	patch_96_97_d.sql|add_object_type_rnaproduct
+2122	\N	patch	patch_96_97_e.sql|add_stable_id_event_type_rnaproduct

--- a/modules/t/test-genome-DBs/homo_sapiens/patch/table.sql
+++ b/modules/t/test-genome-DBs/homo_sapiens/patch/table.sql
@@ -490,7 +490,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`),
   KEY `species_value_idx` (`species_id`,`meta_value`)
-) ENGINE=MyISAM AUTO_INCREMENT=2120 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=2123 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `meta_coord` (
   `table_name` varchar(40) COLLATE latin1_bin NOT NULL DEFAULT '',
@@ -539,7 +539,7 @@ CREATE TABLE `misc_set` (
 CREATE TABLE `object_xref` (
   `object_xref_id` int(11) NOT NULL AUTO_INCREMENT,
   `ensembl_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `ensembl_object_type` enum('RawContig','Transcript','Gene','Translation','regulatory_factor','regulatory_feature','Marker') COLLATE latin1_bin NOT NULL DEFAULT 'RawContig',
+  `ensembl_object_type` enum('RawContig','Transcript','Gene','Translation','Operon','OperonTranscript','Marker','RNAProduct') COLLATE latin1_bin NOT NULL,
   `xref_id` int(10) unsigned NOT NULL,
   `linkage_annotation` varchar(255) COLLATE latin1_bin DEFAULT NULL,
   `analysis_id` smallint(5) unsigned DEFAULT NULL,
@@ -716,6 +716,42 @@ CREATE TABLE `repeat_feature` (
   KEY `analysis_idx` (`analysis_id`)
 ) ENGINE=MyISAM AUTO_INCREMENT=31576665 DEFAULT CHARSET=latin1 COLLATE=latin1_bin MAX_ROWS=100000000 AVG_ROW_LENGTH=80;
 
+CREATE TABLE `rnaproduct` (
+  `rnaproduct_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `rnaproduct_type_id` smallint(5) unsigned NOT NULL,
+  `transcript_id` int(10) unsigned NOT NULL,
+  `seq_start` int(10) NOT NULL,
+  `start_exon_id` int(10) unsigned DEFAULT NULL,
+  `seq_end` int(10) NOT NULL,
+  `end_exon_id` int(10) unsigned DEFAULT NULL,
+  `stable_id` varchar(128) DEFAULT NULL,
+  `version` smallint(5) unsigned DEFAULT NULL,
+  `created_date` datetime DEFAULT NULL,
+  `modified_date` datetime DEFAULT NULL,
+  PRIMARY KEY (`rnaproduct_id`),
+  KEY `transcript_idx` (`transcript_id`),
+  KEY `stable_id_idx` (`stable_id`,`version`)
+) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+
+CREATE TABLE `rnaproduct_attrib` (
+  `rnaproduct_id` int(10) unsigned NOT NULL DEFAULT '0',
+  `attrib_type_id` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `value` text NOT NULL,
+  UNIQUE KEY `rnaproduct_attribx` (`rnaproduct_id`,`attrib_type_id`,`value`(500)),
+  KEY `type_val_idx` (`attrib_type_id`,`value`(40)),
+  KEY `val_only_idx` (`value`(40)),
+  KEY `rnaproduct_idx` (`rnaproduct_id`)
+) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+
+CREATE TABLE `rnaproduct_type` (
+  `rnaproduct_type_id` smallint(5) unsigned NOT NULL AUTO_INCREMENT,
+  `code` varchar(20) NOT NULL DEFAULT '',
+  `name` varchar(255) NOT NULL DEFAULT '',
+  `description` text,
+  PRIMARY KEY (`rnaproduct_type_id`),
+  UNIQUE KEY `code_idx` (`code`)
+) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+
 CREATE TABLE `seq_region` (
   `seq_region_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
   `name` varchar(255) COLLATE latin1_bin NOT NULL,
@@ -774,7 +810,7 @@ CREATE TABLE `stable_id_event` (
   `new_stable_id` varchar(128) COLLATE latin1_bin DEFAULT NULL,
   `new_version` smallint(6) DEFAULT NULL,
   `mapping_session_id` int(10) NOT NULL DEFAULT '0',
-  `type` enum('gene','transcript','translation') COLLATE latin1_bin NOT NULL DEFAULT 'gene',
+  `type` enum('gene','transcript','translation','rnaproduct') COLLATE latin1_bin NOT NULL,
   `score` float NOT NULL DEFAULT '0',
   UNIQUE KEY `uni_idx` (`mapping_session_id`,`old_stable_id`,`old_version`,`new_stable_id`,`new_version`,`type`),
   KEY `new_idx` (`new_stable_id`),

--- a/modules/t/vcf_serializer.t
+++ b/modules/t/vcf_serializer.t
@@ -89,8 +89,7 @@ foreach my $var (@vars) {
   my $var_d = $var_data{$var};
 
   my $var_obj = Bio::EnsEMBL::Variation::Variation->new(
-     -NAME   => $var,
-     -ANCESTRAL_ALLELE => $var_d->{'aa'}
+     -NAME   => $var
   );
   
   #my %sample_genotypes = ();
@@ -112,7 +111,8 @@ foreach my $var (@vars) {
     -VARIATION_NAME => $var,
     -MINOR_ALLELE => $var_d->{'ma'},
     -MINOR_ALLELE_FREQUENCY => $var_d->{'maf'},
-    -MINOR_ALLELE_COUNT => $var_d->{'mac'}
+    -MINOR_ALLELE_COUNT => $var_d->{'mac'},
+    -ANCESTRAL_ALLELE => $var_d->{'aa'}
   );
   
   


### PR DESCRIPTION
Variation `Bio::EnsEMBL::Variation::Variation::ancestral_allele` method has been deprecated and replaced with `Bio::EnsEMBL::Variation::VariationFeature::ancestral_allele`.

`Bio::EnsEMBL::IO::Translator::SampleGenotypeFeature` uses the deprecated method and is now failing, so an update is required.

This fixes the issue by patching the test DBs and the test data object, and updated the deprecated method to the new one.
