### PR TITLE
Travis: explicitly use Ubuntu Trusty for builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+dist: trusty
+
 language: "perl"
 
 sudo: false


### PR DESCRIPTION
## Use case

Make sure we are not affected by the ongoing change of the default Travis build environment from Ubuntu Trusty to Ubuntu Xenial, for which we are not ready yet, by explicitly requesting the former.

## Description

It has turned out that in spite of what the Travis documentation says, perl-5.14 is *not* available under the Xenial environment on Travis. We still require compatibility with that Perl version so it is necessary for us to make sure we continue to use Trusty even after the default Travis environment has been changed to Xenial, a change that is now in progress following the end of life of Ubuntu Trusty (see https://blog.travis-ci.com/2019-04-15-xenial-default-build-environment).

## Possible Drawbacks

Ubuntu Trusty has already reached end of life.

## Testing

_Have you added/modified unit tests to test the changes?_

No, changes affect Travis only.

_If so, do the tests pass/fail?_

N/A

_Have you run the entire test suite and no regression was detected?_

No, changes affect Travis only.