### PR TITLE
Patch the variation test database to version 98 [release/98]

### DIFF
--- a/modules/t/test-genome-DBs/homo_sapiens/variation/meta.txt
+++ b/modules/t/test-genome-DBs/homo_sapiens/variation/meta.txt
@@ -1,5 +1,5 @@
 1	\N	schema_type	variation
-2	\N	schema_version	96
+2	\N	schema_version	98
 3	\N	patch	patch_84_85_a.sql|schema version
 4	\N	patch	patch_84_85_b.sql|create sample_synonym
 5	\N	patch	patch_84_85_c.sql|drop column moltype from variation_synonym
@@ -39,3 +39,7 @@
 39	\N	patch	patch_95_96_c.sql|add new entries to the failed_description table
 40	\N	patch	patch_95_96_d.sql|create table to store failed variation features
 41	\N	patch	patch_95_96_e.sql|Rename motif_name to binding_matrix_stable_id.
+42	\N	patch	patch_96_97_a.sql|schema version
+43	\N	patch	patch_96_97_b.sql|move ancestral allele column to variation_feature
+44	\N	patch	patch_96_97_c.sql|add an unique index on the name column
+45	\N	patch	patch_97_98_a.sql|schema version

--- a/modules/t/test-genome-DBs/homo_sapiens/variation/table.sql
+++ b/modules/t/test-genome-DBs/homo_sapiens/variation/table.sql
@@ -38,24 +38,24 @@ CREATE TABLE `associate_study` (
 
 CREATE TABLE `attrib` (
   `attrib_id` int(11) unsigned NOT NULL AUTO_INCREMENT,
-  `attrib_type_id` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `attrib_type_id` smallint(5) unsigned NOT NULL DEFAULT 0,
   `value` text NOT NULL,
   PRIMARY KEY (`attrib_id`),
   UNIQUE KEY `type_val_idx` (`attrib_type_id`,`value`(80))
 ) ENGINE=MyISAM AUTO_INCREMENT=422 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `attrib_set` (
-  `attrib_set_id` int(11) unsigned NOT NULL DEFAULT '0',
-  `attrib_id` int(11) unsigned NOT NULL DEFAULT '0',
+  `attrib_set_id` int(11) unsigned NOT NULL DEFAULT 0,
+  `attrib_id` int(11) unsigned NOT NULL DEFAULT 0,
   UNIQUE KEY `set_idx` (`attrib_set_id`,`attrib_id`),
   KEY `attrib_idx` (`attrib_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1;
 
 CREATE TABLE `attrib_type` (
-  `attrib_type_id` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `attrib_type_id` smallint(5) unsigned NOT NULL DEFAULT 0,
   `code` varchar(20) NOT NULL DEFAULT '',
   `name` varchar(255) NOT NULL DEFAULT '',
-  `description` text,
+  `description` text DEFAULT NULL,
   PRIMARY KEY (`attrib_type_id`),
   UNIQUE KEY `code_idx` (`code`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1;
@@ -66,7 +66,7 @@ CREATE TABLE `compressed_genotype_region` (
   `seq_region_start` int(11) NOT NULL,
   `seq_region_end` int(11) NOT NULL,
   `seq_region_strand` tinyint(4) NOT NULL,
-  `genotypes` blob,
+  `genotypes` blob DEFAULT NULL,
   KEY `pos_idx` (`seq_region_id`,`seq_region_start`),
   KEY `sample_idx` (`sample_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1;
@@ -74,14 +74,14 @@ CREATE TABLE `compressed_genotype_region` (
 CREATE TABLE `compressed_genotype_var` (
   `variation_id` int(11) unsigned NOT NULL,
   `subsnp_id` int(11) unsigned DEFAULT NULL,
-  `genotypes` blob,
+  `genotypes` blob DEFAULT NULL,
   KEY `variation_idx` (`variation_id`),
   KEY `subsnp_idx` (`subsnp_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1;
 
 CREATE TABLE `coord_system` (
   `coord_system_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `species_id` int(10) unsigned NOT NULL DEFAULT '1',
+  `species_id` int(10) unsigned NOT NULL DEFAULT 1,
   `name` varchar(40) NOT NULL,
   `version` varchar(255) DEFAULT NULL,
   `rank` int(11) NOT NULL,
@@ -151,11 +151,11 @@ CREATE TABLE `genotype_code` (
 CREATE TABLE `individual` (
   `individual_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
   `name` varchar(255) DEFAULT NULL,
-  `description` text,
+  `description` text DEFAULT NULL,
   `gender` enum('Male','Female','Unknown') NOT NULL DEFAULT 'Unknown',
   `father_individual_id` int(10) unsigned DEFAULT NULL,
   `mother_individual_id` int(10) unsigned DEFAULT NULL,
-  `individual_type_id` int(10) unsigned NOT NULL DEFAULT '0',
+  `individual_type_id` int(10) unsigned NOT NULL DEFAULT 0,
   PRIMARY KEY (`individual_id`),
   KEY `father_individual_idx` (`father_individual_id`),
   KEY `mother_individual_idx` (`mother_individual_id`)
@@ -174,19 +174,19 @@ CREATE TABLE `individual_synonym` (
 CREATE TABLE `individual_type` (
   `individual_type_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
   `name` varchar(255) NOT NULL,
-  `description` text,
+  `description` text DEFAULT NULL,
   PRIMARY KEY (`individual_type_id`)
 ) ENGINE=MyISAM AUTO_INCREMENT=5 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `meta` (
   `meta_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `species_id` int(10) unsigned DEFAULT '1',
+  `species_id` int(10) unsigned DEFAULT 1,
   `meta_key` varchar(40) NOT NULL,
   `meta_value` varchar(255) NOT NULL,
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`),
   KEY `species_value_idx` (`species_id`,`meta_value`)
-) ENGINE=MyISAM AUTO_INCREMENT=42 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=46 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `meta_coord` (
   `table_name` varchar(40) NOT NULL,
@@ -200,14 +200,14 @@ CREATE TABLE `motif_feature_variation` (
   `variation_feature_id` int(11) unsigned NOT NULL,
   `feature_stable_id` varchar(128) DEFAULT NULL,
   `motif_feature_id` int(11) unsigned NOT NULL,
-  `allele_string` text,
-  `somatic` tinyint(1) NOT NULL DEFAULT '0',
+  `allele_string` text DEFAULT NULL,
+  `somatic` tinyint(1) NOT NULL DEFAULT 0,
   `consequence_types` set('TF_binding_site_variant','TFBS_ablation','TFBS_fusion','TFBS_amplification','TFBS_translocation') DEFAULT NULL,
   `binding_matrix_stable_id` varchar(60) DEFAULT NULL,
   `motif_start` int(11) unsigned DEFAULT NULL,
   `motif_end` int(11) unsigned DEFAULT NULL,
   `motif_score_delta` float DEFAULT NULL,
-  `in_informative_position` tinyint(1) NOT NULL DEFAULT '0',
+  `in_informative_position` tinyint(1) NOT NULL DEFAULT 0,
   PRIMARY KEY (`motif_feature_variation_id`),
   KEY `variation_feature_idx` (`variation_feature_id`),
   KEY `consequence_type_idx` (`consequence_types`),
@@ -233,7 +233,7 @@ CREATE TABLE `phenotype_feature` (
   `study_id` int(11) unsigned DEFAULT NULL,
   `type` enum('Gene','Variation','StructuralVariation','SupportingStructuralVariation','QTL','RegulatoryFeature') DEFAULT NULL,
   `object_id` varchar(255) DEFAULT NULL,
-  `is_significant` tinyint(1) unsigned DEFAULT '1',
+  `is_significant` tinyint(1) unsigned DEFAULT 1,
   `seq_region_id` int(11) unsigned DEFAULT NULL,
   `seq_region_start` int(11) unsigned DEFAULT NULL,
   `seq_region_end` int(11) unsigned DEFAULT NULL,
@@ -267,8 +267,8 @@ CREATE TABLE `population` (
   `population_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
   `name` varchar(255) DEFAULT NULL,
   `size` int(10) DEFAULT NULL,
-  `description` text,
-  `collection` tinyint(1) DEFAULT '0',
+  `description` text DEFAULT NULL,
+  `collection` tinyint(1) DEFAULT 0,
   `freqs_from_gts` tinyint(1) DEFAULT NULL,
   `display` enum('LD','MARTDISPLAYABLE','UNDISPLAYABLE') DEFAULT 'UNDISPLAYABLE',
   `display_group_id` tinyint(1) DEFAULT NULL,
@@ -310,7 +310,7 @@ CREATE TABLE `population_synonym` (
 CREATE TABLE `protein_function_predictions` (
   `translation_md5_id` int(11) unsigned NOT NULL,
   `analysis_attrib_id` int(11) unsigned NOT NULL,
-  `prediction_matrix` mediumblob,
+  `prediction_matrix` mediumblob DEFAULT NULL,
   PRIMARY KEY (`translation_md5_id`,`analysis_attrib_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1;
 
@@ -318,7 +318,7 @@ CREATE TABLE `protein_function_predictions_attrib` (
   `translation_md5_id` int(11) unsigned NOT NULL,
   `analysis_attrib_id` int(11) unsigned NOT NULL,
   `attrib_type_id` int(11) unsigned NOT NULL,
-  `position_values` blob,
+  `position_values` blob DEFAULT NULL,
   PRIMARY KEY (`translation_md5_id`,`analysis_attrib_id`,`attrib_type_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1;
 
@@ -350,9 +350,9 @@ CREATE TABLE `regulatory_feature_variation` (
   `regulatory_feature_variation_id` int(11) unsigned NOT NULL AUTO_INCREMENT,
   `variation_feature_id` int(11) unsigned NOT NULL,
   `feature_stable_id` varchar(128) DEFAULT NULL,
-  `feature_type` text,
-  `allele_string` text,
-  `somatic` tinyint(1) NOT NULL DEFAULT '0',
+  `feature_type` text DEFAULT NULL,
+  `allele_string` text DEFAULT NULL,
+  `somatic` tinyint(1) NOT NULL DEFAULT 0,
   `consequence_types` set('regulatory_region_variant','regulatory_region_ablation','regulatory_region_fusion','regulatory_region_amplification','regulatory_region_translocation') DEFAULT NULL,
   PRIMARY KEY (`regulatory_feature_variation_id`),
   KEY `variation_feature_idx` (`variation_feature_id`),
@@ -365,10 +365,10 @@ CREATE TABLE `sample` (
   `sample_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
   `individual_id` int(10) unsigned NOT NULL,
   `name` varchar(255) DEFAULT NULL,
-  `description` text,
+  `description` text DEFAULT NULL,
   `study_id` int(10) unsigned DEFAULT NULL,
   `display` enum('REFERENCE','DEFAULT','DISPLAYABLE','UNDISPLAYABLE','LD','MARTDISPLAYABLE') DEFAULT 'UNDISPLAYABLE',
-  `has_coverage` tinyint(1) unsigned NOT NULL DEFAULT '0',
+  `has_coverage` tinyint(1) unsigned NOT NULL DEFAULT 0,
   `variation_set_id` set('1','2','3','4','5','6','7','8','9','10','11','12','13','14','15','16','17','18','19','20','21','22','23','24','25','26','27','28','29','30','31','32','33','34','35','36','37','38','39','40','41','42','43','44','45','46','47','48','49','50','51','52','53','54','55','56','57','58','59','60','61','62','63','64') DEFAULT NULL,
   PRIMARY KEY (`sample_id`),
   KEY `individual_idx` (`individual_id`),
@@ -421,7 +421,8 @@ CREATE TABLE `source` (
   `type` enum('chip','lsdb') DEFAULT NULL,
   `somatic_status` enum('germline','somatic','mixed') DEFAULT 'germline',
   `data_types` set('variation','variation_synonym','structural_variation','phenotype_feature','study') DEFAULT NULL,
-  PRIMARY KEY (`source_id`)
+  PRIMARY KEY (`source_id`),
+  UNIQUE KEY `name_idx` (`name`)
 ) ENGINE=MyISAM AUTO_INCREMENT=2 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `structural_variation` (
@@ -430,11 +431,11 @@ CREATE TABLE `structural_variation` (
   `alias` varchar(255) DEFAULT NULL,
   `source_id` int(10) unsigned NOT NULL,
   `study_id` int(10) unsigned DEFAULT NULL,
-  `class_attrib_id` int(10) unsigned NOT NULL DEFAULT '0',
+  `class_attrib_id` int(10) unsigned NOT NULL DEFAULT 0,
   `clinical_significance` set('uncertain significance','not provided','benign','likely benign','likely pathogenic','pathogenic','drug response','histocompatibility','other','confers sensitivity','risk factor','association','protective') DEFAULT NULL,
   `validation_status` enum('validated','not validated','high quality') DEFAULT NULL,
-  `is_evidence` tinyint(4) DEFAULT '0',
-  `somatic` tinyint(1) NOT NULL DEFAULT '0',
+  `is_evidence` tinyint(4) DEFAULT 0,
+  `somatic` tinyint(1) NOT NULL DEFAULT 0,
   `copy_number` tinyint(2) DEFAULT NULL,
   PRIMARY KEY (`structural_variation_id`),
   UNIQUE KEY `variation_name` (`variation_name`),
@@ -465,10 +466,10 @@ CREATE TABLE `structural_variation_feature` (
   `variation_name` varchar(255) DEFAULT NULL,
   `source_id` int(10) unsigned NOT NULL,
   `study_id` int(10) unsigned DEFAULT NULL,
-  `class_attrib_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `allele_string` longtext,
-  `is_evidence` tinyint(1) NOT NULL DEFAULT '0',
-  `somatic` tinyint(1) NOT NULL DEFAULT '0',
+  `class_attrib_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `allele_string` longtext DEFAULT NULL,
+  `is_evidence` tinyint(1) NOT NULL DEFAULT 0,
+  `somatic` tinyint(1) NOT NULL DEFAULT 0,
   `breakpoint_order` tinyint(4) DEFAULT NULL,
   `length` int(10) DEFAULT NULL,
   `variation_set_id` set('1','2','3','4','5','6','7','8','9','10','11','12','13','14','15','16','17','18','19','20','21','22','23','24','25','26','27','28','29','30','31','32','33','34','35','36','37','38','39','40','41','42','43','44','45','46','47','48','49','50','51','52','53','54','55','56','57','58','59','60','61','62','63','64') NOT NULL DEFAULT '',
@@ -495,7 +496,7 @@ CREATE TABLE `study` (
   `study_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
   `source_id` int(10) unsigned NOT NULL,
   `name` varchar(255) DEFAULT NULL,
-  `description` text,
+  `description` text DEFAULT NULL,
   `url` varchar(255) DEFAULT NULL,
   `external_reference` varchar(255) DEFAULT NULL,
   `study_type` varchar(255) DEFAULT NULL,
@@ -538,8 +539,8 @@ CREATE TABLE `transcript_variation` (
   `transcript_variation_id` int(11) unsigned NOT NULL AUTO_INCREMENT,
   `variation_feature_id` int(11) unsigned NOT NULL,
   `feature_stable_id` varchar(128) DEFAULT NULL,
-  `allele_string` text,
-  `somatic` tinyint(1) NOT NULL DEFAULT '0',
+  `allele_string` text DEFAULT NULL,
+  `somatic` tinyint(1) NOT NULL DEFAULT 0,
   `consequence_types` set('splice_acceptor_variant','splice_donor_variant','stop_lost','coding_sequence_variant','missense_variant','stop_gained','synonymous_variant','frameshift_variant','non_coding_transcript_variant','non_coding_transcript_exon_variant','mature_miRNA_variant','NMD_transcript_variant','5_prime_UTR_variant','3_prime_UTR_variant','incomplete_terminal_codon_variant','intron_variant','splice_region_variant','downstream_gene_variant','upstream_gene_variant','start_lost','stop_retained_variant','inframe_insertion','inframe_deletion','transcript_ablation','transcript_fusion','transcript_amplification','transcript_translocation','feature_elongation','feature_truncation','protein_altering_variant','start_retained_variant') DEFAULT NULL,
   `cds_start` int(11) unsigned DEFAULT NULL,
   `cds_end` int(11) unsigned DEFAULT NULL,
@@ -548,16 +549,16 @@ CREATE TABLE `transcript_variation` (
   `translation_start` int(11) unsigned DEFAULT NULL,
   `translation_end` int(11) unsigned DEFAULT NULL,
   `distance_to_transcript` int(11) unsigned DEFAULT NULL,
-  `codon_allele_string` text,
-  `pep_allele_string` text,
-  `hgvs_genomic` text,
-  `hgvs_transcript` text,
-  `hgvs_protein` text,
+  `codon_allele_string` text DEFAULT NULL,
+  `pep_allele_string` text DEFAULT NULL,
+  `hgvs_genomic` text DEFAULT NULL,
+  `hgvs_transcript` text DEFAULT NULL,
+  `hgvs_protein` text DEFAULT NULL,
   `polyphen_prediction` enum('unknown','benign','possibly damaging','probably damaging') DEFAULT NULL,
   `polyphen_score` float DEFAULT NULL,
   `sift_prediction` enum('tolerated','deleterious','tolerated - low confidence','deleterious - low confidence') DEFAULT NULL,
   `sift_score` float DEFAULT NULL,
-  `display` int(1) DEFAULT '1',
+  `display` int(1) DEFAULT 1,
   PRIMARY KEY (`transcript_variation_id`),
   KEY `variation_feature_idx` (`variation_feature_id`),
   KEY `consequence_type_idx` (`consequence_types`),
@@ -575,16 +576,15 @@ CREATE TABLE `variation` (
   `variation_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
   `source_id` int(10) unsigned NOT NULL,
   `name` varchar(255) DEFAULT NULL,
-  `ancestral_allele` varchar(255) DEFAULT NULL,
   `flipped` tinyint(1) unsigned DEFAULT NULL,
-  `class_attrib_id` int(10) unsigned DEFAULT '0',
-  `somatic` tinyint(1) NOT NULL DEFAULT '0',
+  `class_attrib_id` int(10) unsigned DEFAULT 0,
+  `somatic` tinyint(1) NOT NULL DEFAULT 0,
   `minor_allele` varchar(50) DEFAULT NULL,
   `minor_allele_freq` float DEFAULT NULL,
   `minor_allele_count` int(10) unsigned DEFAULT NULL,
   `clinical_significance` set('uncertain significance','not provided','benign','likely benign','likely pathogenic','pathogenic','drug response','histocompatibility','other','confers sensitivity','risk factor','association','protective') DEFAULT NULL,
   `evidence_attribs` set('367','368','369','370','371','372','418','421','573','585') DEFAULT NULL,
-  `display` int(1) DEFAULT '1',
+  `display` int(1) DEFAULT 1,
   PRIMARY KEY (`variation_id`),
   UNIQUE KEY `name` (`name`),
   KEY `source_idx` (`source_id`)
@@ -612,21 +612,22 @@ CREATE TABLE `variation_feature` (
   `seq_region_strand` tinyint(4) NOT NULL,
   `variation_id` int(10) unsigned NOT NULL,
   `allele_string` varchar(50000) DEFAULT NULL,
+  `ancestral_allele` varchar(50) DEFAULT NULL,
   `variation_name` varchar(255) DEFAULT NULL,
   `map_weight` int(11) NOT NULL,
   `flags` set('genotyped') DEFAULT NULL,
   `source_id` int(10) unsigned NOT NULL,
   `consequence_types` set('intergenic_variant','splice_acceptor_variant','splice_donor_variant','stop_lost','coding_sequence_variant','missense_variant','stop_gained','synonymous_variant','frameshift_variant','non_coding_transcript_variant','non_coding_transcript_exon_variant','mature_miRNA_variant','NMD_transcript_variant','5_prime_UTR_variant','3_prime_UTR_variant','incomplete_terminal_codon_variant','intron_variant','splice_region_variant','downstream_gene_variant','upstream_gene_variant','start_lost','stop_retained_variant','inframe_insertion','inframe_deletion','transcript_ablation','transcript_fusion','transcript_amplification','transcript_translocation','TFBS_ablation','TFBS_fusion','TFBS_amplification','TFBS_translocation','regulatory_region_ablation','regulatory_region_fusion','regulatory_region_amplification','regulatory_region_translocation','feature_elongation','feature_truncation','regulatory_region_variant','TF_binding_site_variant','protein_altering_variant','start_retained_variant') NOT NULL DEFAULT 'intergenic_variant',
   `variation_set_id` set('1','2','3','4','5','6','7','8','9','10','11','12','13','14','15','16','17','18','19','20','21','22','23','24','25','26','27','28','29','30','31','32','33','34','35','36','37','38','39','40','41','42','43','44','45','46','47','48','49','50','51','52','53','54','55','56','57','58','59','60','61','62','63','64') NOT NULL DEFAULT '',
-  `class_attrib_id` int(10) unsigned DEFAULT '0',
-  `somatic` tinyint(1) NOT NULL DEFAULT '0',
+  `class_attrib_id` int(10) unsigned DEFAULT 0,
+  `somatic` tinyint(1) NOT NULL DEFAULT 0,
   `minor_allele` varchar(50) DEFAULT NULL,
   `minor_allele_freq` float DEFAULT NULL,
   `minor_allele_count` int(10) unsigned DEFAULT NULL,
   `alignment_quality` double DEFAULT NULL,
   `evidence_attribs` set('367','368','369','370','371','372','418','421','573','585') DEFAULT NULL,
   `clinical_significance` set('uncertain significance','not provided','benign','likely benign','likely pathogenic','pathogenic','drug response','histocompatibility','other','confers sensitivity','risk factor','association','protective') DEFAULT NULL,
-  `display` int(1) DEFAULT '1',
+  `display` int(1) DEFAULT 1,
   PRIMARY KEY (`variation_feature_id`),
   KEY `pos_idx` (`seq_region_id`,`seq_region_start`,`seq_region_end`),
   KEY `variation_idx` (`variation_id`),
@@ -650,7 +651,7 @@ CREATE TABLE `variation_hgvs` (
 CREATE TABLE `variation_set` (
   `variation_set_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
   `name` varchar(255) DEFAULT NULL,
-  `description` text,
+  `description` text DEFAULT NULL,
   `short_name_attrib_id` int(10) unsigned DEFAULT NULL,
   PRIMARY KEY (`variation_set_id`),
   KEY `name_idx` (`name`)

--- a/modules/t/test-genome-DBs/homo_sapiens/variation/variation.txt
+++ b/modules/t/test-genome-DBs/homo_sapiens/variation/variation.txt
@@ -1,3 +1,3 @@
-1	1	rs12345	\N	\N	0	0	\N	\N	\N	\N	\N	1
-2	1	rs67890	\N	\N	0	0	\N	\N	\N	\N	\N	1
-3	1	rs54321	\N	\N	0	1	\N	\N	\N	\N	\N	1
+1	1	rs12345	\N	0	0	\N	\N	\N	\N	\N	1
+2	1	rs67890	\N	0	0	\N	\N	\N	\N	\N	1
+3	1	rs54321	\N	0	1	\N	\N	\N	\N	\N	1

--- a/modules/t/test-genome-DBs/homo_sapiens/variation/variation_feature.txt
+++ b/modules/t/test-genome-DBs/homo_sapiens/variation/variation_feature.txt
@@ -1,3 +1,3 @@
-1	469283	30252800	30252800	1	1	\N	rs12345	1	genotyped	1	intergenic_variant	1	0	0	\N	\N	\N	\N	\N	\N	1
-2	469283	30252900	30252900	1	2	\N	rs67890	1	\N	1	intergenic_variant	1	0	0	\N	\N	\N	\N	\N	\N	1
-3	469283	30253900	30253900	1	3	\N	rs54321	1	\N	1	intergenic_variant		0	1	\N	\N	\N	\N	\N	\N	1
+1	469283	30252800	30252800	1	1	\N	\N	rs12345	1	genotyped	1	intergenic_variant	1	0	0	\N	\N	\N	\N	\N	\N	1
+2	469283	30252900	30252900	1	2	\N	\N	rs67890	1	\N	1	intergenic_variant	1	0	0	\N	\N	\N	\N	\N	\N	1
+3	469283	30253900	30253900	1	3	\N	\N	rs54321	1	\N	1	intergenic_variant		0	1	\N	\N	\N	\N	\N	\N	1


### PR DESCRIPTION
I forgot that patch_test_databases can only handle single-version bumps so with the test databases having only fully been sinced with 97 on the relevant release branch, the variation schema ended up remaining at 96 on master even when all other DBs got bumped to 98. Manually apply variation schema patches to bring that test DB up to date.
