### PR TITLE
Accession in GFF3/GTF headers

### DIFF
--- a/modules/Bio/EnsEMBL/Utils/IO/GFFSerializer.pm
+++ b/modules/Bio/EnsEMBL/Utils/IO/GFFSerializer.pm
@@ -342,10 +342,7 @@ sub print_main_header {
     # Get accession and only print if it is there
     my $accession = $gc->get_accession();
     if($accession) {
-       my $accession_source = $mc->single_value_by_key('assembly.web_accession_source');
-       my $string = "#!genome-build-accession ";
-       $string .= "$accession_source:" if $accession_source;
-       $string .= "$accession";
+       my $string = "#!genome-build-accession $accession";
 
        print $fh "$string\n";
     }

--- a/modules/Bio/EnsEMBL/Utils/IO/GTFSerializer.pm
+++ b/modules/Bio/EnsEMBL/Utils/IO/GTFSerializer.pm
@@ -77,14 +77,9 @@ sub print_main_header {
   # Get accession and only print if it is there
   my $accession = $gc->get_accession();
   if($accession) {
-     my $accession_source = $mc->single_value_by_key('assembly.web_accession_source');
-     my $string = "#!genome-build-accession ";
-     $string .= "$accession_source:" if $accession_source;
-     $string .= "$accession"; 
+     my $string = "#!genome-build-accession $accession"; 
 
      print $fh "$string\n";
-     #my $accession_source = $mc->single_value_by_key('assembly.web_accession_source');
-     #print $fh "#!genome-build-accession ${accession_source}:${accession}\n";
   }
 
   # Genebuild last updated


### PR DESCRIPTION
In GFF3 and GTF headers, the assembly accession was being prefixed by the value of the meta_key 'assembly.web_accession_source'. This is incorrect - this value is intended to be used by the webcode, in order to decide whether to create hyperlinks to ENA or NCBI, and thus the meta_value is 'ENA' or 'NCBI'. We don't want to prefix the accession with either of those values - it is an INSDC identifier, and it's unnecessary/misleading/confusing to associate it with a specific member.