### PR TITLE
[ENSCORESW-3334] escape RDF

### DIFF
--- a/modules/Bio/EnsEMBL/IO/Writer/RDF.pm
+++ b/modules/Bio/EnsEMBL/IO/Writer/RDF.pm
@@ -190,7 +190,7 @@ sub _bulk_fetcher_feature_record {
     # Homeologues - same species, different sub-genome in a polyploid species.
     foreach my $alt_gene (@{$translator->homologues($object)}) {
       my $predicate = ($alt_gene->{description} eq 'within_species_paralog') ? 'sio:SIO_000630': 'sio:SIO_000558';
-      ${$record} .= sprintf "%s\n", triple(u($feature_uri), $predicate, 'ensembl:'.$alt_gene->{stable_id});
+      ${$record} .= sprintf "%s\n", triple(u($feature_uri), $predicate, 'ensembl:'.uri_escape_utf8($alt_gene->{stable_id}));
     }
   }
 

--- a/modules/Bio/EnsEMBL/IO/Writer/RDF.pm
+++ b/modules/Bio/EnsEMBL/IO/Writer/RDF.pm
@@ -190,7 +190,7 @@ sub _bulk_fetcher_feature_record {
     # Homeologues - same species, different sub-genome in a polyploid species.
     foreach my $alt_gene (@{$translator->homologues($object)}) {
       my $predicate = ($alt_gene->{description} eq 'within_species_paralog') ? 'sio:SIO_000630': 'sio:SIO_000558';
-      ${$record} .= sprintf "%s\n", triple(u($feature_uri), $predicate, 'ensembl:'.uri_escape_utf8($alt_gene->{stable_id}));
+      ${$record} .= sprintf "%s\n", triple(u($feature_uri), $predicate, 'ensembl:'.uri_escape($alt_gene->{stable_id}));
     }
   }
 


### PR DESCRIPTION
added an utf8 escape to avoid syntax errors on RDF.
URLs should be fine with the escape, and RDF will now be valid