### PR TITLE
Added support for keys with no value to the Genbank parser.

### DIFF
--- a/modules/Bio/EnsEMBL/IO/Parser/Genbank.pm
+++ b/modules/Bio/EnsEMBL/IO/Parser/Genbank.pm
@@ -502,7 +502,11 @@ sub _finish_feature {
     foreach my $section (@sections) {
         my ($key,$value) = split '=',$section;
         $value =~ s/"//g if $value;
-        push @{ $feature->{$key} },$value if ($key && $value);
+        if ($key && $value) {
+            push @{ $feature->{$key} },$value;
+        } elsif ($key) {
+            push @{ $feature->{$key} },'1';
+        }
     }
     my %final_copy = %$feature;
     return \%final_copy;

--- a/modules/t/genbank.t
+++ b/modules/t/genbank.t
@@ -54,6 +54,28 @@ $feature = $features[2];
 is($feature->{gene}->[0],'si:dkey-111e8.5','Check correct gene extracted from feature block');
 is_deeply($feature->{db_xref}, ['GeneID:566993','ZFIN:ZDB-GENE-060526-192'], 'Xrefs extracted from feature are correct');
 
+ok ($parser->next(), "Loading third record");
+is($parser->get_accession,'NC_011032',"Testing get_accession");
+is($parser->get_sequence_name,'NC_011032.1',"Testing get_sequence_name");
+is($parser->get_sequence_version,'1',"Testing get_sequence_version");
+is($parser->get_length,'135199',"Testing get_length");
+is($parser->get_organism,'Brachypodium distachyon',"Testing get_organism");
+is($parser->get_description,'Brachypodium distachyon chloroplast, complete genome.',"Testing get_description with multiline definition");
+is($parser->get_locus_id,'NC_011032',"Testing get_locus_id");
+is($parser->get_sequence_type,'DNA',"Testing get_sequence_type");
+is($parser->get_modification_date,'26-MAR-2010',"Testing get_modification_date");
+is($parser->get_source,'chloroplast Brachypodium distachyon (stiff brome)',"Testing get_source");
+is($parser->get_taxon_id,'15368',"Testing get_taxon_id");
+cmp_ok($parser->is_circular, '==', 1, "Testing is_circular");
+ok($parser->get_length == length($parser->get_sequence), "Testing length of the sequence");
+
+@features = @{ $parser->get_features };
+cmp_ok(scalar @features,'==', 294, "Testing number of features");
+$feature = $features[1];
+is($feature->{gene}->[0],'rps12','Check correct gene extracted from feature block');
+is($feature->{trans_splicing}->[0],'1','Check valueless feature trans_splicing extracted from feature block');
+is_deeply($feature->{db_xref}, ['GeneID:6439811'], 'Xrefs extracted from feature are correct');
+
 ok ($parser->close(), "Closing file");
 
 done_testing();

--- a/modules/t/input/data.gbk
+++ b/modules/t/input/data.gbk
@@ -1373,3 +1373,4255 @@ ORIGIN
       541 acttgtgtta ttctctga
 //
 
+LOCUS       NC_011032             135199 bp    DNA     circular PLN 26-MAR-2010
+DEFINITION  Brachypodium distachyon chloroplast, complete genome.
+ACCESSION   NC_011032
+VERSION     NC_011032.1
+DBLINK      Project: 30589
+            BioProject: PRJNA30589
+KEYWORDS    RefSeq.
+SOURCE      chloroplast Brachypodium distachyon (stiff brome)
+  ORGANISM  Brachypodium distachyon
+            Eukaryota; Viridiplantae; Streptophyta; Embryophyta; Tracheophyta;
+            Spermatophyta; Magnoliopsida; Liliopsida; Poales; Poaceae; BOP
+            clade; Pooideae; Brachypodieae; Brachypodium.
+REFERENCE   1  (bases 1 to 135199)
+  AUTHORS   Bortiri,E., Coleman-Derr,D., Lazo,G.R., Anderson,O.D. and Gu,Y.Q.
+  TITLE     The complete chloroplast genome sequence of Brachypodium
+            distachyon: sequence comparison and phylogenetic analysis of eight
+            grass plastomes
+  JOURNAL   BMC Res Notes 1, 61 (2008)
+   PUBMED   18710514
+  REMARK    Publication Status: Online-Only
+REFERENCE   2  (bases 1 to 135199)
+  AUTHORS   Bortiri,E., Coleman-Derr,D., Anderson,O. and Gu,Y.
+  TITLE     Direct Submission
+  JOURNAL   Submitted (03-DEC-2007) ARS, USDA, 800 Buchanan Avenue, Albany, CA
+            94710, USA
+REFERENCE   3  (bases 1 to 135199)
+  CONSRTM   NCBI Genome Project
+  TITLE     Direct Submission
+  JOURNAL   Submitted (01-AUG-2000) National Center for Biotechnology
+            Information, NIH, Bethesda, MD 20894, USA
+COMMENT     PROVISIONAL REFSEQ: This record has not yet been subject to final
+            NCBI review. The reference sequence was derived from EU325680.
+            COMPLETENESS: full length.
+FEATURES             Location/Qualifiers
+     source          1..135199
+                     /organism="Brachypodium distachyon"
+                     /organelle="plastid:chloroplast"
+                     /mol_type="genomic DNA"
+                     /cultivar="Bd21"
+                     /db_xref="taxon:15368"
+     gene            complement(join(88290..89078,66293..66406))
+                     /gene="rps12"
+                     /locus_tag="BrdiC_p049"
+                     /trans_splicing
+                     /db_xref="GeneID:6439811"
+     CDS             complement(join(88290..88317,88858..89078,66293..66406))
+                     /gene="rps12"
+                     /locus_tag="BrdiC_p049"
+                     /trans_splicing
+                     /codon_start=1
+                     /transl_table=11
+                     /product="ribosomal protein S12"
+                     /protein_id="YP_002000467.1"
+                     /db_xref="GeneID:6439811"
+                     /translation="MPTVKQLIRNARQPIRTARKTAALKGCPQRRGTCARVYKKPNSA
+                     LRKVARVRLTSGFEITAYIPGIGHNLQEHSVVLVRGGRVKDLPGVRYRIIRGTLDAVA
+                     VKNRQQGRSRYGVKKPKK"
+     gene            complement(95..1156)
+                     /gene="psbA"
+                     /locus_tag="BrdiC_p001"
+                     /db_xref="GeneID:6439798"
+     CDS             complement(95..1156)
+                     /gene="psbA"
+                     /locus_tag="BrdiC_p001"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="photosystem II protein D1"
+                     /protein_id="YP_002000468.1"
+                     /db_xref="GeneID:6439798"
+                     /translation="MTAILERRESTSLWGRFCNWITSTENRLYIGWFGVLMIPTLLTA
+                     TSVFIIAFIAAPPVDIDGIREPVSGSLLYGNNIISGAIIPTSAAIGLHFYPIWEAASV
+                     DEWLYNGGPYELIVLHFLLGVACYMGREWELSFRLGMRPWIAVAYSAPVAAATAVFLI
+                     YPIGQGSFSDGMPLGISGTFNFMIVFQAEHNILMHPFHMLGVAGVFGGSLFSAMHGSL
+                     VTSSLIRETTENESANEGYKFGQEEETYNIVAAHGYFGRLIFQYASFNNSRSLHFFLA
+                     AWPVVGIWFTALGISTMAFNLNGFNFNQSVVDSQGRVINTWADIINRANLGMEVMHER
+                     NAHNFPLDLAALEVPAING"
+     gene            complement(1392..3847)
+                     /gene="trnK"
+                     /locus_tag="BrdiC_t001"
+                     /db_xref="GeneID:6439770"
+     tRNA            complement(join(1392..1416,3718..3847))
+                     /gene="trnK"
+                     /locus_tag="BrdiC_t001"
+                     /product="tRNA-Lys"
+                     /codon_recognized="AAA"
+                     /db_xref="GeneID:6439770"
+     gene            complement(1646..3181)
+                     /gene="matK"
+                     /locus_tag="BrdiC_p002"
+                     /db_xref="GeneID:6439874"
+     CDS             complement(1646..3181)
+                     /gene="matK"
+                     /locus_tag="BrdiC_p002"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="maturase K"
+                     /protein_id="YP_002000469.2"
+                     /db_xref="GeneID:6439874"
+                     /translation="MEKFEEISEKHKSRQQYFVYPLLFQEFLYAFAHDYGLNDSEPVE
+                     IVSCNNKKFSSLLVKRLIIRMYQQNFWINSVNHPNQDRLLDYKNFFYSEFFSQILSEG
+                     FSIVVEIPFSLRESFCPKEKEIPKFQNLRSIHSIFSFLEDKFLHLHYLSHIEIPYPIH
+                     LEILVQLLQYHIQDVPSLHLLRFFLNYNSNWNSFITSIKSFFLLKKENKRLFRFLYNS
+                     YVSEYEFFLLFLRKQSSCLPLASSGGFLERIHFSRKMEHFGIMDPGFFRKTLWFFMDP
+                     LMHYVRYQGKAILASKGTLFLKKKWKWYLVNFCQYSFSFWTQPRRIHLNQLANSCFDF
+                     LGYLSSVPKSPLLVRNQMLENSFLIDTRMIKFDTIVPATLLIGSLSKAQFCTGSGHPI
+                     SKPIWTELSDWDILDRFGQICKNLFHYHSGSSKKRTLYRLKYILRLSCARTLARKHKS
+                     TVRTFMQRLGSVFLEEFFTEEDPVFSLMFTKTTLFYFRGSHSERIWYLDIIRINGLVN
+                     PRN"
+     gene            complement(4407..5489)
+                     /gene="rps16"
+                     /locus_tag="BrdiC_p003"
+                     /db_xref="GeneID:6439809"
+     CDS             complement(join(4407..4624,5450..5489))
+                     /gene="rps16"
+                     /locus_tag="BrdiC_p003"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="ribosomal protein S16"
+                     /protein_id="YP_002000470.1"
+                     /db_xref="GeneID:6439809"
+                     /translation="MVKLRLKRCGRKQQAVYRIVAIDVRSRREGRDLRKVGFYDPIKN
+                     QTSLNVPAILYFLEKGAQPTRTVYDILKKAEFFKEKERTLS"
+     exon            complement(4407..4624)
+                     /gene="rps16"
+                     /locus_tag="BrdiC_p003"
+                     /number=1
+     exon            complement(5450..5489)
+                     /gene="rps16"
+                     /locus_tag="BrdiC_p003"
+                     /number=2
+     gene            complement(6273..6390)
+                     /gene="trnQ"
+                     /locus_tag="BrdiC_t002"
+                     /db_xref="GeneID:6439891"
+     tRNA            complement(6273..6390)
+                     /gene="trnQ"
+                     /locus_tag="BrdiC_t002"
+                     /product="tRNA-Gln"
+                     /codon_recognized="CAA"
+                     /db_xref="GeneID:6439891"
+     gene            6693..6875
+                     /gene="psbK"
+                     /locus_tag="BrdiC_p004"
+                     /db_xref="GeneID:6439852"
+     CDS             6693..6875
+                     /gene="psbK"
+                     /locus_tag="BrdiC_p004"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="PSII K protein"
+                     /protein_id="YP_002000471.1"
+                     /db_xref="GeneID:6439852"
+                     /translation="MPNILSLTCICFNCVLYPTSFFLLTTRSLCHFHPIVDFMPVIPL
+                     FFFLLAFVWQAAVSFR"
+     gene            7286..7396
+                     /gene="psbI"
+                     /locus_tag="BrdiC_p005"
+                     /db_xref="GeneID:6439853"
+     CDS             7286..7396
+                     /gene="psbI"
+                     /locus_tag="BrdiC_p005"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="photosystem II protein I"
+                     /protein_id="YP_002000472.1"
+                     /db_xref="GeneID:6439853"
+                     /translation="MLTLKLFVYTVVIFFVSLFIFGFLSNDPGRNPGREE"
+     gene            complement(7516..7603)
+                     /gene="trnS"
+                     /locus_tag="BrdiC_t003"
+                     /db_xref="GeneID:6439858"
+     tRNA            complement(7516..7603)
+                     /gene="trnS"
+                     /locus_tag="BrdiC_t003"
+                     /product="tRNA-Ser"
+                     /codon_recognized="AGC"
+                     /db_xref="GeneID:6439858"
+     gene            8591..9652
+                     /gene="psbD"
+                     /locus_tag="BrdiC_p006"
+                     /db_xref="GeneID:6439844"
+     CDS             8591..9652
+                     /gene="psbD"
+                     /locus_tag="BrdiC_p006"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="photosystem II protein D2"
+                     /protein_id="YP_002000473.1"
+                     /db_xref="GeneID:6439844"
+                     /translation="MTIALGRIPKEEKDLFDTVDDWLRRDRFVFVGWSGLLLFPCAYF
+                     ALGGWFTGTTFVTSWYTHGLASSYLEGCNFLTAAVSTPANSLAHSLLLLWGPEAQGDF
+                     TRWCQLGGLWTFVALHGAFALIGFMLRQFELARSIQLRPYNAISFSGPIAVFVSVFLI
+                     YPLGQSGWFFAPSFGVAAIFRFILFFQGFHNWTLNPFHMMGVAGVLGAALLCAIHGAT
+                     VENTLFEDGDGANTFRAFNPTQAEETYSMVTANRFWSQIFGVAFSNKRWLHFFMLFVP
+                     VTGLWMSAIGVVGLALNLRAYDFVSQEIRAAEDPEFETFYTKNILLNEGIRAWMAAQD
+                     QPHENLIFPEEVLPRGNAL"
+     gene            9600..11021
+                     /gene="psbC"
+                     /locus_tag="BrdiC_p007"
+                     /db_xref="GeneID:6439864"
+     CDS             9600..11021
+                     /gene="psbC"
+                     /locus_tag="BrdiC_p007"
+                     /note="CP43"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="photosystem II 44 kDa protein"
+                     /protein_id="YP_002000474.1"
+                     /db_xref="GeneID:6439864"
+                     /translation="MKILYSLRRFYHVETLFNGTFVLAGRDQETTGFAWWAGNARLIN
+                     LSGKLLGAHVAHAGLIVFWAGAMNLFEVAHFVPEKPMYEQGLILLPHLATLGWGVGPG
+                     GEVLDTFPYFVSGVLHLISSAVLGFGGIYHALLGPETLEESFPFFGYVWKDRNKMTTI
+                     LGIHLILLGLGAFLLVLKALYFGGVYDTWAPGGGDVRKITNLTLSPGVIFGYLLKSPF
+                     GGEGWIVSVDDLEDIIGGHVWLGFICVFGGIWHILTKPFAWARRAFVWSGEAYLSYSL
+                     AALSVFGFIACCFVWFNNTAYPSEFYGPTGPEASQAQAFTFLVRDQRLGANVGSAQGP
+                     TGLGKYLMRSPTGEVIFGGETMRFWDLRAPWLEPLRGPNGLDLSRLKKDIQPWQERRS
+                     AEYMTHAPLGSLNSVGGVATEINAVNYVSPRSWLSTSHFVLGFFFFVGHLWHAGRARA
+                     AAAGFEKGIDRDLEPVLYMNPLN"
+     gene            complement(11186..11273)
+                     /gene="trnS"
+                     /locus_tag="BrdiC_t004"
+                     /db_xref="GeneID:6439773"
+     tRNA            complement(11186..11273)
+                     /gene="trnS"
+                     /locus_tag="BrdiC_t004"
+                     /product="tRNA-Ser"
+                     /codon_recognized="UCA"
+                     /db_xref="GeneID:6439773"
+     gene            11632..11820
+                     /gene="psbZ"
+                     /locus_tag="BrdiC_p008"
+                     /db_xref="GeneID:6439780"
+     CDS             11632..11820
+                     /gene="psbZ"
+                     /locus_tag="BrdiC_p008"
+                     /note="YCF9"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="photosystem II protein Z"
+                     /protein_id="YP_002000475.1"
+                     /db_xref="GeneID:6439780"
+                     /translation="MTIAFQLAVFALIATSSVLVISVPLVFASPDGWSNNKNVVFSGT
+                     SLWIGLVFLVAILNSLIS"
+     gene            12088..12158
+                     /gene="trnG"
+                     /locus_tag="BrdiC_t005"
+                     /db_xref="GeneID:6439889"
+     tRNA            12088..12158
+                     /gene="trnG"
+                     /locus_tag="BrdiC_t005"
+                     /product="tRNA-Gly"
+                     /codon_recognized="GGC"
+                     /db_xref="GeneID:6439889"
+     gene            complement(12596..12668)
+                     /gene="trnfM"
+                     /locus_tag="BrdiC_t006"
+                     /db_xref="GeneID:6439851"
+     tRNA            complement(12596..12668)
+                     /gene="trnfM"
+                     /locus_tag="BrdiC_t006"
+                     /product="tRNA-Met"
+                     /note="fMet"
+                     /codon_recognized="AUG"
+                     /db_xref="GeneID:6439851"
+     gene            complement(12798..13538)
+                     /gene="trnG"
+                     /locus_tag="BrdiC_t007"
+                     /db_xref="GeneID:6439794"
+     tRNA            complement(join(12798..12845,13515..13538))
+                     /gene="trnG"
+                     /locus_tag="BrdiC_t007"
+                     /product="tRNA-Gly"
+                     /codon_recognized="GGC"
+                     /db_xref="GeneID:6439794"
+     gene            complement(13817..13904)
+                     /gene="trnI"
+                     /locus_tag="BrdiC_p009"
+                     /pseudo
+                     /db_xref="GeneID:6439863"
+     gene            complement(13905..13996)
+                     /gene="rps12a"
+                     /locus_tag="BrdiC_p010"
+                     /pseudo
+                     /db_xref="GeneID:6439843"
+     gene            14320..14391
+                     /gene="trnT"
+                     /locus_tag="BrdiC_t008"
+                     /db_xref="GeneID:6439786"
+     tRNA            14320..14391
+                     /gene="trnT"
+                     /locus_tag="BrdiC_t008"
+                     /product="tRNA-Thr"
+                     /codon_recognized="ACC"
+                     /db_xref="GeneID:6439786"
+     gene            14399..14459
+                     /gene="trnT"
+                     /locus_tag="BrdiC_p011"
+                     /pseudo
+                     /db_xref="GeneID:6439862"
+     gene            14898..14916
+                     /gene="trnE"
+                     /locus_tag="BrdiC_p012"
+                     /pseudo
+                     /db_xref="GeneID:6439768"
+     gene            14917..14989
+                     /gene="trnE"
+                     /locus_tag="BrdiC_t009"
+                     /db_xref="GeneID:6439805"
+     tRNA            14917..14989
+                     /gene="trnE"
+                     /locus_tag="BrdiC_t009"
+                     /product="tRNA-Glu"
+                     /codon_recognized="GAA"
+                     /db_xref="GeneID:6439805"
+     gene            15051..15134
+                     /gene="trnY"
+                     /locus_tag="BrdiC_t010"
+                     /db_xref="GeneID:6439816"
+     tRNA            15051..15134
+                     /gene="trnY"
+                     /locus_tag="BrdiC_t010"
+                     /product="tRNA-Tyr"
+                     /codon_recognized="UAC"
+                     /db_xref="GeneID:6439816"
+     gene            15487..15560
+                     /gene="trnD"
+                     /locus_tag="BrdiC_t011"
+                     /db_xref="GeneID:6439884"
+     tRNA            15487..15560
+                     /gene="trnD"
+                     /locus_tag="BrdiC_t011"
+                     /product="tRNA-Asp"
+                     /codon_recognized="GAC"
+                     /db_xref="GeneID:6439884"
+     gene            16359..16463
+                     /gene="psbM"
+                     /locus_tag="BrdiC_p013"
+                     /db_xref="GeneID:6439785"
+     CDS             16359..16463
+                     /gene="psbM"
+                     /locus_tag="BrdiC_p013"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="photosystem II protein M"
+                     /protein_id="YP_002000476.1"
+                     /db_xref="GeneID:6439785"
+                     /translation="MEVNILAFIATALFILVPTAFLLIIYVKTVSQNN"
+     gene            complement(17260..17349)
+                     /gene="petN"
+                     /locus_tag="BrdiC_p014"
+                     /db_xref="GeneID:6439899"
+     CDS             complement(17260..17349)
+                     /gene="petN"
+                     /locus_tag="BrdiC_p014"
+                     /note="ycf6"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="cytochrome b6/f complex subunit VIII"
+                     /protein_id="YP_002000477.1"
+                     /db_xref="GeneID:6439899"
+                     /translation="MDIVSLAWAALMVVFTFSLSLVVWGRSGL"
+     gene            complement(18284..18354)
+                     /gene="trnC"
+                     /locus_tag="BrdiC_t012"
+                     /db_xref="GeneID:6439836"
+     tRNA            complement(18284..18354)
+                     /gene="trnC"
+                     /locus_tag="BrdiC_t012"
+                     /product="tRNA-Cys"
+                     /codon_recognized="UGC"
+                     /db_xref="GeneID:6439836"
+     gene            19550..22780
+                     /gene="rpoB"
+                     /locus_tag="BrdiC_p015"
+                     /db_xref="GeneID:6439892"
+     CDS             19550..22780
+                     /gene="rpoB"
+                     /locus_tag="BrdiC_p015"
+                     /note="one of four subunits of the minimal PEP RNA
+                     polymerase catalytic core"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="RNA polymerase beta subunit"
+                     /protein_id="YP_002000478.1"
+                     /db_xref="GeneID:6439892"
+                     /translation="MLRNGNEGMSTIPGFSQIQFEGFCRFINQGLAEELEKFLTIKDP
+                     DHEIAFQLFAKGYQLLEPSIKERDAVYESLTYSSELYVSARLIFGFDVQKQTISIGNI
+                     PIMNSLGTFIINGIYRIVINQILLSPGIYYRSELDHKGISIYTGTIISDWGGRSELAI
+                     DKKERIWARVSRKQKISILVLSSAMGSNLREILDNVSYPEIFLSFPNAKEKKRIESKE
+                     KAILEFYQQFACVGGDLVFSESLCEELQKKFFQQKCELGRIGRRNMNRRLNLDIPQNN
+                     TFLLPRDVLAATDQLIGMKFGTGILDDDDMNHLKNKRIRSVADLLQDQFGLALGRLQH
+                     AVQKTIRRVFIRQSKPTPHTLVTPTSTSILLITTYETFFGAYPLSQVFDQTNPLTQTV
+                     HGRKVSCLGPGGLTGRTASFRSRDIHPSHYGRICPIDTSEGINVGLTGSLAIHAKIDH
+                     LWGSVESPFYEISAEKAKEKKERQVVYLSPNRDEYYMIAAGNSLSLNQGIQEEQVVPA
+                     RYRQEFLTIVWEQIHVRSIFPFQYFSIGGSLIPFIEHNDANRALMSSNMQRQAVPLSR
+                     SEKCIVGTGLERQTALDSRVSVIAEREGKIISTDSHRILLSSSGKTISIPLVNHRRSN
+                     KNTCMHQKPRVPRGKSIKKGQILAEGAATVGGELALGKNVLVAYMPWEGYNFEDAVLI
+                     SERLVYEDIYTSFHIRKYEIQTDTTSQGSAEKITKEIPHLEEHLLRNLDRNGVVRLGS
+                     WVETGDILVGKLTPQIASESSYIAEAGLLRAIFGLEVSTSKETSLKLPIGGRGRVIDV
+                     KWIQRDPLDIMVRVYILQKREIKVGDKVAGRHGNKGIISKILTRQDMPYLQDGTPVDV
+                     VFNPLGVPSRMNVGQIFESSLGLAGDLLKKHYRIAPFDERYEQEASRKLVFSELYEAS
+                     KETKNPWVFEPEYPGKSRIFDGRTGDPFEQPVLIGKSYILKLIHQVDEKIHGRSTGPY
+                     SLVTQQPVRGRAKQGGQRVGEMEVWALEGFGVAHILQEILTYKSDHLIARQEILNATI
+                     WGKRIANHEDPPESFRVLVRELRSLALELNHFLVSEKNFQVNREEI"
+     gene            22813..24861
+                     /gene="rpoC1"
+                     /locus_tag="BrdiC_p016"
+                     /db_xref="GeneID:6439871"
+     CDS             22813..24861
+                     /gene="rpoC1"
+                     /locus_tag="BrdiC_p016"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="RNA polymerase beta' subunit"
+                     /protein_id="YP_002000479.1"
+                     /db_xref="GeneID:6439871"
+                     /translation="MIDQYKHQQLQIGLVSPQQIKAWANKNLPNGEVIGQVTRPSTFH
+                     YKTDKPEKDGLFCERIFGPIKSGICACGNSRASGAENEDERFCQKCGVEFADSRIRRY
+                     QMGYIKLACPVTHVWYLKGLPSYIANLLDKPLKKLEGLVYGDFSFARPSTKKPTFLRL
+                     RGLFEEEIASCNHSISPFFSTPSFTTFRNREIATGAGAIREQLADLDLQIIIENSLVE
+                     WKELEDEGYSGDEWEDRKRRIRKVFLIRRMQLAKHFIQTNVEPEWMVLCLLPVLPPEL
+                     RPIVYRSGDKVVTSDINELYKRVIRRNNNLAYLLKRSELAPADLVMCQEKLVQEAVDT
+                     LLDSGSRGQPTRDGHNKVYKSLSDVIEGKEGRFRETLLGKRVDYSGRSVIVVGPSLSL
+                     HQCGLPLEIAIKLFQLFVIRDLITKRATSNVRIAKRKIWEKEPIVWEILQEVMRGHPV
+                     LLNRAPTLHRLGIQAFQPTLVEGRTISLHPLVCKGFNADFDGDQMAVHLPLSLEAQAE
+                     ARLLMFSHMNLLSPAIGDPICVPTQDMLIGLYVLTIGNPRGICANRYNSCGNYPNQKV
+                     NYNNNNSTYTRDKEPIFYSSYDALGAYRQKLISLDSPLWLRWKLDQRAIGSREVPIEV
+                     QYESLGTYHEIYAHYLIVGNRKKEICSIYIRTTLGHISFYREIEEAVQGFSQAYSYTI
+                     "
+     gene            25071..29508
+                     /gene="rpoC2"
+                     /locus_tag="BrdiC_p017"
+                     /db_xref="GeneID:6439877"
+     misc_feature    25071..29508
+                     /gene="rpoC2"
+                     /locus_tag="BrdiC_p017"
+                     /note="similar to RNA polymerase beta' subunit-2"
+     gene            29820..30530
+                     /gene="rps2"
+                     /locus_tag="BrdiC_p018"
+                     /db_xref="GeneID:6439795"
+     CDS             29820..30530
+                     /gene="rps2"
+                     /locus_tag="BrdiC_p018"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="ribosomal protein S2"
+                     /protein_id="YP_002000480.1"
+                     /db_xref="GeneID:6439795"
+                     /translation="MTRRYWNINLKEMIEAGVHFGHGIKKWNPKMAPYISAKRKGTHI
+                     TNLARTARFLSEACDLVFDAASQGKSFLIVGTKKRAADLVASAAIRARCHYVNKKWFS
+                     GMLTNWSITKTRLSQFRDLRAEEKMGKFHHLPKRDVAILKRKLSTLQRYLGGIQYMTR
+                     LPDIVIVLDQQKEYIALRECAILGIPTISLVDTNCDPDLANISIPANDDTMTSIRLIL
+                     NKLVFAICEGRSLYIRNL"
+     gene            30781..31524
+                     /gene="atpI"
+                     /locus_tag="BrdiC_p019"
+                     /db_xref="GeneID:6439835"
+     CDS             30781..31524
+                     /gene="atpI"
+                     /locus_tag="BrdiC_p019"
+                     /note="ATP synthase CF0 A chain"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="ATP synthase CF0 A subunit"
+                     /protein_id="YP_002000481.1"
+                     /db_xref="GeneID:6439835"
+                     /translation="MNIIPCSIKTLKGLYDISGVEVGQHFYWQIGGFQIHAQVLITSW
+                     VVITILLGSVLIAVRNPQTIPTDGQNFFEYILEFIRDLSKTQIGEEYGPWVPFIGTMF
+                     LFIFVSNWSGALLPWKIIELPHGELAAPTNDINTTVALALLTSAAYFYAGLSKKGLSY
+                     FEKYIKPTPILLPINILEDFTKPLSLSFRLFGNILADELVVVVLVSLVPLVVPIPVMF
+                     LGLFTSGIQALIFATLAAAYIGESMEGHH"
+     gene            31911..32156
+                     /gene="atpH"
+                     /locus_tag="BrdiC_p020"
+                     /db_xref="GeneID:6439782"
+     CDS             31911..32156
+                     /gene="atpH"
+                     /locus_tag="BrdiC_p020"
+                     /note="ATP synthase CF0 C chain"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="ATP synthase CF0 C subunit"
+                     /protein_id="YP_002000482.1"
+                     /db_xref="GeneID:6439782"
+                     /translation="MNPLIAAASVIAAGLAVGLASIGPGVGQGTAAGQAVEGIARQPE
+                     AEGKIRGTLLLSLAFMEALTIYGLVVALALLFANPFV"
+     gene            32572..33945
+                     /gene="atpF"
+                     /locus_tag="BrdiC_p021"
+                     /db_xref="GeneID:6439854"
+     CDS             join(32572..32716,33539..33945)
+                     /gene="atpF"
+                     /locus_tag="BrdiC_p021"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="ATP synthase CF0 B subunit"
+                     /protein_id="YP_002000483.1"
+                     /db_xref="GeneID:6439854"
+                     /translation="MKNVTHSFVFLAHWPSAGSFGLNTDILATNLINLTVVVGVLIFF
+                     GKGVLKDLLDNRKQRILSTIRNSEELRRGTFEQLEKARIRLQKVELEADEYRMNGYSE
+                     IEREKENLINATSISLEQLEKSKNETLYFEKQRAMNQVRQRVFQQAVQGALGTLNSCL
+                     NTELHFRTIRANIGILGSMEWKR"
+     exon            32572..32716
+                     /gene="atpF"
+                     /locus_tag="BrdiC_p021"
+                     /number=1
+     exon            33539..33945
+                     /gene="atpF"
+                     /locus_tag="BrdiC_p021"
+                     /number=2
+     gene            34040..>35554
+                     /gene="atpA"
+                     /locus_tag="BrdiC_p022"
+                     /db_xref="GeneID:6439769"
+     CDS             34040..>35554
+                     /gene="atpA"
+                     /locus_tag="BrdiC_p022"
+                     /note="ATPase alpha subunit"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="ATP synthase CF1 alpha subunit"
+                     /protein_id="YP_002000484.1"
+                     /db_xref="GeneID:6439769"
+                     /translation="MATLRVDEIHKILRERIEQYNRKIGIENIGRVVQVGDGIARIIG
+                     LGQIMSGELVEFAEGTRGIALNLESKNVGIVLMGDGLMIQEGSFVKATGRIAQIPVSE
+                     AYLGRVINALAKPIDGRGEIIASESRLIESPAPSIISRRSVYEPLQTGLIAIDSMIPI
+                     GRGQRELIIGDRQTGKTAVATDTILNQKGQDVICVYVAIGQRASSVAQVVTTFHEEGA
+                     MEYTIVVAEMADSPATLQYLAPYTGAALAEYFMYRERHTLIIYDDLSKQAQAYRQMSL
+                     LLRRPPGREAYPGDVFYLHSRLLERAAKLNSLLGEGSMTALPIVETQSGDVSAYIPTN
+                     VISITDGQIFLSADLFNAGIRPAINVGISVSRVGSAAQIKAMKQVAGKSKLELAQFAE
+                     LQAFAQFASALDKTSQNQLARGRRLRELLKQSQANPLPVEEQIATIYTGTRGYLDSLE
+                     IEQVNKFLGELRKNLKDTKPQFKEIISSSKTFTEQAEILLKEAIQEQLERFSLQE"
+     gene            complement(35687..35758)
+                     /gene="trnR"
+                     /locus_tag="BrdiC_t013"
+                     /db_xref="GeneID:6439791"
+     tRNA            complement(35687..35758)
+                     /gene="trnR"
+                     /locus_tag="BrdiC_t013"
+                     /product="tRNA-Arg"
+                     /codon_recognized="AGA"
+                     /db_xref="GeneID:6439791"
+     gene            complement(36106..36417)
+                     /gene="rps14"
+                     /locus_tag="BrdiC_p023"
+                     /db_xref="GeneID:6439772"
+     CDS             complement(36106..36417)
+                     /gene="rps14"
+                     /locus_tag="BrdiC_p023"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="ribosomal protein S14"
+                     /protein_id="YP_002000485.1"
+                     /db_xref="GeneID:6439772"
+                     /translation="MAKKSLIQREKKRQKLEQKYHLIRQSLKKKIRSKVSPLSLSEKT
+                     KMREKLQSLPRNSAPTRLHRRCFLTGRPRANYRDFGLSGHVLREMVYECLLPGATRSS
+                     W"
+     gene            complement(36561..38765)
+                     /gene="psaB"
+                     /locus_tag="BrdiC_p024"
+                     /db_xref="GeneID:6439870"
+     CDS             complement(36561..38765)
+                     /gene="psaB"
+                     /locus_tag="BrdiC_p024"
+                     /note="PsaB"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="photosystem I P700 chlorophyll a apoprotein A2"
+                     /protein_id="YP_002000486.1"
+                     /db_xref="GeneID:6439870"
+                     /translation="MELRFPRFSQGLAQDPTTRRIWFGIATAHDFESHDDITEERLYQ
+                     NIFASHFGQLAIIFLWTSGNLFHVAWQGNFESWIQDPLHVRPIAHAIWDPHFGQPAVE
+                     AFTRGGAAGPVNIAYSGVYQWWYTIGLRTNEDLYTGALFLLFLSTLSLIAGWLHLQPK
+                     WKPSLSWFKNAESRLNHHLSGLFGVSSLAWTGHLIHVAIPASRGEYVRWNNFLDVLPY
+                     PQGLGPLLTGQWNLYAQNPDSSNHLFGTTQGAGTAILTLLGGFHPQTQSLWLTDIAHH
+                     HLAIAFIFLIAGHMYRTNFGIGHSIKDLLEAHTPPGGRLGRGHKGLYDTINNSIHFQL
+                     GLALASLGVITSLVAQHMYSLPAYAFIAQDFTTQAALYTHHQYIAGFIMTGAFAHGAI
+                     FFIRDYNPEQNEDNVLARMLDHKEAIISHLSWASLFLGFHTLGLYVHNDVMLAFGTPE
+                     KQILIEPIFAQWIQSAHGKTTYGFDILLSSTNGPAFNAGRSLWLPGWLNAVNENSNSL
+                     FLTIGPGDFLVHHAIALGLHTTTLILVKGALDARGSKLMPDKKDFGYSFPCDGPGRGG
+                     TCDISAWDAFYLAVFWMLNTIGWVTFYWHWKHITLWQGNVSQFNESSTYLMGWLRDYL
+                     WLNSSQLINGYNPFGMNSLSVWAWMFLFGHLVWATGFMFLISWRGYWQELIETLAWAH
+                     ERTPLANLIRWRDKPVALSIVQARLVGLAHFSVGYIFTYAAFLIASTSGKFG"
+     gene            complement(38791..41043)
+                     /gene="psaA"
+                     /locus_tag="BrdiC_p025"
+                     /db_xref="GeneID:6439778"
+     CDS             complement(38791..41043)
+                     /gene="psaA"
+                     /locus_tag="BrdiC_p025"
+                     /note="PsaA"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="photosystem I P700 chlorophyll a apoprotein A1"
+                     /protein_id="YP_002000487.1"
+                     /db_xref="GeneID:6439778"
+                     /translation="MIIRSPEPEVKIIVDRDPVKTSFEEWARPGHFSKTLAKGPDTTT
+                     WIWNLHADAHDFDSHTGDLEEISRKVFSAHFGQLSIIFLWLSGMYFHGARFSNYEAWL
+                     SDPTHIGPSAQVVWPIVGQEILNGDVGGGFRGIQITSGFFQIWRASGITSELQLYCTA
+                     IGALIFASLMLFAGWFHYHKAAPKLAWFQDVESMLNHHLAGLLGLGSLSWAGHQIHVS
+                     LPINQFLDAGVDPKEIPLPHEFILNRDLLAQLYPSFAEGATPFFTLNWSKYAEFLTFR
+                     GGLDPVTGGLWLTDIAHHHLAIAILFLIAGHMYRTNWGIGHGLKDILEAHKGPFTGQG
+                     HKGLYEILTTSWHAQLALNLAMLGSTTIVVAHHMYSMPPYPYLATDYGTQLSLFTHHM
+                     WIGGFLIVGAAAHAAIFMVRDYDPTTRYNDLLDRVLRHRDAIISHLNWVCIFLGFHSF
+                     GLYIHNDTMSALGRPQDMFSDTAIQLQPIFAQWVQNIHANAPGVTAPGATTSTSLTWG
+                     GGELVAVGGKVALLPIPLGTADFLVHHIHAFTIHVTVLILLKGVLFARSSRLIPDKAN
+                     LGFRFPCDGPGRGGTCQVSAWDHVFLGLFWMYNAISVVIFHFSWKMQSDVWGTISDQG
+                     VVTHITGGNFAQSSITINGWLRDFLWAQASQVIQSYGSSLSAYGLFFLGAHFVWAFSL
+                     MFLFSGRGYWQELIESIVWAHNKLKVAPATQPRALSIIQGRAVGVTHYLLGGIATTWA
+                     FFLARIIAVG"
+     gene            complement(41679..43667)
+                     /gene="ycf3"
+                     /locus_tag="BrdiC_p026"
+                     /db_xref="GeneID:6439779"
+     CDS             complement(join(41679..41837,42564..42793,43544..43667))
+                     /gene="ycf3"
+                     /locus_tag="BrdiC_p026"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="photosystem I assembly protein Ycf3"
+                     /protein_id="YP_002000488.1"
+                     /db_xref="GeneID:6439779"
+                     /translation="MPRSRVNGNFIDKTSSIVANILLRIIPTTSGEKRAFTYYRDGML
+                     AQSEGNYAEALQNYYEATRLEIDPYDRSYILYNIGLIHTSNGEHTKALEYYFRALERN
+                     PFLPQAFNNMAVICHYRGEQAILQGDSEIAEAWFDQAAEYWKQAIALTPGNYIEAQNW
+                     LKITKRFEFE"
+     exon            complement(41679..41837)
+                     /gene="ycf3"
+                     /locus_tag="BrdiC_p026"
+                     /number=3
+     exon            complement(42564..42793)
+                     /gene="ycf3"
+                     /locus_tag="BrdiC_p026"
+                     /number=2
+     exon            complement(43544..43667)
+                     /gene="ycf3"
+                     /locus_tag="BrdiC_p026"
+                     /number=1
+     gene            44258..44344
+                     /gene="trnS"
+                     /locus_tag="BrdiC_t014"
+                     /db_xref="GeneID:6439781"
+     tRNA            44258..44344
+                     /gene="trnS"
+                     /locus_tag="BrdiC_t014"
+                     /product="tRNA-Ser"
+                     /codon_recognized="UCC"
+                     /db_xref="GeneID:6439781"
+     gene            complement(44625..45230)
+                     /gene="rps4"
+                     /locus_tag="BrdiC_p027"
+                     /db_xref="GeneID:6439771"
+     CDS             complement(44625..45230)
+                     /gene="rps4"
+                     /locus_tag="BrdiC_p027"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="ribosomal protein S4"
+                     /protein_id="YP_002000489.1"
+                     /db_xref="GeneID:6439771"
+                     /translation="MSRYRGPRLKKIRRLGALPGLTRKTPKSGSNLKKKFHSGKKEQY
+                     RIRLQEKQKLRFHYGLTERQLLRYVHIAGKAKRSTGQVLLQLLEMRLDNILFRLGMAA
+                     TIPGARQLVNHRHILVNGRIVNIPSFRCKPRDIITTKDNQRSQSLVQNSIASSDPGKL
+                     PKHLTIDTLEYKGLVNKILDRKWVGLKINELLVVEYYSRQT"
+     gene            complement(45534..45606)
+                     /gene="trnT"
+                     /locus_tag="BrdiC_t015"
+                     /db_xref="GeneID:6439872"
+     tRNA            complement(45534..45606)
+                     /gene="trnT"
+                     /locus_tag="BrdiC_t015"
+                     /product="tRNA-Thr"
+                     /codon_recognized="ACA"
+                     /db_xref="GeneID:6439872"
+     gene            46435..47061
+                     /gene="trnL"
+                     /locus_tag="BrdiC_t016"
+                     /db_xref="GeneID:6439893"
+     tRNA            join(46435..46469,47012..47061)
+                     /gene="trnL"
+                     /locus_tag="BrdiC_t016"
+                     /product="tRNA-Leu"
+                     /codon_recognized="UUA"
+                     /db_xref="GeneID:6439893"
+     gene            47418..47490
+                     /gene="trnF"
+                     /locus_tag="BrdiC_t017"
+                     /db_xref="GeneID:6439875"
+     tRNA            47418..47490
+                     /gene="trnF"
+                     /locus_tag="BrdiC_t017"
+                     /product="tRNA-Phe"
+                     /codon_recognized="UUC"
+                     /db_xref="GeneID:6439875"
+     gene            complement(48065..48544)
+                     /gene="ndhJ"
+                     /locus_tag="BrdiC_p028"
+                     /db_xref="GeneID:6439868"
+     CDS             complement(48065..48544)
+                     /gene="ndhJ"
+                     /locus_tag="BrdiC_p028"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="NADH dehydrogenase subunit J"
+                     /protein_id="YP_002000490.1"
+                     /db_xref="GeneID:6439868"
+                     /translation="MQQGWLSNWLVKHKVVHRSLGFDHRGIETLQIKAGDWDSIAVIL
+                     YVYGYNYLRSQCAYDVAPGGSLASVYHLTRIQYGIDNPEEVCIKVFAQKDNPRIPSVF
+                     WIWRSADFQERESYDMVGISYDNHPRLKRILMPESWVGWPLRKDYITPNFYEIQDAH"
+     gene            complement(48650..49387)
+                     /gene="ndhK"
+                     /locus_tag="BrdiC_p029"
+                     /db_xref="GeneID:6439869"
+     CDS             complement(48650..49387)
+                     /gene="ndhK"
+                     /locus_tag="BrdiC_p029"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="NADH dehydrogenase subunit K"
+                     /protein_id="YP_002000491.1"
+                     /db_xref="GeneID:6439869"
+                     /translation="MVLTEYLEKKKEEKDSIETVMSLIEFPLLDQTSSNSVISTTPND
+                     LSNWSRLSSLWPLLYGTSCCFIEFASLIGSRFDFDRYGLVPRSSPRQADLILTAGTVT
+                     MKMAPSLVRLYEQMPEPKYVIAMGACTITGGMFSTDSYSTVRGVDKLIPVDVYLPGCP
+                     PKPEAVIDALTKLRKKISREIVEDRIRSQNKNRCFTTSHKLYVRRSTHTGTYEQELLY
+                     QSPSTLDISSENFYKSKSIVPSYKLVN"
+     gene            complement(49378..49740)
+                     /gene="ndhC"
+                     /locus_tag="BrdiC_p030"
+                     /db_xref="GeneID:6439845"
+     CDS             complement(49378..49740)
+                     /gene="ndhC"
+                     /locus_tag="BrdiC_p030"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="NADH dehydrogenase subunit 3"
+                     /protein_id="YP_002000492.1"
+                     /db_xref="GeneID:6439845"
+                     /translation="MFLLHEYDIFWTFLIIASLIPILAFWISGLLAPISEGPEKLSSY
+                     ESGIEPMGGAWLQFRIRYYMFALVFVVFDVETVFLYPWAMSFDVLGVSVFIEAFIFVL
+                     ILVVGLVYAWRKGALEWS"
+     gene            complement(50556..51227)
+                     /gene="trnV"
+                     /locus_tag="BrdiC_t018"
+                     /db_xref="GeneID:6439846"
+     tRNA            complement(join(50556..50590,51189..51227))
+                     /gene="trnV"
+                     /locus_tag="BrdiC_t018"
+                     /product="tRNA-Val"
+                     /codon_recognized="GUA"
+                     /db_xref="GeneID:6439846"
+     gene            51415..51487
+                     /gene="trnM"
+                     /locus_tag="BrdiC_t019"
+                     /db_xref="GeneID:6439876"
+     tRNA            51415..51487
+                     /gene="trnM"
+                     /locus_tag="BrdiC_t019"
+                     /product="tRNA-Met"
+                     /codon_recognized="AUG"
+                     /db_xref="GeneID:6439876"
+     gene            complement(51602..52015)
+                     /gene="atpE"
+                     /locus_tag="BrdiC_p031"
+                     /db_xref="GeneID:6439847"
+     CDS             complement(51602..52015)
+                     /gene="atpE"
+                     /locus_tag="BrdiC_p031"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="ATP synthase CF1 epsilon subunit"
+                     /protein_id="YP_002000493.1"
+                     /db_xref="GeneID:6439847"
+                     /translation="MKLNLYVLTPKRIIWDCEVKEIILSTNSGQIGVLPNHAPINTAV
+                     DMGPLRIRLLNDQWLTAVLWSGFARIVNNEIIILGNDAELGSDIDPEEAQQALKIAED
+                     NLSKAEGTKELVEAKLALRRARIRIEAVNWIPPSN"
+     gene            complement(52012..53508)
+                     /gene="atpB"
+                     /locus_tag="BrdiC_p032"
+                     /db_xref="GeneID:6439896"
+     CDS             complement(52012..53508)
+                     /gene="atpB"
+                     /locus_tag="BrdiC_p032"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="ATP synthase CF1 beta subunit"
+                     /protein_id="YP_002000494.1"
+                     /db_xref="GeneID:6439896"
+                     /translation="MRTNPTTSRPGVSPIEEKSTGRIDQIIGPVLDVTFPPGKLPYIY
+                     NALVVQSRDTADKQINVTCEVQQLLGNNRVRAVAMSATDGLMRGMEVIDTGAPLSVPV
+                     GGATLGRIFNVLGEPVDNLGPVDSSATFPIHRSAPAFIELDTKLSIFETGIKVVDLLA
+                     PYRRGGKIGLFGGAGVGKTVLIMELINNIAKAHGGVSVFGGVGERTREGNDLYMEMRE
+                     SGVINEKNIEESKVALVYGQMNEPPGARMRVGLTALTMAEYFRDVNKQDVLLFIDNIF
+                     RFVQAGSEVSALLGRMPSAVGYQPTLSTEMGSLQERIASTKKGSITSIQAVYVPADDL
+                     TDPAPATTFAHLDATTVLSRGLASKGIYPAVDPLDSTSTMLQPRIVGNEHYETAQRVK
+                     ETLQRYKELQDIIAILGLDELSEEDRLTVARARKIERFLSQPFFVAEVFTGSAGKYVG
+                     LAETIRGFQLILSGELDGLPEQAFYLVGNIDEASTKAITLEEENKSKK"
+     gene            54293..55723
+                     /gene="rbcL"
+                     /locus_tag="BrdiC_p033"
+                     /db_xref="GeneID:6439897"
+     CDS             54293..55723
+                     /gene="rbcL"
+                     /locus_tag="BrdiC_p033"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="ribulose-1,5-bisphosphate carboxylase/oxygenase
+                     large subunit"
+                     /protein_id="YP_002000495.1"
+                     /db_xref="GeneID:6439897"
+                     /translation="MSPQTETKASVGFKAGVKDYRLTYYTPEYETKDTDILAAFRVSP
+                     QPGVPPEEAGAAVAAESSTGTWTTVWTDGLTSLDRYKGRCYHIEPVPGEDSQWICYVA
+                     YPLDLFEEGSVTNMFTSIVGNVFGFKALRALRLEDLRIPPTYSKTFQGPPHGIQVERD
+                     KLNKYGRPLLGCTIKPKLGLSAKNYGRACYECLRGGLDFTKDDENVNSQPFMRWRDRF
+                     VFCAEAIYKSQAETGEIKGHYLNATAGTCEEMMKRAVFARELGVPIVMHDYLTGGFTA
+                     NTTLAHYCRDNGLLLHIHRAMHAVIDRQKNHGMHFRVLAKALRMSGGDHIHAGTVVGK
+                     LEGEREITLGFVDLLRDDFIEKDRARGIFFTQDWVSMPGVIPVASGGIHVWHMPALTE
+                     IFGDDSVLQFGGGTLGHPWGNAPGAAANRVALEACVQARNEGRDLAREGNEIIRAACK
+                     WSPELAAACEVWKAIKFEFAPVDTID"
+     gene            56185..56295
+                     /gene="psaI"
+                     /locus_tag="BrdiC_p034"
+                     /db_xref="GeneID:6439898"
+     CDS             56185..56295
+                     /gene="psaI"
+                     /locus_tag="BrdiC_p034"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="photosystem I subunit VIII"
+                     /protein_id="YP_002000496.1"
+                     /db_xref="GeneID:6439898"
+                     /translation="MTDLNLPSIFVPLVGLVFPAIAMASLFLYVQKNKIV"
+     gene            56615..57172
+                     /gene="ycf4"
+                     /locus_tag="BrdiC_p035"
+                     /db_xref="GeneID:6439787"
+     CDS             56615..57172
+                     /gene="ycf4"
+                     /locus_tag="BrdiC_p035"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="photosystem I assembly protein Ycf4"
+                     /protein_id="YP_002000497.1"
+                     /db_xref="GeneID:6439787"
+                     /translation="MNWRSEHIWVELLKGSRKRGNFFWASILFLGSLGFLSVGVSSYL
+                     GKNMISILPSQQILFFPQGVVMSFYGIAGLFISSYLWCAILWNVGSGYDRFDRKEGIV
+                     CIFRWGFPGIKRRVFLRFLMRDIQSIRIQVKEGFYPRRILYMEIRGQGVIPLTRTDDK
+                     FFTPREIEQKAAELAYFLRVPIEVF"
+     gene            57598..58290
+                     /gene="cemA"
+                     /locus_tag="BrdiC_p036"
+                     /db_xref="GeneID:6439788"
+     CDS             57598..58290
+                     /gene="cemA"
+                     /locus_tag="BrdiC_p036"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="envelope membrane protein"
+                     /protein_id="YP_002000498.1"
+                     /db_xref="GeneID:6439788"
+                     /translation="MKKKKALPSLLYLVFIVLLPWGASFSVNKCLELWIKNWWNTRQS
+                     ETLLTDIQEKRILERFIELEELSLLDEMIKEKPKTHVQKPPIGIHKEIIQWVKIDNED
+                     HLHIILHFSTNIICLAILSSSFFFGKEELVIWNSWVQEFFHNLNDSIKAFFILLVTDF
+                     FVGFHSTRGWELVIRWVYNDLGWAPNELIFTIFVCSFPVILDTCLKFWVFFCLNRLSP
+                     SLVVIYHSISEA"
+     gene            58515..59477
+                     /gene="petA"
+                     /locus_tag="BrdiC_p037"
+                     /db_xref="GeneID:6439865"
+     CDS             58515..59477
+                     /gene="petA"
+                     /locus_tag="BrdiC_p037"
+                     /note="component of cytochrome b6/f complex"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="cytochrome f"
+                     /protein_id="YP_002000499.1"
+                     /db_xref="GeneID:6439865"
+                     /translation="MENRNTFSWVKEQMTRSISVSIMIYVITRTSISNAYPIFAQQGY
+                     ENPREATGRIVCANCHLASKPVDIEVPQAVLPDTVFEAVLRIPYDMQLKQVLANGKKG
+                     GLNVGAVLILPEGFELAPPDRISPELKEKIGNLSFQSYRPDKKNILVIGPVPGKKYSE
+                     IVFPILSPDPATKKDAHFLKYPIYVGGNRGRGQIYPDGSKSNNTVYNATSTGIVKKIL
+                     RKEKGGYEISIVDASDGRQLIDIIPPGPELLVSEGESIKLDQPLTSNPNVGGFGQGDA
+                     EIVLQDPLRVQGLLFFFASVILAQVFLVLKKKQFEKVQLYEMNF"
+     gene            complement(60312..60434)
+                     /gene="psbJ"
+                     /locus_tag="BrdiC_p038"
+                     /db_xref="GeneID:6439866"
+     CDS             complement(60312..60434)
+                     /gene="psbJ"
+                     /locus_tag="BrdiC_p038"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="photosystem II protein J"
+                     /protein_id="YP_002000500.1"
+                     /db_xref="GeneID:6439866"
+                     /translation="MADTTGRIPLWLIGTVTGIPVIGLVGVFFYGSYSGLGSSL"
+     gene            complement(60565..60681)
+                     /gene="psbL"
+                     /locus_tag="BrdiC_p039"
+                     /db_xref="GeneID:6439867"
+     CDS             complement(60565..60681)
+                     /gene="psbL"
+                     /locus_tag="BrdiC_p039"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="photosystem II protein L"
+                     /protein_id="YP_002000501.1"
+                     /db_xref="GeneID:6439867"
+                     /translation="MTQSNPNEQNVELNRTSLYWGLLLIFVLAVLFSNYFFN"
+     gene            complement(60704..60823)
+                     /gene="psbF"
+                     /locus_tag="BrdiC_p040"
+                     /db_xref="GeneID:6439878"
+     CDS             complement(60704..60823)
+                     /gene="psbF"
+                     /locus_tag="BrdiC_p040"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="photosystem II protein VI"
+                     /protein_id="YP_002000502.1"
+                     /db_xref="GeneID:6439878"
+                     /translation="MTIDRTYPIFTVRWLAIHGLAVPTVFFLGSISAMQFIQR"
+     gene            complement(60834..61085)
+                     /gene="psbE"
+                     /locus_tag="BrdiC_p041"
+                     /db_xref="GeneID:6439879"
+     CDS             complement(60834..61085)
+                     /gene="psbE"
+                     /locus_tag="BrdiC_p041"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="photosystem II protein V"
+                     /protein_id="YP_002000503.1"
+                     /db_xref="GeneID:6439879"
+                     /translation="MSGSTGERSFADIITSIRYWVIHSITIPSLFIAGWLFVSTGLAY
+                     DVFGSPRPNEYFTESRQGIPLITDRFDSLEQLDEFSRSF"
+     gene            62362..62457
+                     /gene="petL"
+                     /locus_tag="BrdiC_p042"
+                     /db_xref="GeneID:6439886"
+     CDS             62362..62457
+                     /gene="petL"
+                     /locus_tag="BrdiC_p042"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="cytochrome b6/f complex subunit VI"
+                     /protein_id="YP_002000504.1"
+                     /db_xref="GeneID:6439886"
+                     /translation="MLTITSYFGFLLAALTITPALFIGLNKIRLI"
+     gene            62631..62744
+                     /gene="petG"
+                     /locus_tag="BrdiC_p043"
+                     /db_xref="GeneID:6439887"
+     CDS             62631..62744
+                     /gene="petG"
+                     /locus_tag="BrdiC_p043"
+                     /note="required for the either the stability or assembly
+                     of the cytochrome b6/f complex"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="cytochrome b6/f complex subunit V"
+                     /protein_id="YP_002000505.1"
+                     /db_xref="GeneID:6439887"
+                     /translation="MIEVFLFGIVLGLIPITLAGLFVTAYLQYRRGDQLDL"
+     gene            complement(62866..62939)
+                     /gene="trnW"
+                     /locus_tag="BrdiC_t020"
+                     /db_xref="GeneID:6439888"
+     tRNA            complement(62866..62939)
+                     /gene="trnW"
+                     /locus_tag="BrdiC_t020"
+                     /product="tRNA-Trp"
+                     /codon_recognized="UGG"
+                     /db_xref="GeneID:6439888"
+     gene            complement(63079..63153)
+                     /gene="trnP"
+                     /locus_tag="BrdiC_t021"
+                     /db_xref="GeneID:6439848"
+     tRNA            complement(63079..63153)
+                     /gene="trnP"
+                     /locus_tag="BrdiC_t021"
+                     /product="tRNA-Pro"
+                     /codon_recognized="CCA"
+                     /db_xref="GeneID:6439848"
+     gene            63491..63776
+                     /gene="psaJ"
+                     /locus_tag="BrdiC_p044"
+                     /db_xref="GeneID:6439883"
+     misc_feature    63491..63776
+                     /gene="psaJ"
+                     /locus_tag="BrdiC_p044"
+                     /note="similar to PSI small peptide"
+     gene            64061..64261
+                     /gene="rpl33"
+                     /locus_tag="BrdiC_p045"
+                     /db_xref="GeneID:6439774"
+     CDS             64061..64261
+                     /gene="rpl33"
+                     /locus_tag="BrdiC_p045"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="ribosomal protein L33"
+                     /protein_id="YP_002000506.1"
+                     /db_xref="GeneID:6439774"
+                     /translation="MAKGKDVRIRVILECISCVRKGANEESTGISRYSTEKNRHNTPG
+                     QLEFKKFCRYCRKHTTHHEIKK"
+     gene            64593..65084
+                     /gene="rps18"
+                     /locus_tag="BrdiC_p046"
+                     /db_xref="GeneID:6439775"
+     CDS             64593..65084
+                     /gene="rps18"
+                     /locus_tag="BrdiC_p046"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="ribosomal protein S18"
+                     /protein_id="YP_002000507.1"
+                     /db_xref="GeneID:6439775"
+                     /translation="MYTSKQPFLKSKQPFRKSKQTFNKSKQPFRKSKQTFRKSKQPFR
+                     RRPRIGPGDRIDYRNMSLINRFISEQGKILSRRINRLTLKQQRLITLAIKQARILSFL
+                     PFRNYENEKQFQAQSISIITGSRPRKNRHIPQLTQKYSSNRNVRNYNQNLRNNNRNLS
+                     SDC"
+     gene            complement(65241..65600)
+                     /gene="rpl20"
+                     /locus_tag="BrdiC_p047"
+                     /db_xref="GeneID:6439776"
+     CDS             complement(65241..65600)
+                     /gene="rpl20"
+                     /locus_tag="BrdiC_p047"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="ribosomal protein L20"
+                     /protein_id="YP_002000508.1"
+                     /db_xref="GeneID:6439776"
+                     /translation="MTRVPRGYIARRRRTKMRSFASNFRGAHLRLNRMITQQVKRAFV
+                     SSHRDRGRQKRDFRRLWITRINAATRIFKVFDSYSKLIHNLYKKKLILNRKMLAQVAV
+                     SNPNNLYTISKKIKIIN"
+     gene            join(complement(66293..66406),125558..126358)
+                     /gene="rps12"
+                     /locus_tag="BrdiC_p048"
+                     /trans_splicing
+                     /db_xref="GeneID:6439783"
+     CDS             join(complement(66293..66406),125558..125789,
+                     126330..126358)
+                     /gene="rps12"
+                     /locus_tag="BrdiC_p048"
+                     /trans_splicing
+                     /codon_start=1
+                     /transl_table=11
+                     /product="ribosomal protein S12"
+                     /protein_id="YP_002000509.1"
+                     /db_xref="GeneID:6439783"
+                     /translation="MPTVKQLIRNARQPIRTARKTAALKGCPQRRGTCARVYTINPKK
+                     PNSALRKVARVRLTSGFEITAYIPGIGHNLQEHSVVLVRGGRVKDLPGVRYRIIRGTL
+                     DAVAVKNRQQGRSKYGVKKPKK"
+     exon            complement(66293..66406)
+                     /gene="rps12"
+                     /locus_tag="BrdiC_p049"
+                     /number=1
+     gene            complement(66548..67198)
+                     /gene="clpP"
+                     /locus_tag="BrdiC_p050"
+                     /db_xref="GeneID:6439882"
+     CDS             complement(66548..67198)
+                     /gene="clpP"
+                     /locus_tag="BrdiC_p050"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="ATP-dependent Clp protease proteolytic subunit"
+                     /protein_id="YP_002000510.1"
+                     /db_xref="GeneID:6439882"
+                     /translation="MPIGVPKVPYQIPGDEEATWVDLYNVMYRERTLFLGQEIRCEIT
+                     NHITGLMVYLSIEDGISDIFLFINSPGGWLISGMAIFDTMQTVTPDIYTICLGIAASM
+                     ASFILLGGEPTKRIAFPHARIMLHQPASAYYRARTPEFLLEVEELHKVREMITRVYAL
+                     RTGKPFWVVSEDMERDVFMSADEAKAYGLVDIVGDEMIHEHCDTDPVWFPEMFKDW"
+     gene            67711..69237
+                     /gene="psbB"
+                     /locus_tag="BrdiC_p051"
+                     /db_xref="GeneID:6439814"
+     CDS             67711..69237
+                     /gene="psbB"
+                     /locus_tag="BrdiC_p051"
+                     /note="PSII 47 kDa protein"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="photosystem II 47 kDa protein"
+                     /protein_id="YP_002000511.1"
+                     /db_xref="GeneID:6439814"
+                     /translation="MGLPWYRVHTVVLNDPGRLLAVHIMHTALVSGWAGSMALYELAV
+                     FDPSDPVLDPMWRQGMFVIPFMTRLGITDSWGGWSISGGTVTNPGIWSYEGVAGTHIV
+                     FSGLCFLAAIWHWVYWDLAIFSDDRTGKPSLDLPKIFGIHLFLAGVACFGFGAFHVTG
+                     LYGPGIWVSDPYGLTGKVQAVNPAWGAEGFDPFVPGGIASHHIAAGTLGILAGLFHLS
+                     VRPPQRLYKGLRMGNIETVLSSSIAAVFFAAFVVAGTMWYGSATTPIELFGPTRYQWD
+                     QGYFQQEIYRRVSNGLSENLSLSEAWSKIPEKLAFYDYIGNNPAKGGLFRAGSMDNGD
+                     GIAVGWLGHPVFRDKEGRELFVRRMPTFFETFPVVLVDEEGIVRADVPFRRAESKYSV
+                     EQVGVTVEFYGGELNGVSYSDPATVKKYARRSQLGEIFELDRATLKSDGVFRSSPRGW
+                     FTFGHATFALLFFFGHIWHGARTLFRDVFAGIDPDLDAQVEFGTFQKVGDPTTRKQAV
+                     "
+     gene            69424..69531
+                     /gene="psbT"
+                     /locus_tag="BrdiC_p052"
+                     /db_xref="GeneID:6439859"
+     CDS             69424..69531
+                     /gene="psbT"
+                     /locus_tag="BrdiC_p052"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="photosystem II protein T"
+                     /protein_id="YP_002000512.1"
+                     /db_xref="GeneID:6439859"
+                     /translation="MEALVYTFLLVSTLGIIFFAIFFREPPKVPTKRVK"
+     gene            complement(69580..69711)
+                     /gene="psbN"
+                     /locus_tag="BrdiC_p053"
+                     /db_xref="GeneID:6439860"
+     CDS             complement(69580..69711)
+                     /gene="psbN"
+                     /locus_tag="BrdiC_p053"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="photosystem II protein N"
+                     /protein_id="YP_002000513.1"
+                     /db_xref="GeneID:6439860"
+                     /translation="METATLVAISISGLLVSFTGYALYTAFGQPSQQLRDPFEEHGD"
+     gene            69815..70036
+                     /gene="psbH"
+                     /locus_tag="BrdiC_p054"
+                     /db_xref="GeneID:6439861"
+     CDS             69815..70036
+                     /gene="psbH"
+                     /locus_tag="BrdiC_p054"
+                     /note="photosystem II phosphoprotein"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="photosystem II protein H"
+                     /protein_id="YP_002000514.1"
+                     /db_xref="GeneID:6439861"
+                     /translation="MATQTVEDSSKPKPRRTGAGSLLKPLNSEYGKVAPGWGTTPFMG
+                     VAMALFAIFLSIILEIYNSSVLLDGILTY"
+     gene            70923..71621
+                     /gene="petB"
+                     /locus_tag="BrdiC_p055"
+                     /db_xref="GeneID:6439849"
+     CDS             70923..71621
+                     /gene="petB"
+                     /locus_tag="BrdiC_p055"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="cytochrome b6"
+                     /protein_id="YP_002000515.1"
+                     /db_xref="GeneID:6439849"
+                     /translation="MKFSYTVLRGGLRLVTYLNKVYDWFEERLEIQAIADDITSKYVP
+                     PHVNIFYCLGGITLTCFLVQVATGFAMTFYYRPTVTEAFSSVQYIMTEANFGWLIRSV
+                     HRWSASMMVLMMILHVFRVYLTGGFKKPRELTWVTGVVLAVLTASFGVTGYSLPWDQI
+                     GYWAVKIVTGVPDAIPVIGSPLVELLRGSASVGQSTLTRFYSLHTFVLPLLTAVFMLM
+                     HFPMIRKQGISGPL"
+     gene            71809..73048
+                     /gene="petD"
+                     /locus_tag="BrdiC_p056"
+                     /db_xref="GeneID:6439850"
+     CDS             join(71809..71816,72574..73048)
+                     /gene="petD"
+                     /locus_tag="BrdiC_p056"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="cytochrome b6/f complex subunit IV"
+                     /protein_id="YP_002000516.1"
+                     /db_xref="GeneID:6439850"
+                     /translation="MGVTKKPDLNDPVLRAKLAKGMGHNYYGEPAWPNDLLYIFPVVI
+                     LGTIACNVGLAVLEPSMIGEPADPFATPLEILPEWYFFPVFQILRTVPNKLLGVLLMV
+                     SVPTGLLTVPFLENVNKFQNPFRRPVATTVFLIGTAVALWLGIGATLPIDKSLTLGLF
+                     "
+     exon            71809..71816
+                     /gene="petD"
+                     /locus_tag="BrdiC_p056"
+                     /number=1
+     exon            72574..73048
+                     /gene="petD"
+                     /locus_tag="BrdiC_p056"
+                     /number=2
+     gene            complement(<73264..74277)
+                     /gene="rpoA"
+                     /locus_tag="BrdiC_p057"
+                     /db_xref="GeneID:6439777"
+     CDS             complement(<73264..74277)
+                     /gene="rpoA"
+                     /locus_tag="BrdiC_p057"
+                     /note="stop codon not determined"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="RNA polymerase alpha subunit"
+                     /protein_id="YP_002000517.1"
+                     /db_xref="GeneID:6439777"
+                     /translation="MVREEVAGSTQTLQWKCVESRVDSKRLYYGRFILSPLIKGQADT
+                     VGIALRRALLGEIEGTCITRAKFGSVPHEYSTIAGIEESVQEILVNLKEIVLRSNLYG
+                     VRDASICVKGPRCITAQDIILPPSVEVVDTAQPIANLTEPIDFCIQLQIKRDRGYQTE
+                     LRKNYQDGSYPIDAVSMPVRNVNYSIFSCGNGNEKHEILFLEIWTNGSLTPKEALYEA
+                     SRNLIDLFLPFLHAEEEGTGFEENKNRFTPPLFTFQKRLTNRKKNKKGIPLNFIFIDQ
+                     LELPSRTYNYLKRANIHTLLDLLSKTEEDLMRIDSFRMEDGKQIWDTLEKHLPVDLLK
+                     NKLS"
+     gene            complement(74342..74773)
+                     /gene="rps11"
+                     /locus_tag="BrdiC_p058"
+                     /db_xref="GeneID:6439841"
+     CDS             complement(74342..74773)
+                     /gene="rps11"
+                     /locus_tag="BrdiC_p058"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="ribosomal protein S11"
+                     /protein_id="YP_002000518.1"
+                     /db_xref="GeneID:6439841"
+                     /translation="MAKAVPKIGSRKRVRIGLRRNARFSLRKSARRITKGVIHVQASF
+                     NNTIITVTDPQGRVVFWSSAGTCGFKSSRKASPYAGQRTAVDAIRTVGLQRAEVMVKG
+                     AGSGRDAALRAIAKSGVRLSCIRDVTPMPHNGCRPPKKRRL"
+     gene            complement(74961..75074)
+                     /gene="rpl36"
+                     /locus_tag="BrdiC_p059"
+                     /db_xref="GeneID:6439842"
+     CDS             complement(74961..75074)
+                     /gene="rpl36"
+                     /locus_tag="BrdiC_p059"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="ribosomal protein L36"
+                     /protein_id="YP_002000519.1"
+                     /db_xref="GeneID:6439842"
+                     /translation="MKIRASVRKICTKCRLIRRRGRIRVICSNPKHKQRQG"
+     gene            complement(75181..75504)
+                     /gene="infA"
+                     /locus_tag="BrdiC_p060"
+                     /db_xref="GeneID:6439856"
+     CDS             complement(75181..75504)
+                     /gene="infA"
+                     /locus_tag="BrdiC_p060"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="translation initiation factor 1"
+                     /protein_id="YP_002000520.1"
+                     /db_xref="GeneID:6439856"
+                     /translation="MTEKKNRREKKNPREAKVTFEGLVTEALPNGMFRVRLENDTIIL
+                     GYISGKIRSSSIRILMGDRVKIEVSRYDSSKGRIIYRLPHKDSKRIEDSKDSEDLKDS
+                     EDLKD"
+     gene            complement(75585..75995)
+                     /gene="rps8"
+                     /locus_tag="BrdiC_p061"
+                     /db_xref="GeneID:6439857"
+     CDS             complement(75585..75995)
+                     /gene="rps8"
+                     /locus_tag="BrdiC_p061"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="ribosomal protein S8"
+                     /protein_id="YP_002000521.1"
+                     /db_xref="GeneID:6439857"
+                     /translation="MGKDTIADLLTSIRNADMNKKATVRVVSTNITENIVKILLREGF
+                     IESVRKHQERNRYFLVLTLRHQKRKTRKGIYRTRTFLKRISRPGLRIYTNYQGIPKVL
+                     GGMGIAILSTSRGIMTDREARLNRIGGEVLCYIW"
+     gene            complement(76137..76508)
+                     /gene="rpl14"
+                     /locus_tag="BrdiC_p062"
+                     /db_xref="GeneID:6439838"
+     CDS             complement(76137..76508)
+                     /gene="rpl14"
+                     /locus_tag="BrdiC_p062"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="ribosomal protein L14"
+                     /protein_id="YP_002000522.1"
+                     /db_xref="GeneID:6439838"
+                     /translation="MIQPQTLLNVADNSGARKLMCIRVIGTAGNQRYARIGDVIVAVI
+                     KDAVPQMPLERSEVIRAVIVRTCKEFKCEDGIIIRYDDNAAVIIDQKGNPKGTRVFGA
+                     ITEELRELNFTKIVSLAPEVL"
+     gene            complement(76595..78054)
+                     /gene="rpl16"
+                     /locus_tag="BrdiC_p063"
+                     /db_xref="GeneID:6439839"
+     CDS             complement(join(76595..76996,78046..78054))
+                     /gene="rpl16"
+                     /locus_tag="BrdiC_p063"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="ribosomal protein L16"
+                     /protein_id="YP_002000523.1"
+                     /db_xref="GeneID:6439839"
+                     /translation="MLSPKRTKFRKQHRGRMKGKSCRGNRICFGRYALQALEPTWITA
+                     RQIEAGRRAITRYARRGGKIWVRIFPDKPVTLRPTETRMGSGKGSPEYWVAVVKPGRI
+                     LYEMGGVSETVARAAISIAASKMPIRSQFIRLEI"
+     exon            complement(76595..76996)
+                     /gene="rpl16"
+                     /locus_tag="BrdiC_p063"
+                     /number=2
+     exon            complement(78046..78054)
+                     /gene="rpl16"
+                     /locus_tag="BrdiC_p063"
+                     /number=1
+     gene            complement(78198..78917)
+                     /gene="rps3"
+                     /locus_tag="BrdiC_p064"
+                     /db_xref="GeneID:6439840"
+     CDS             complement(78198..78917)
+                     /gene="rps3"
+                     /locus_tag="BrdiC_p064"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="ribosomal protein S3"
+                     /protein_id="YP_002000524.1"
+                     /db_xref="GeneID:6439840"
+                     /translation="MGQKINPLGFRLGTTQKHHSFWFAQPKNYSEGLQEDKKIRNCIK
+                     NYIQKNRKKGSNRKIESDSSSEVITHNRKMDSGSSSEVITHIEIQKEIDTIHVIIHIG
+                     FPNLLKKKGVIEELEKDLQKEINSVNQRLNISIEKVKEPYRQPNILAEYIAFQLKNRV
+                     SFRKAIKKAIELTKKADIRGVKVKIAGRLGGKEIARAECIKKGRLPLQTIRAKIDYCC
+                     YPIRTIYGVLGVKIWIFVDEE"
+     gene            complement(78974..79423)
+                     /gene="rpl22"
+                     /locus_tag="BrdiC_p065"
+                     /db_xref="GeneID:6439880"
+     CDS             complement(78974..79423)
+                     /gene="rpl22"
+                     /locus_tag="BrdiC_p065"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="ribosomal protein L22"
+                     /protein_id="YP_002000525.1"
+                     /db_xref="GeneID:6439880"
+                     /translation="MTSFKLVKYIPRIKKKKSGLRKLARKVPTDRLLKFERVFKAQKR
+                     IHMSVFKAQRVLDEIRWRYYEETVMILNLMPYRASYPILKLVYSAAANAAHYRDFDKA
+                     NLFITKAEVSRSTIMKKFRPRARGRSFPIKKSMCHITIALNIVKRSK"
+     misc_feature    79452
+                     /note="junction LSC-IR; JLB"
+     gene            complement(79497..79778)
+                     /gene="rps19"
+                     /locus_tag="BrdiC_p066"
+                     /db_xref="GeneID:6439881"
+     CDS             complement(79497..79778)
+                     /gene="rps19"
+                     /locus_tag="BrdiC_p066"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="ribosomal protein S19"
+                     /protein_id="YP_002000526.1"
+                     /db_xref="GeneID:6439881"
+                     /translation="MTRKKTNPFVAHHLLAKIEKVNMKEEKETIVTWSRASSILPTMV
+                     GHTIAIHNGKEHIPIYITNPMVGRKLGEFVPTRHFTSYENARKDTKSRR"
+     gene            79912..79986
+                     /gene="trnH"
+                     /locus_tag="BrdiC_t022"
+                     /db_xref="GeneID:6439819"
+     tRNA            79912..79986
+                     /gene="trnH"
+                     /locus_tag="BrdiC_t022"
+                     /product="tRNA-His"
+                     /codon_recognized="CAC"
+                     /db_xref="GeneID:6439819"
+     gene            complement(80042..81525)
+                     /gene="rpl2"
+                     /locus_tag="BrdiC_p067"
+                     /db_xref="GeneID:6439900"
+     CDS             complement(join(80042..80472,81135..81525))
+                     /gene="rpl2"
+                     /locus_tag="BrdiC_p067"
+                     /exception="RNA editing"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="ribosomal protein L2"
+                     /protein_id="YP_002000527.1"
+                     /db_xref="GeneID:6439900"
+                     /translation="MAKHLYKTPISSTRKGTVDRQVKSNPRNNLIHGRHRCGKGRNSR
+                     GIITARHRGGGHKRLYRKIDFRRNQKDISGRIVTIEYDPNRNAYICLIHYGDGEKRYI
+                     LHPRGAIIGDTIVSGTKVPISMGNALPLTDMPLGTAMHNIEITRGRGGQLARAAGAVA
+                     KLIAKEGKSATLRLPSGEVRLVSQNCLATVGQVGNVGVNQKSLGRAGSKCWLGKRPIV
+                     RGVVMNPVDHPHGGGEGKAPIGRKKPTTPWGYPALGRRTRKRKKYSDSFILRRRK"
+     exon            complement(80042..80472)
+                     /gene="rpl2"
+                     /locus_tag="BrdiC_p067"
+     exon            complement(81135..81525)
+                     /gene="rpl2"
+                     /locus_tag="BrdiC_p067"
+     gene            complement(81544..81825)
+                     /gene="rpl23"
+                     /locus_tag="BrdiC_p068"
+                     /db_xref="GeneID:6439885"
+     CDS             complement(81544..81825)
+                     /gene="rpl23"
+                     /locus_tag="BrdiC_p068"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="ribosomal protein L23"
+                     /protein_id="YP_002000528.1"
+                     /db_xref="GeneID:6439885"
+                     /translation="MDGIKYAVFTEKSLRLLGKNQYTFNVESGFTKTEIKHWVELFFG
+                     VKVVAVNSHRLPGKGRRIGPILGHTMHYRRMIITLQPGYSIPLLDREKN"
+     gene            complement(82000..82073)
+                     /gene="trnI"
+                     /locus_tag="BrdiC_t023"
+                     /db_xref="GeneID:6439827"
+     tRNA            complement(82000..82073)
+                     /gene="trnI"
+                     /locus_tag="BrdiC_t023"
+                     /product="tRNA-Ile"
+                     /db_xref="GeneID:6439827"
+     gene            complement(84570..84650)
+                     /gene="trnL"
+                     /locus_tag="BrdiC_t024"
+                     /db_xref="GeneID:6439821"
+     tRNA            complement(84570..84650)
+                     /gene="trnL"
+                     /locus_tag="BrdiC_t024"
+                     /product="tRNA-Leu"
+                     /codon_recognized="UUG"
+                     /db_xref="GeneID:6439821"
+     gene            complement(85223..87471)
+                     /gene="ndhB"
+                     /locus_tag="BrdiC_p069"
+                     /db_xref="GeneID:6439822"
+     CDS             complement(join(85223..85978,86695..87471))
+                     /gene="ndhB"
+                     /locus_tag="BrdiC_p069"
+                     /note="RNA edited conceptual translation not provided"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="NADH dehydrogenase subunit 2"
+                     /protein_id="YP_002000529.1"
+                     /db_xref="GeneID:6439822"
+                     /translation="MIWHVQNENFILDSTRIFMKALHLLLFHGSFIFPECILIFGLIL
+                     LLMIDSTSDQKDRPWFYFISSTSLVISITALLFRWREEPIISFSGNFQTNNFNEIFQF
+                     LILLCSTLCIPLSVEYIECTEMAITEFLLFVLTATLGGMFLCGANDLITIFVASECFS
+                     LCSYLLSGYTKRDLRSNEATMKYLLMGGASSSILVHGFSWLYGSSGGEIELQEIVNGL
+                     INTQMYNSPGISIALISITVGLGFKLSPAPFHQWTPDVYEGSPTPVVAFLSVTSKVAA
+                     SASATRILDIPFYFSSNEWHLLLEILAILSMILGNLLAITQTSMKRMLAYSSIGQIGY
+                     VIIGIIVGDSNDGYASMITYMLFYISMNLGTFACIVLFGLRTGTDNIRDYAGLYTKDP
+                     FLALSLALCLLSLGGLPPLAGFFGKLYLFWCGWQAGLYFLVSIGLLTSVLSIYYYLKI
+                     IKLLMTGRNQEITPYVRNYRRSPLRSNNSIELSMTVCVIASTIPGISMNPILAIAQDT
+                     LF"
+     exon            complement(85223..85978)
+                     /gene="ndhB"
+                     /locus_tag="BrdiC_p069"
+                     /number=1
+     exon            complement(86695..87471)
+                     /gene="ndhB"
+                     /locus_tag="BrdiC_p069"
+                     /number=2
+     misc_feature    86852
+                     /note="C to U editing"
+     gene            complement(87766..88236)
+                     /gene="rps7"
+                     /locus_tag="BrdiC_p070"
+                     /db_xref="GeneID:6439826"
+     CDS             complement(87766..88236)
+                     /gene="rps7"
+                     /locus_tag="BrdiC_p070"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="ribosomal protein S7"
+                     /protein_id="YP_002000530.1"
+                     /db_xref="GeneID:6439826"
+                     /translation="MSRRGTAEKRTAKSDPIFRNRLVNMVVNRIMKDGKKSLAYQILY
+                     RAVKKIQQKTETNPLLVLRQAIRRVTPNIGVKTRRNKKGSTRKVPIEIGSKQGRALAI
+                     RWLLEASQKRPGRNMAFKLSSELVDAAKGSGGAIRKKEATHRMAEANRALAHFR"
+     exon            complement(88290..88317)
+                     /gene="rps12"
+                     /locus_tag="BrdiC_p049"
+                     /number=2
+     exon            complement(88858..89078)
+                     /gene="rps12"
+                     /locus_tag="BrdiC_p049"
+                     /number=3
+     gene            90720..90791
+                     /gene="trnV"
+                     /locus_tag="BrdiC_t025"
+                     /db_xref="GeneID:6439832"
+     tRNA            90720..90791
+                     /gene="trnV"
+                     /locus_tag="BrdiC_t025"
+                     /product="tRNA-Val"
+                     /codon_recognized="GUC"
+                     /db_xref="GeneID:6439832"
+     gene            91021..92512
+                     /locus_tag="BrdiC_r001"
+                     /db_xref="GeneID:6439810"
+     rRNA            91021..92512
+                     /locus_tag="BrdiC_r001"
+                     /product="16S ribosomal RNA"
+                     /db_xref="GeneID:6439810"
+     gene            92823..93699
+                     /gene="trnI"
+                     /locus_tag="BrdiC_t026"
+                     /db_xref="GeneID:6439815"
+     tRNA            join(92823..92859,93665..93699)
+                     /gene="trnI"
+                     /locus_tag="BrdiC_t026"
+                     /product="tRNA-Ile"
+                     /codon_recognized="AUC"
+                     /db_xref="GeneID:6439815"
+     gene            93765..94648
+                     /gene="trnA"
+                     /locus_tag="BrdiC_t027"
+                     /db_xref="GeneID:6439833"
+     tRNA            join(93765..93802,94614..94648)
+                     /gene="trnA"
+                     /locus_tag="BrdiC_t027"
+                     /product="tRNA-Ala"
+                     /codon_recognized="GCA"
+                     /db_xref="GeneID:6439833"
+     gene            94794..97681
+                     /locus_tag="BrdiC_r002"
+                     /db_xref="GeneID:6439784"
+     rRNA            94794..97681
+                     /locus_tag="BrdiC_r002"
+                     /product="23S ribosomal RNA"
+                     /db_xref="GeneID:6439784"
+     gene            97777..97871
+                     /locus_tag="BrdiC_r003"
+                     /db_xref="GeneID:6439801"
+     rRNA            97777..97871
+                     /locus_tag="BrdiC_r003"
+                     /product="4.5S ribosomal RNA"
+                     /db_xref="GeneID:6439801"
+     gene            98098..98218
+                     /locus_tag="BrdiC_r004"
+                     /db_xref="GeneID:6439802"
+     rRNA            98098..98218
+                     /locus_tag="BrdiC_r004"
+                     /product="5S ribosomal RNA"
+                     /db_xref="GeneID:6439802"
+     gene            98447..98520
+                     /gene="trnR"
+                     /locus_tag="BrdiC_t028"
+                     /db_xref="GeneID:6439803"
+     tRNA            98447..98520
+                     /gene="trnR"
+                     /locus_tag="BrdiC_t028"
+                     /product="tRNA-Arg"
+                     /codon_recognized="CGU"
+                     /db_xref="GeneID:6439803"
+     gene            complement(98780..98851)
+                     /gene="trnN"
+                     /locus_tag="BrdiC_t029"
+                     /db_xref="GeneID:6439895"
+     tRNA            complement(98780..98851)
+                     /gene="trnN"
+                     /locus_tag="BrdiC_t029"
+                     /product="tRNA-Asn"
+                     /codon_recognized="AAC"
+                     /db_xref="GeneID:6439895"
+     gene            100387..100659
+                     /gene="rps15"
+                     /locus_tag="BrdiC_p071"
+                     /db_xref="GeneID:6439894"
+     CDS             100387..100659
+                     /gene="rps15"
+                     /locus_tag="BrdiC_p071"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="ribosomal protein S15"
+                     /protein_id="YP_002000531.1"
+                     /db_xref="GeneID:6439894"
+                     /translation="MKKKGGRKIFGFMVKEEKEEKKGSVEFQVFSFTNKIRRLASHLE
+                     LHKKDFSSERGLRRLLGKRRRLLAYLAKKNRVRYKKLISQLNIREQ"
+     misc_feature    100988
+                     /note="junction IR-SSC; JSB"
+     gene            complement(101058..103283)
+                     /gene="ndhF"
+                     /locus_tag="BrdiC_p072"
+                     /db_xref="GeneID:6439789"
+     CDS             complement(101058..103283)
+                     /gene="ndhF"
+                     /locus_tag="BrdiC_p072"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="NADH dehydrogenase subunit 5"
+                     /protein_id="YP_002000532.1"
+                     /db_xref="GeneID:6439789"
+                     /translation="MEHTYQYAWVIPLLPLPVILSMGFGLFLIPIATKNFRRIWAFPS
+                     VLLLSIAMVFSVQLSIQQINGSSIYQYLWSWTINNDFSLEFGYLIDPLTSIMLMLITT
+                     VGILVLIYSDGYMSHDEGYLRFFIYISFFNISMLGLVTSSNLIQIYFFWELVGMCSYL
+                     LIGFWFTRPIAASACQKAFVTNRIGDFGLLLGILGFFWITGSLEFRDLFQTANNWIPN
+                     NGTTSLLTTLCAFLLFLGAVAKSAQFPLHVWLPDAMEGPTPISALIHAATMVAAGIFL
+                     LARLLPLFISLPLIMTFISLVGTITLFLGATLALAQRDIKRTLAYSTMSQLGYMMLAL
+                     GIGSYQAALFHLITHAYSKALLFLGSGSIIHSMEPLVGYSPDKSQNMALMGGLRKYIP
+                     ITRTAFLWGTLSICGIPPLACFWSKDEILSNSWLYSPFFGIIASFTAGLTAFYMFRIY
+                     LLTFDGYFRFHFQNYSSTKEGSLYSISLWGNRIPKGVSKDFVLSTTKSEVYFFSQNIS
+                     ISKGQGNTRNRIESFSTSFGSKNVFTYPHETGNTMLFPLLILLLFTFFIGFIGIPFDN
+                     ETMDNGIAGVTILSKWLIPSINFTQESSNSSINSYEFITNAISSVSLVILGLFIAYIF
+                     YGSAYSFFQNLDLQNSFYKGSPKKNFFYQVKKKIYSWSYNRGYIDIFYSRLFTLGIRG
+                     LTELTEFFDKGVIDGITNGVGLASFCIGEEIKYVGGGRISSYLFFFLCYVSVFLFFFL
+                     S"
+     gene            104129..104308
+                     /gene="rpl32"
+                     /locus_tag="BrdiC_p073"
+                     /db_xref="GeneID:6439790"
+     CDS             104129..104308
+                     /gene="rpl32"
+                     /locus_tag="BrdiC_p073"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="ribosomal protein L32"
+                     /protein_id="YP_002000533.1"
+                     /db_xref="GeneID:6439790"
+                     /translation="MAVPKKRTSMSKKRIRKNIWKNKTYFSIVQSYCLAKSRSFSSGN
+                     EHPKPKGFSGKQTNK"
+     gene            105005..105104
+                     /gene="trnL"
+                     /locus_tag="BrdiC_t030"
+                     /db_xref="GeneID:6439792"
+     tRNA            105005..105104
+                     /gene="trnL"
+                     /locus_tag="BrdiC_t030"
+                     /product="tRNA-Leu"
+                     /codon_recognized="CUA"
+                     /db_xref="GeneID:6439792"
+     gene            105182..106150
+                     /gene="ccsA"
+                     /locus_tag="BrdiC_p074"
+                     /db_xref="GeneID:6439793"
+     CDS             105182..106150
+                     /gene="ccsA"
+                     /locus_tag="BrdiC_p074"
+                     /note="ycf5"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="cytochrome c biogenesis protein"
+                     /protein_id="YP_002000534.1"
+                     /db_xref="GeneID:6439793"
+                     /translation="MLFATLEHILTHISFSTISIVITIHLRALLVRELGGLRDSSEKG
+                     MIATFFSITGFLVSRWLSSGHFPLSNLYESLIFLSWALYILHTIPKVQNSKNDLSTIT
+                     TPSTILTQGFATSGLLTEMHQSTILVPALQSQWLMMHVSMMLLSYATLLCGSLLSAAI
+                     LIIRFRNNFNFFSKKNKNVLKKTFLFSKMEYFYAKRSYFKSASVPSFPNYYKYQLTER
+                     LDSWSYRVISLGFTLLTIGILCGAVWANEAWGSYWNWDPKETWAFITWTIFAIYLHSR
+                     TNQNWKGTNSALVASIGFLIIWICYFGINLLGIGLHSYGSFTLTPN"
+     gene            complement(106314..107816)
+                     /gene="ndhD"
+                     /locus_tag="BrdiC_p075"
+                     /db_xref="GeneID:6439837"
+     CDS             complement(106314..107816)
+                     /gene="ndhD"
+                     /locus_tag="BrdiC_p075"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="NADH dehydrogenase subunit 4"
+                     /protein_id="YP_002000535.1"
+                     /db_xref="GeneID:6439837"
+                     /translation="MSYFPWLTILVVLPIFAGSLIFFLPHRGNKIVRWYTISICLLEF
+                     LLMTYAFCYHFQLEDPLIQLKEDSKWIDVFDFHWRLGIDGLSLGSILLTGFITTLATL
+                     AAWPVTRNSRLFYFLMLAMYSGQIGLFSSRDLLLFFIMWELELIPVYLLLSMWGGKRR
+                     LYSATKFILYTAGGSIFFLIGVLGMGLYGSNEPGLDLERLINQSYPATLEILLYFGFL
+                     IAYAVKLPIIPLHTWLPDTHGEAHYSTCMLLAGILLKMGAYGLIRINMELLPHAHYLF
+                     SPWLVIIGAIQIIYAASTSLGQRNFKKRIAYSSVSHMGFIIIGIGSITNIGLNGAILQ
+                     ILSHGFIGATLFFLAGTACDRMRLVYLEELGGISILIPKIFTMFSSFSMASLALPGMS
+                     GFVAELLVFFGLITSPKFLLMPKTLITFVMAIGMILTPIYLLSMLRQMFYGYKLFNVP
+                     NANFMDSGPRELFLLICIFLPVIGIGIYPDFVLSLSVDRVEALLSNYYPK"
+     gene            complement(107936..108181)
+                     /gene="psaC"
+                     /locus_tag="BrdiC_p076"
+                     /db_xref="GeneID:6439823"
+     CDS             complement(107936..108181)
+                     /gene="psaC"
+                     /locus_tag="BrdiC_p076"
+                     /note="9 kDa protein"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="photosystem I subunit VII"
+                     /protein_id="YP_002000536.1"
+                     /db_xref="GeneID:6439823"
+                     /translation="MSHSVKIYDTCIGCTQCVRACPTDVLEMIPWDGCKAKQIASAPR
+                     TEDCVGCKRCESACPTDFLSVRVYLGPETTRSMALSY"
+     gene            complement(108628..108933)
+                     /gene="ndhE"
+                     /locus_tag="BrdiC_p077"
+                     /db_xref="GeneID:6439824"
+     CDS             complement(108628..108933)
+                     /gene="ndhE"
+                     /locus_tag="BrdiC_p077"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="NADH dehydrogenase subunit 4L"
+                     /protein_id="YP_002000537.1"
+                     /db_xref="GeneID:6439824"
+                     /translation="MMFEHVLFLSVYLFSIGIYGLITSRNMVRALICLELILNSINLN
+                     LVTFSDLFDSRQLKGDIFAIFVIALAAAEAAIGLSILSSIHRNRKSTRINQSNFLNN"
+     gene            complement(109142..109672)
+                     /gene="ndhG"
+                     /locus_tag="BrdiC_p078"
+                     /db_xref="GeneID:6439825"
+     CDS             complement(109142..109672)
+                     /gene="ndhG"
+                     /locus_tag="BrdiC_p078"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="NADH dehydrogenase subunit 6"
+                     /protein_id="YP_002000538.1"
+                     /db_xref="GeneID:6439825"
+                     /translation="MDLPGPIHEILVLFLGFVLLLGGLGVVLLTNPIYSAFSLGLVLV
+                     CISLFYFLLNSYFVAVAQLLIYVGAINVLIIFAVMFVNGSEWSKDKNSWTIGDGFTSL
+                     VCITIVFSLMTTIPDTSWYGILWTTRSNQIVEQGLINNVQQIGIHLATDFYLPFELIS
+                     IILLVSLIGAITMARQ"
+     gene            complement(109923..110465)
+                     /gene="ndhI"
+                     /locus_tag="BrdiC_p079"
+                     /db_xref="GeneID:6439807"
+     CDS             complement(109923..110465)
+                     /gene="ndhI"
+                     /locus_tag="BrdiC_p079"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="NADH dehydrogenase subunit I"
+                     /protein_id="YP_002000539.1"
+                     /db_xref="GeneID:6439807"
+                     /translation="MFPMVTGFMSYGQQTIRATRYIGQSFITTLSHTNRLPITIHYPY
+                     EKSITPERFRGRIHFEFDKCIACEVCVRVCPIDLPIVDWRFEKAVKRKQLLNYSIDFG
+                     VCIFCGNCVEYCPTSCLSMTEEYELSTYDRHELNYNQIALSRLPISIMGDYTIQTIRN
+                     SAESQIDEDLSSNSRTITDY"
+     gene            complement(110559..112683)
+                     /gene="ndhA"
+                     /locus_tag="BrdiC_p080"
+                     /db_xref="GeneID:6439808"
+     CDS             complement(join(110559..111097,112134..112683))
+                     /gene="ndhA"
+                     /locus_tag="BrdiC_p080"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="NADH dehydrogenase subunit 1"
+                     /protein_id="YP_002000540.1"
+                     /db_xref="GeneID:6439808"
+                     /translation="MIIDRVEVETLNSFSKSELLKEIYGLIWILPILTLLLGITIEVL
+                     VIVWLEREISASIQQRIGPEYAGPLGLLQAIADGTKLLLKEDILPSRGDIPLFSIGPS
+                     IAVISILLSFLVIPLGYRFALADLSIGVFLWIAISSIAPIGLLMAGYSSNNKYSFSGG
+                     LRAAAQSISYEIPLTFCVLAISLLSNSSSTVDIVEAQSKYGFFGWNIWRQPIGFLVFL
+                     ISSLAECERLPFDLPEAEEELVAGYQTEYSGIKYGLFYLVSYLNLLVSSLFVTVLYLG
+                     GWDLSIPYISFFDFFQMNKAVGILEMTMGIFITLTKAYLFLFISITIRWTLPRMRIDQ
+                     LLNLGWKFLLPISLGNLLLTTSSQLVSL"
+     exon            complement(110559..111097)
+                     /gene="ndhA"
+                     /locus_tag="BrdiC_p080"
+                     /number=1
+     exon            complement(112134..112683)
+                     /gene="ndhA"
+                     /locus_tag="BrdiC_p080"
+                     /number=2
+     gene            complement(112685..113866)
+                     /gene="ndhH"
+                     /locus_tag="BrdiC_p081"
+                     /db_xref="GeneID:6439817"
+     CDS             complement(112685..113866)
+                     /gene="ndhH"
+                     /locus_tag="BrdiC_p081"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="NADH dehydrogenase subunit 7"
+                     /protein_id="YP_002000541.1"
+                     /db_xref="GeneID:6439817"
+                     /translation="MSLPLTRKDLMIVNMGPQHPSMHGVLRLIVTLDGEDVIDCEPIL
+                     GYLHRGMEKIAENRTIIQYLPYVTRWDYLATMFTEAITVNAPEFLENIQIPQRASYIR
+                     VIMLELSRIASHLLWLGPFMADLGAQTPFFYIFRERELIYDLFEAATGMRMMHNYFRI
+                     GGVAADLPYGWIEKCLDFCDYFLRGVVEYQQLITQNPIFLERVERVGFISGEEAVNWG
+                     LSGPMLRASGIRWDLRKVDLYESYNQFGWKVQWQKEGDSLARYLVRIGEMRESIKIIQ
+                     QAVEKIPGGPYENLEVRRFKKEKNSEWNDFEYRFLGKKPSPNFELSKQELYVRIEAPK
+                     GELGIYLVGDDGLFPWRWKIRPPGFINLQILPQLVKKMKLADIMTILGSIDIIMGEVD
+                     R"
+     misc_feature    113660
+                     /note="junction SSC-IR; JSA"
+     gene            complement(113988..114260)
+                     /gene="rps15"
+                     /locus_tag="BrdiC_p082"
+                     /db_xref="GeneID:6439806"
+     CDS             complement(113988..114260)
+                     /gene="rps15"
+                     /locus_tag="BrdiC_p082"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="ribosomal protein S15"
+                     /protein_id="YP_002000542.1"
+                     /db_xref="GeneID:6439806"
+                     /translation="MKKKGGRKIFGFMVKEEKEEKKGSVEFQVFSFTNKIRRLASHLE
+                     LHKKDFSSERGLRRLLGKRRRLLAYLAKKNRVRYKKLISQLNIREQ"
+     gene            115797..115868
+                     /gene="trnN"
+                     /locus_tag="BrdiC_t031"
+                     /db_xref="GeneID:6439796"
+     tRNA            115797..115868
+                     /gene="trnN"
+                     /locus_tag="BrdiC_t031"
+                     /product="tRNA-Asn"
+                     /codon_recognized="AAC"
+                     /db_xref="GeneID:6439796"
+     gene            complement(116128..116203)
+                     /gene="trnR"
+                     /locus_tag="BrdiC_t032"
+                     /db_xref="GeneID:6439797"
+     tRNA            complement(116128..116203)
+                     /gene="trnR"
+                     /locus_tag="BrdiC_t032"
+                     /product="tRNA-Arg"
+                     /codon_recognized="CGU"
+                     /db_xref="GeneID:6439797"
+     gene            complement(116430..116550)
+                     /locus_tag="BrdiC_r005"
+                     /db_xref="GeneID:6439855"
+     rRNA            complement(116430..116550)
+                     /locus_tag="BrdiC_r005"
+                     /product="5S ribosomal RNA"
+                     /db_xref="GeneID:6439855"
+     gene            complement(116777..116871)
+                     /locus_tag="BrdiC_r006"
+                     /db_xref="GeneID:6439830"
+     rRNA            complement(116777..116871)
+                     /locus_tag="BrdiC_r006"
+                     /product="4.5S ribosomal RNA"
+                     /db_xref="GeneID:6439830"
+     gene            complement(116967..119853)
+                     /locus_tag="BrdiC_r007"
+                     /db_xref="GeneID:6439831"
+     rRNA            complement(116967..119853)
+                     /locus_tag="BrdiC_r007"
+                     /product="23S ribosomal RNA"
+                     /db_xref="GeneID:6439831"
+     gene            complement(119999..120882)
+                     /gene="trnA"
+                     /locus_tag="BrdiC_t033"
+                     /db_xref="GeneID:6439828"
+     tRNA            complement(join(119999..120033,120845..120882))
+                     /gene="trnA"
+                     /locus_tag="BrdiC_t033"
+                     /product="tRNA-Ala"
+                     /codon_recognized="GCA"
+                     /db_xref="GeneID:6439828"
+     gene            complement(120948..121824)
+                     /gene="trnI"
+                     /locus_tag="BrdiC_t034"
+                     /db_xref="GeneID:6439873"
+     tRNA            complement(join(120948..120982,121788..121824))
+                     /gene="trnI"
+                     /locus_tag="BrdiC_t034"
+                     /product="tRNA-Ile"
+                     /codon_recognized="AUC"
+                     /db_xref="GeneID:6439873"
+     gene            complement(122135..123626)
+                     /locus_tag="BrdiC_r008"
+                     /db_xref="GeneID:6439890"
+     rRNA            complement(122135..123626)
+                     /locus_tag="BrdiC_r008"
+                     /product="16S ribosomal RNA"
+                     /db_xref="GeneID:6439890"
+     gene            complement(123857..123928)
+                     /gene="trnV"
+                     /locus_tag="BrdiC_t035"
+                     /db_xref="GeneID:6439829"
+     tRNA            complement(123857..123928)
+                     /gene="trnV"
+                     /locus_tag="BrdiC_t035"
+                     /product="tRNA-Val"
+                     /codon_recognized="GUC"
+                     /db_xref="GeneID:6439829"
+     exon            126330..126358
+                     /gene="rps12"
+                     /locus_tag="BrdiC_p048"
+     gene            126412..126882
+                     /gene="rps7"
+                     /locus_tag="BrdiC_p083"
+                     /db_xref="GeneID:6439812"
+     CDS             126412..126882
+                     /gene="rps7"
+                     /locus_tag="BrdiC_p083"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="ribosomal protein S7"
+                     /protein_id="YP_002000543.1"
+                     /db_xref="GeneID:6439812"
+                     /translation="MSRRGTAEKRTAKSDPIFRNRLVNMVVNRIMKDGKKSLAYQILY
+                     RAVKKIQQKTETNPLLVLRQAIRRVTPNIGVKTRRNKKGSTRKVPIEIGSKQGRALAI
+                     RWLLEASQKRPGRNMAFKLSSELVDAAKGSGGAIRKKEATHRMAEANRALAHFR"
+     gene            127181..129429
+                     /gene="ndhB"
+                     /locus_tag="BrdiC_p084"
+                     /db_xref="GeneID:6439820"
+     CDS             join(127181..127957,128674..129429)
+                     /gene="ndhB"
+                     /locus_tag="BrdiC_p084"
+                     /note="RNA edited conceptual translation not provided"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="NADH dehydrogenase subunit 2"
+                     /protein_id="YP_002000544.1"
+                     /db_xref="GeneID:6439820"
+                     /translation="MIWHVQNENFILDSTRIFMKALHLLLFHGSFIFPECILIFGLIL
+                     LLMIDSTSDQKDRPWFYFISSTSLVISITALLFRWREEPIISFSGNFQTNNFNEIFQF
+                     LILLCSTLCIPLSVEYIECTEMAITEFLLFVLTATLGGMFLCGANDLITIFVASECFS
+                     LCSYLLSGYTKRDLRSNEATMKYLLMGGASSSILVHGFSWLYGSSGGEIELQEIVNGL
+                     INTQMYNSPGISIALISITVGLGFKLSPAPFHQWTPDVYEGSPTPVVAFLSVTSKVAA
+                     SASATRILDIPFYFSSNEWHLLLEILAILSMILGNLLAITQTSMKRMLAYSSIGQIGY
+                     VIIGIIVGDSNDGYASMITYMLFYISMNLGTFACIVLFGLRTGTDNIRDYAGLYTKDP
+                     FLALSLALCLLSLGGLPPLAGFFGKLYLFWCGWQAGLYFLVSIGLLTSVLSIYYYLKI
+                     IKLLMTGRNQEITPYVRNYRRSPLRSNNSIELSMTVCVIASTIPGISMNPILAIAQDT
+                     LF"
+     exon            127181..127957
+                     /gene="ndhB"
+                     /locus_tag="BrdiC_p084"
+                     /number=1
+     misc_feature    128030
+                     /gene="ndhB"
+                     /locus_tag="BrdiC_p084"
+                     /note="C to U editing"
+     exon            128674..129429
+                     /gene="ndhB"
+                     /locus_tag="BrdiC_p084"
+                     /number=2
+     gene            130002..130082
+                     /gene="trnL"
+                     /locus_tag="BrdiC_t036"
+                     /db_xref="GeneID:6439834"
+     tRNA            130002..130082
+                     /gene="trnL"
+                     /locus_tag="BrdiC_t036"
+                     /product="tRNA-Leu"
+                     /codon_recognized="UUG"
+                     /db_xref="GeneID:6439834"
+     gene            132576..132649
+                     /gene="trnI"
+                     /locus_tag="BrdiC_t037"
+                     /db_xref="GeneID:6439813"
+     tRNA            132576..132649
+                     /gene="trnI"
+                     /locus_tag="BrdiC_t037"
+                     /product="tRNA-Ile"
+                     /db_xref="GeneID:6439813"
+     gene            132824..133105
+                     /gene="rpl23"
+                     /locus_tag="BrdiC_p085"
+                     /db_xref="GeneID:6439804"
+     CDS             132824..133105
+                     /gene="rpl23"
+                     /locus_tag="BrdiC_p085"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="ribosomal protein L23"
+                     /protein_id="YP_002000545.1"
+                     /db_xref="GeneID:6439804"
+                     /translation="MDGIKYAVFTEKSLRLLGKNQYTFNVESGFTKTEIKHWVELFFG
+                     VKVVAVNSHRLPGKGRRIGPILGHTMHYRRMIITLQPGYSIPLLDREKN"
+     gene            133124..134605
+                     /gene="rpl2"
+                     /locus_tag="BrdiC_p086"
+                     /db_xref="GeneID:6439799"
+     CDS             join(133124..133514,134175..134605)
+                     /gene="rpl2"
+                     /locus_tag="BrdiC_p086"
+                     /exception="RNA editing"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="ribosomal protein L2"
+                     /protein_id="YP_002000546.1"
+                     /db_xref="GeneID:6439799"
+                     /translation="MAKHLYKTPISSTRKGTVDRQVKSNPRNNLIHGRHRCGKGRNSR
+                     GIITARHRGGGHKRLYRKIDFRRNQKDISGRIVTIEYDPNRNAYICLIHYGDGEKRYI
+                     LHPRGAIIGDTIVSGTKVPISMGNALPLTDMPLGTAMHNIEITRGRGGQLARAAGAVA
+                     KLIAKEGKSATLRLPSGEVRLVSQNCLATVGQVGNVGVNQKSLGRAGSKCWLGKRPIV
+                     RGVVMNPVDHPHGGGEGKAPIGRKKPTTPWGYPALGRRTRKRKKYSDSFILRRRK"
+     exon            133124..133514
+                     /gene="rpl2"
+                     /locus_tag="BrdiC_p086"
+                     /number=1
+     exon            134175..134605
+                     /gene="rpl2"
+                     /locus_tag="BrdiC_p086"
+                     /number=2
+     misc_feature    134199
+                     /gene="rpl2"
+                     /locus_tag="BrdiC_p086"
+                     /note="junction IRA-LSC; JLA"
+     gene            complement(134658..134735)
+                     /gene="trnH"
+                     /locus_tag="BrdiC_t038"
+                     /db_xref="GeneID:6439800"
+     tRNA            complement(134658..134735)
+                     /gene="trnH"
+                     /locus_tag="BrdiC_t038"
+                     /product="tRNA-His"
+                     /codon_recognized="CAC"
+                     /db_xref="GeneID:6439800"
+     gene            134869..135150
+                     /gene="rps19"
+                     /locus_tag="BrdiC_p087"
+                     /db_xref="GeneID:6439818"
+     CDS             134869..135150
+                     /gene="rps19"
+                     /locus_tag="BrdiC_p087"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="ribosomal protein S19"
+                     /protein_id="YP_002000547.1"
+                     /db_xref="GeneID:6439818"
+                     /translation="MTRKKTNPFVAHHLLAKIEKVNMKEEKETIVTWSRASSILPTMV
+                     GHTIAIHNGKEHIPIYITNPMVGRKLGEFVPTRHFTSYENARKDTKSRR"
+ORIGIN      
+        1 agggaaatac cccaatatct tgggtaggaa caagatattg ggtatttctc gcttttcttt
+       61 tcttcaaaaa ttcttatatg ttagcggaaa aaccttatcc attaatagcg ggaacttcaa
+      121 gagcagctag atctagaggg aagttgtgag cattacgttc gtgcattact tccataccaa
+      181 gattagcacg gttgatgata tcagcccaag tattaataac gcgaccttga ctatcaacta
+      241 cagattggtt gaaattgaat ccatttaggt tgaacgccat agtactaata cctaaagcag
+      301 tgaaccagat tcctactaca ggccaagcag ccaagaagaa gtgtaaagaa cgagagttgt
+      361 tgaaactagc atattggaag attaatcggc caaaataacc atgagcagcc acaatattat
+      421 aagtctcttc ctcttgacca aatttgtaac cctcattagc agattcattt tcagtagttt
+      481 ccctgatcaa actagaggtt accaaggaac catgcatagc actgaatagg gaaccgccga
+      541 aaacaccagc tacacctaac atgtgaaatg gatgcataag gatgttgtgc tcggcctgga
+      601 atacaatcat aaagttgaaa gtaccagata ttcctaaagg cataccatca gagaagcttc
+      661 cttgaccaat agggtaaatc aagaaaacag cagtcgcagc tgcaacagga gctgaatatg
+      721 caacagcaat ccaagggcgc atacccaaac ggaaactaag ttcccactca cgacccatat
+      781 aacaagctac accaagtaag aagtgtagaa caattagctc ataaggacca ccattgtata
+      841 accattcatc aacggatgca gcttcccaaa ttgggtaaaa gtgcaatccg attgccgcag
+      901 aagtaggaat aatagcacca gagataatat tgtttccata aagtaaagaa ccagaaacag
+      961 gctcgcgaat accatcaata tctactggag gggctgcgat gaaggcgata ataaatacag
+     1021 aagttgcggt caataaggta gggatcatca aaacaccgaa ccatccgatg taaagacgat
+     1081 tttcagtgct agttatccag ttgcagaagc gaccccacag gcttgtactt tcgcgtctct
+     1141 ctaaaattgc agtcatggta agatcttggt ttattcaaat tgcaaggact cccaagcaca
+     1201 catattaact agaaataata tagataatag aaggcttgtt atttaacagt ataacataga
+     1261 ctatatacca atgtcaacta agtcagccca aagattggat atccatataa ctaaattaac
+     1321 caaaccaaaa aattttgtaa atgaagtgag tcaaaattaa aaactcagat tcctcttttc
+     1381 aattttccat atgggttgcc cgggactcga acccggaact agtcggatgg agtagataat
+     1441 tcttccttgt tacaatagag aaaaatccct ccccaaaccg tgcttgcatt tttcattgca
+     1501 cacgactttc cctatgtgga aatggctcat ttctattaca aagagttata ctaaaattat
+     1561 gaagaacatt tcagaatgca aaaatatgca agttttatct tgatcattca tcgacccttt
+     1621 cctgtttatt agttttgtct aataattaat tacgaggatt caccaggccg ttgatacgga
+     1681 taatatccaa ataccaaata cgctcactat gcgatccacg gaaataaaaa agggttgttt
+     1741 tggtgaacat caaagaaaaa actgggtctt cttccgtaaa aaattcttct aaaaataccg
+     1801 agcccaatcg ttgcataaaa gttcgtaccg tgcttttatg tttacgagct aaagttctag
+     1861 cgcatgaaag tcgaagtata tactttagtc gatacaaagt ccgttttttg gaagatccac
+     1921 tatgataatg aaaaagattt ttacatatct gaccaaatcg atcaagaata tcccaatcag
+     1981 ataactctgt ccaaatgggt ttactaatag gatgccccga tccagtacaa aattgagctt
+     2041 ttgataaaga tcctatgagg agagtagcgg ggactatggt atcgaatttt atcattcgag
+     2101 tatctattag aaaagaattc tccagcattt gattccttac taacaaagga ctttttggta
+     2161 cacttgaaag gtaccccaaa aaatcgaagc aagagtttgc caattggttt agatggatcc
+     2221 ttcgcggttg agtccaaaaa gaaaaagaat attggcagaa attgacaagg taccatttcc
+     2281 atttcttctt caaaaaaaga gttccttttg atgcaagaat tgcctttcct tgatatcgaa
+     2341 cataatgcat aagaggatcc ataaagaacc ataaggtttt ccgaaaaaaa ccagggtcca
+     2401 ttatcccaaa atgttccatc ttcctagaaa agtggattcg ttccaaaaat cctccagaag
+     2461 atgctaatgg taagcaagaa gattgtttac gaagaaacaa caaaaaaaac tcatattctg
+     2521 atacataaga gttatatagg aatcgaaata gtcttttatt ttcttttttt aaaagaaaaa
+     2581 aagatttgat tgaagtaata aaactattcc aattcgaatt gtagttgaga aagaatcgca
+     2641 ataaatgcaa agatggaaca tcttggatat ggtattgaag gagttgaacc aagatttcca
+     2701 aatggatagg atagggtatt tctatatgtg atagataatg caaatgcaaa aatttgtctt
+     2761 ctaaaaagga aaatattgaa tgaatagagc gtaaattctg aaactttggt atttcttttt
+     2821 ctttcggaca aaaagattct cgtagcgaga atgggatttc tacaacgatc gaaaacccct
+     2881 cagatagaat ctgagaaaaa aactcagaat aaaaaaaatt tttgtaatcc aacaatcgat
+     2941 cttggttagg atgattaacc gagttaatcc aaaaattctg ctgatacatt cgaataatta
+     3001 aacgtttcac aagtagtgaa ctaaattttt tgttattaca actaacaatt tccacaggtt
+     3061 cggaatcatt taatccataa tcatgggcaa atgcataaag aaactcctga aagagaagtg
+     3121 ggtatacaaa gtattgttga cgagatttat gtttttctga aatctcttcg aatttttcca
+     3181 tttgtatttc tacttgaatc agaaagagag aagcttttct cggtttatcg aatgctgata
+     3241 catagtgcaa tatggtcaga acagggtgtt gcatttttta ataaaaaccc tggaaagaaa
+     3301 gggagtctaa tccacttttt ttatttttgc aggccaatcg ctcttttgac tttggaataa
+     3361 agtctcttta tcaatatact gcttctttta cacattcaat acataacatc ctttattcaa
+     3421 cccataatca agaataataa ggatttctaa aaataaaaga aaaaataaag ggcccactca
+     3481 taggaaaacc ctacttttcc ccgcatccgg cactaatcca tttttaacgt ctaattagag
+     3541 cggggaatta ttccaattaa gaagtaaagc tcgttgcttt tttattttac cagaattaga
+     3601 gccaggctct atccatttat tcactagacc cagaaaatag taaattttct attccattcc
+     3661 aaaaataaaa aaaaaagaaa tgaattttat tacgacatgc ttttttttcc attcattacc
+     3721 cttgaggatc agtcgtggtc ttctagactc taccaagagt ctggacgaat ttgttgcttc
+     3781 atccaaatgt gtaaaagatc atagtcgcac ttaaaagccg agtactctac cattgagtta
+     3841 gcaacccaga taaaaaagaa tcttagatac gatcgaaatc caaaaatcaa tggaattaca
+     3901 ccgcgcgctt ttgccaaacc attgaactag caagacataa aaagaaagat tttatcgacc
+     3961 atgaaaaaga ctcaaatgct aaaacgaaca gatccagtta aattccccta aggtaaaaaa
+     4021 aaaagagtga ccccaatcgc gatgggaaaa ttctcctttt tttagcgatt tttaatttaa
+     4081 attaaaaaaa atcttctatg aaaatagatg gaagagaaac acccttatca tttgagggaa
+     4141 gtgtaggcag aaaagtagaa tatggagtga ggataaagag acctatctat ctacaaattc
+     4201 tagttgttca agagaccttt gtcaatggaa atacaatggt aagaaaaaaa ttggataaaa
+     4261 aaagtaaata aaataggggt ttatgttgaa ttggcacgac ataaatccaa ataggactaa
+     4321 gaaagaggta aattgtatct aaataattag acaacgaggg atactagtaa tcttctccta
+     4381 cttttttatt catttagttc tctattttaa ctcaaagttc tttctttttc tttaaagaat
+     4441 tccgccttct ttaaaatatc ataaacagtt cttgtcggtt gagcaccctt ttcaaggaaa
+     4501 tagagaatag ctggaacatt taaagaagtt tgattcttta tcggatcata aaaacctact
+     4561 tttcgaagat ctcttccttc tctccgagat cgaacatcaa ttgcaacgat tcgatagaca
+     4621 gcttattggg atagatgtag ataaacaacg tcccccccta gaaacgtata ggaggttttc
+     4681 tcctcatacg gctcgagaaa atgattcgaa tttctttcta taataataga aattagactg
+     4741 tgacgtgcat taatttcctt acagaaaaaa caaattacat ttatactcat gactcaagtt
+     4801 ggctaatttt gactgacaga cttcaaaggt aaaatccttc taaatttttt gagtcgtctc
+     4861 taaactcttt tctttgtctc atttcgaacg aattgacttt tattctttat tctgatccaa
+     4921 ttctgttgtt aagaacaatt taaaattgtg tttacttgtt cgggaatgtt ttatctttaa
+     4981 tttgttaaat ccttgggttt agacattact tcgggaattc ctattctttg tttctttcaa
+     5041 aagagtagca acataccctt ttttcttatt tccttcgata aaagcatttc cctcttctat
+     5101 agaaatcgaa gatgggggat ttattctgat agacttttaa ttaaaagaat tttccaaatc
+     5161 ttccaaaatg ggattttctt cttattttaa cctttcgatt tctatatcaa ggatagactg
+     5221 acaaagttgg cctaatttat tagttttcac taaccctaga ttctttccct tgataaaaaa
+     5281 taaatttcgt cttctcgagc tccattgtgt actatttact taaaaacaac ccagggcaaa
+     5341 tttggttcgg aacgaataga acagactatg tcgagccaag agcattttca ttactatgga
+     5401 aaatgatgga tagcaaaatc cacaatcgat catgtccttc aagtcgcacg ttgctttcta
+     5461 ccacatcgtt ttaaacgaag ttttaccata acaaacattc ctcttttcat tgcaaagtgg
+     5521 tatagggagt tgatccaata tatatggaat catgaatagt cattggttta gttttttgta
+     5581 tactaattca aacttgctat ctatggagca atagggataa aagaaagtaa gtatttatcg
+     5641 cggaagcctc tgcaaagatc caatttattt aaacctatat tctatcatat gaatgaaata
+     5701 tagttcgaaa aagacaaatg aacaagtttg cttaagactt atttattatt aaattcccat
+     5761 cctcaacgaa tagctcgaaa tgatcaatct tgaagtgaga agagaaggag gaactcttac
+     5821 gcaataacta aactataagc ctccaaaaaa gcttaattaa tttaattact ctattcgaat
+     5881 tagagtagca atatatagaa ttagagtagc aatatatttc tccgtaccaa aaacttatta
+     5941 actaaataaa ctattccaat gaatagattg aaagtttctt ggtagttata gaattctcgt
+     6001 acttcttcta cttgaatacc aaaataaaga aaaataatga gtaagtgagg agtagaagca
+     6061 tgtcctgaat gtgactgata gacgcctttt tcatgaaaat aaagatactc aatttgactg
+     6121 gacttaacac tttattatat tttctgagaa aaaaatgaat gcttagaaat gggtctaatc
+     6181 taagagttca taagatatta ttattctctt taataaagtt ttgtctcatg cggagtacaa
+     6241 tatgatttca tcttttgttt catcagaaac aatctgggac ggaaggattc gaacctccga
+     6301 gtaacgggac caaaacccgc tgccttacca cttggccacg ccccatttcg ggttttatgc
+     6361 gacactaata aacactagtt tatttatttg ttattcgtca atcccatttg aattacataa
+     6421 aaatgaagga tattatcttg ctagtattct agacatgcgg ataatataga atcaaaaaat
+     6481 gcattgatca ttacatggaa ttctattaag atattatatg aaagtctaat ttattccaca
+     6541 ctcatcatca tttgagagtg cgaatacaag gaggtatttt gtatttggga aagtccgaaa
+     6601 aaaagatttt gaatctgcct tttccttttt tccttagaaa aataactcaa tcaaaatcca
+     6661 attatttact ctacaagaac gaaatgcttg ttatgcctaa tatacttagt ttaacctgta
+     6721 tctgttttaa ttgtgttctt tatccgacta gttttttctt gctaactacc cgaagcttat
+     6781 gccattttca cccaatcgtg gattttatgc ctgtcatacc tctattcttt tttctattag
+     6841 cctttgtttg gcaagctgct gtaagttttc gatgaaatct ttactactcc gtctgccaaa
+     6901 ttgaatggtc tattcattcc aaaaccaaaa aaaattataa aaattcggta aaagccaaga
+     6961 agttttatat ttttatatta taaaccttcg attctaaaat aaaaattatt ctacattgaa
+     7021 tggatagcta cagcaataaa tttggatcag cctttctacc cccctgcacc tacgttgagc
+     7081 aggtaccttt aggtacccac acaatactta accctatttt tgatattgat aagagtgctt
+     7141 attataaatg aattcttgca attttttgca agaattcatt tttgcatttt taggtaccaa
+     7201 aataaacaaa acccatccta gtggatctgt gtggtaagga aaaactggta atctattcct
+     7261 taaaaaaaat attggagatt ttgtaatgct tactctcaaa ctttttgttt atacagtagt
+     7321 gatattcttt gtttccctct ttatctttgg attcttatct aatgacccag gacgtaatcc
+     7381 tgggcgcgag gagtaaaaat tcacattttt ttgcattttt tcttacaaat tggatttgtt
+     7441 tcttacattt atctatgaga aaatccgggg gtcagaattc cttccaattc gaaagtccta
+     7501 aatgatacga gggagcggaa agagagggat tcgaaccctc ggtacaaaaa aattgtacaa
+     7561 cggattagca atccgccgct ttagtccact cagccatctc tccccgttcc aaatcgaacg
+     7621 gtttccgtga tatgatagaa gcaagaaata acgattgcaa aaaaccttct tttttctttc
+     7681 aaaagtctat aaaaattata ttgccaattc cattttagtt atattctttt ttcttaatgt
+     7741 taataaaaaa aagaagaaaa ttcttctttt ttattttgaa aaatagatat gggccgagag
+     7801 gcaatcagat agattttctc tttagcgggt atttccatat aggacttgtt ataataaaaa
+     7861 aagcaggttg caggttatag aaaaaagaaa aaacgctttt tttcgatttt ttatcaagaa
+     7921 agcaaaaagg gttcttatca aacccacaat aaaataggaa acaaggataa agtaagtaga
+     7981 cctgactcct tgaattatgc ctctatccgc tattctgata tataaattcg atatagatga
+     8041 aattgtataa acgaattttt tttattttct tagacttaga ccctgcaaga taataatttt
+     8101 tcgctattta cgattttata ttcttgttac tagatactct ataggaataa gaataaatcg
+     8161 caactccttt ccactacaca taaaaattga tttcgaaagt cttttttttt taagaatcct
+     8221 ccatttttgt tcttccaccc atgcaataga gagcaaatgg gaaaagaggg gttacttttt
+     8281 ttcatttttc ccttaaaaga taggctttga aatcggagtc atggaataat ggtgaattca
+     8341 aatgtttagt tctttagtat aagaagtata agaaaaaagt ataagaaaaa aatcgaatcc
+     8401 aatttatgga tttaccacga cctcggttgt gactccatag ataaaaatga aaaaatttat
+     8461 atcttcgaga ccattgaaaa acggcattgc acgagaaaga aatcgtccac agataatcaa
+     8521 actatcatat gccttggaag tgatacgagg tgctcggaaa tggttgaagt aattgaatag
+     8581 gaggatcact atgactatag cccttggtag aattcctaaa gaagaaaagg atctatttga
+     8641 tactgtggac gactggttac gaagggaccg tttcgttttt gtaggatggt ccggcttatt
+     8701 gctctttcct tgtgcttatt tcgctttagg agggtggttt acagggacaa cttttgtaac
+     8761 ttcttggtat acccatggat tggctagttc ctatttggaa ggttgtaatt tcttaaccgc
+     8821 agcagtttct acccctgcca atagtttagc acactctttg ttgctactat ggggcccgga
+     8881 agcacaagga gattttactc gttggtgtca attaggtggc ctatggactt ttgtagctct
+     8941 ccacggggct tttgcactaa taggtttcat gttacgccaa tttgaacttg ctcggtctat
+     9001 tcaattgcgg ccttataatg caatctcatt ctctggtcca atcgctgttt ttgtttctgt
+     9061 attccttatt tatccactgg ggcaatccgg ttggttcttt gcgccgagtt ttggcgtagc
+     9121 agcgatattt cgattcatcc ttttcttcca aggatttcat aattggacgt tgaacccgtt
+     9181 tcatatgatg ggagttgccg gagtattagg cgcggctctc ctatgcgcta ttcatggagc
+     9241 gaccgtagaa aacactctat tcgaagacgg tgatggtgca aatacttttc gcgcttttaa
+     9301 cccaactcaa gctgaagaaa cttattcaat ggtcactgct aatcgctttt ggtcccaaat
+     9361 ctttggtgtt gctttttcca acaaacgttg gttacatttc tttatgctat ttgtccccgt
+     9421 caccggttta tggatgagtg ctattggcgt agttggcctg gctctgaact tacgtgccta
+     9481 tgactttgtt tcccaggaaa tccgtgcagc ggaagatcct gaatttgaga ctttctacac
+     9541 caaaaatatt cttttaaacg agggtattcg tgcgtggatg gcagctcagg atcagcctca
+     9601 tgaaaatctt atattccctg aggaggttct accacgtgga aacgctcttt aatggaactt
+     9661 tcgttttagc tggtcgtgac caagaaacca ccgggtttgc ttggtgggct gggaatgcta
+     9721 gacttatcaa tttgtccggt aaactacttg gcgcccacgt agcccatgcc ggattaatcg
+     9781 tattctgggc cggagcaatg aacctatttg aagtggccca tttcgtgcca gaaaagccca
+     9841 tgtatgaaca agggttgatt ttacttccac acttagctac cctaggttgg ggagtcgggc
+     9901 cagggggaga agttctcgat acttttccgt actttgtatc tggagtactt cacctaattt
+     9961 cctccgcagt cttaggcttc ggtggcattt atcacgcgct tctgggaccc gagactcttg
+    10021 aggaatcttt tccattcttt ggttatgtat ggaaagatag aaataaaatg actacaattt
+    10081 tgggtattca tttaattttg ttaggtctag gtgcttttct tctagtactc aaggctcttt
+    10141 attttggcgg tgtatatgat acctgggccc ccgggggggg ggatgtaaga aaaataacca
+    10201 acttgaccct tagccccggt gttatatttg gttatttact aaaatcccct tttgggggag
+    10261 aaggctggat tgttagtgtg gatgatttag aagatataat tggtggacat gtatggttgg
+    10321 gtttcatttg tgtatttggc ggaatttggc atatcttaac caaacctttc gcatgggctc
+    10381 gccgtgcatt tgtatggtct ggagaagctt acttgtctta tagtttagct gctttatctg
+    10441 tctttggttt tatcgcttgt tgttttgtct ggttcaataa tacggcttat ccgagtgagt
+    10501 tttatggacc caccggccca gaagcttctc aagctcaagc atttactttt ctagttagag
+    10561 accagcgtct tggagctaat gtgggatctg ctcaaggacc cacaggttta ggtaaatatc
+    10621 taatgcgttc cccaacggga gaggttatct ttggagggga aactatgcgt ttttgggacc
+    10681 tccgtgctcc atggttagaa cctctaaggg ggcccaacgg tttggacttg agtaggttga
+    10741 aaaaagacat acaaccttgg caagaacgac gttcagcgga atatatgacc catgctcctt
+    10801 taggctcttt aaattccgtg ggtggcgtag ctaccgagat caatgcagtt aattatgtct
+    10861 ctcctagaag ttggttatcg acttctcatt ttgttctagg attcttcttt tttgtgggcc
+    10921 atttgtggca tgcaggaaga gcccgagctg ctgcagcagg ttttgaaaag ggaatcgatc
+    10981 gtgatttaga acctgttctt tacatgaacc ctcttaacta agattttctt atttatacct
+    11041 gttctacttc tactgttttt ttctgctctg gctcggttat ttcatttagc cgagccattc
+    11101 attccttttt ctgaatgaaa gataagggga cagaataaag aaaaaaaaaa aaaaatgaaa
+    11161 gaaacaaacg tattcaataa gcaaaaggag agagagggat tcgaaccctc gatagttcct
+    11221 agaactatac cggttttcaa gaccggagct atcaaccact cagccatctc tccacagctt
+    11281 aatccctatt ttactcctag aaatagaaca cagccatata aaaataaaag gatctactaa
+    11341 cctctagaaa catctcagat gcaaatcctt tttcgatata tttctgtata ctgtatacac
+    11401 ggatagaaga tccgctatac ccgcttttga aataaagact aaatccccta ccctaatccc
+    11461 catatccaaa taaaagcggt aagtaataag ttttaattat taattaaaga gaagaatcaa
+    11521 tggattcatg attaaacccc tcctacttct tgtatttttt acaatttagg ttaagtgagg
+    11581 gatcaaatat gtagtcaact ttatttgatg atagcttgga ggattagaaa tatgactatt
+    11641 gctttccaat tagctgtttt tgcattaatt gcgacttcct cagtcttagt aattagtgta
+    11701 ccccttgtat ttgcttctcc tgatggttgg tcaaataata aaaacgttgt tttttccggt
+    11761 acatcattat ggattggtct agtctttctc gtagctattc tgaattctct catttcataa
+    11821 atttgtttag tattgagtaa cccgatacaa aataaataaa aaggacattt cttcgaaaaa
+    11881 attcgaatag tgagacgcat taaaacgcaa tttgcgttcc gaattgctac ctcttctctt
+    11941 tcagtattat gaaattgcat tgccattaga atattgattg acagacaatc aaaaaaagga
+    12001 aaactctaat ataatagaaa atgaaacggt cgacccagac atagacggtc gacccaagcg
+    12061 gatatacgct ataaaatata ttccgtagcg agcgtagttc aatggtaaaa catctccttg
+    12121 ccaaggagaa gatacgggtt cgattcccgc cgctcgcccg cttactttag tcaagtacta
+    12181 tgagaaaaaa tttagtctag ttgaatgttt aactacttag aataaattat atattaatta
+    12241 ggtgttagtc tagtacccta tcccttatta cccttacttt tcaccccact caaaaaaagg
+    12301 agggctccgg agagggaaat agaactctcc aaccaggggg gtattcactg agacaaagaa
+    12361 ctggcaaact gcttttaaag ggaagggagg tagactgtgc gtttctttca tttttctttt
+    12421 ctgcagggta gggagaaacc ttgcctgttc ttcttatgga ggcaggcggc ttcgcagact
+    12481 gctcaatttt gccctctaag gccaggaagt aatgaataaa aaaattggat tggataccac
+    12541 ccaaccctgt accatatata tagaaatgga atagtccttt tatagagact gctaagtgcg
+    12601 gagacgggaa tcgaacccgt gacctcaagg ttatgagcct cgtgagctac caaactgctc
+    12661 tactccgctc tgcagtacca gaaaatggtg aacggaaaag gttaaatacg ggcctctact
+    12721 atgtctagac aaatagaata ctccttttat acaggtctag acaaatggaa tactcctttt
+    12781 atacatatac agaatggagc gggtagcggg aatcgaaccc gcatcgttag cttggaaggc
+    12841 taggggttat agtcgacgtt ggttgattat ttataacgtc tctaattcaa aaccgaacat
+    12901 gaaattttca tttcattcgg ctcctttatg gatattctca ccacttaaca tctatgtcag
+    12961 cttttctatt tgaatagaac caaagctctc cgctttctag atgatcctta tagagtaagg
+    13021 agatagaaat tcgatctaaa tccatctaat ctacttactt cgttccctaa tttcattcaa
+    13081 gggatccttg aggaaaagaa ttgggtttcc accgagctta aacaatatgc tgatggttct
+    13141 agtaaaccaa aactaccgct tttagctatt tggcttcctt ttcccttttt gaaggtaaag
+    13201 gagatttagt tacgattgga aaaaactttt ttgtatctcc atccatagat cctttactca
+    13261 tatttttaat atatggaata cttaatccaa tgtaaaatta tgcttcgcga ctctgtactc
+    13321 ataatcctat ttgtattttg gatgcaattt caattataca aatcacgaga atgtatattg
+    13381 ttcctcaata cgctattgag aggaaaagga tgaaatcctt tataagaact aaagttttca
+    13441 tcggaataga aaaaaaactt aaggatgcct taagtatatc attttaaatt cagttattaa
+    13501 tagaacgaat cacactttta ccactaaact atacccgcta catgtagatt atgatacaaa
+    13561 cgcaaccctt tgtcaatgat acccattcga gaaggaggtg aatttcccct tagtgaatca
+    13621 agaaggttca tggcagtgag ccgttggtac ttctacttcg attgcaggcc tttactttag
+    13681 gatttcgata acccctatgg tctgtaaaat acacctcttc ttaccatgcc aatagcatct
+    13741 gaactgtccc tataaacccc ttttttccac tcactcaatt tcaattctgg tttagtagat
+    13801 tcttgttttg tttaaaagaa tcaaaaaagt gcaatcgaac tagcaacaca taaaaaagag
+    13861 catagaggat caagaccatt acgaaatgtt cctcccaaga atcatattgg gtatctgttc
+    13921 cgttcctttt cccgctagga tcagaaatct tatattttcc atagccatat accatcgaat
+    13981 ccttagggtt ccagaatccg cctattttcc tagtcttcgg aaacgaaaaa ccctgaatta
+    14041 agaagagtta ggtatgtata gggtatggtt tattattttt tattgtgtca actttctctt
+    14101 cacgcatttt attatataaa aaaggatctc tactttgttt tatgcaagtt ataagagata
+    14161 atagcaaata ttttcttatt tttattgatt ttatcaatat tttgaacctc acgatgaata
+    14221 aacttatata gatatatgga tatctacata tattatgtac attatgcagt agacccagaa
+    14281 tgggaaatga aagtggctca tttttgaatt aaaaaaaaag cccttttaac tcagtggtag
+    14341 agtaatgcca tggtaaggcg taagtcatcg gttcaaatcc gataaagggc ttttaaagtt
+    14401 agtggtagag taatggcatg gtaaggcata agtcatcggt tcgaatctga tagaatactt
+    14461 ttctactaaa ttcatttact ttttactttg tttttgaaac tttctctatt ttttattgaa
+    14521 ttttatgact tagtgcgaga tgcatgcatt tttggtctga acactaaatg aagcacggaa
+    14581 tctaaattgc aaaaaagaaa tgaaattgga ctctttttca tcttagatca atcaaatgac
+    14641 tacctatact gaactaatct agaatccctt ttagtaatcg attcttattc tctacctttt
+    14701 aaaggaattt ccctaataaa gtaggggatg acccatgaat taatctaagc atgaattaaa
+    14761 aaaaatccta tgaaaacata acagccaaag tagcaaaaat tctttgcttt ggatcttgtt
+    14821 atactcttcg agtatattga caattcaaaa aaattgctca tactatgatt atagtataat
+    14881 cacgagcggt tatatatggc cctatcgtct agtgatgccc ctatcgtcta gtggttcagg
+    14941 acatctctct ttcaaggagg cagcggggat tcgacttccc ctgggggtag ggagtattat
+    15001 gaaaggagat taatcataga ttatcaaaaa ccctagaaaa aattcttcct gggtcgatgc
+    15061 ccgagcggtt aatggggacg gactgtaaat tcgttgacaa aatgtctacg ctggttcaaa
+    15121 tccagctcgg cccaaaaatc tggggcttcg tgaatatgaa ctaaatcttt ttatttttct
+    15181 tccataaaca aatgtctgat ctatagaaat aaaagagaaa gaaaaaaagg ggaaattcaa
+    15241 tttctaatcc atatctctct cattcctttc ttacaaacaa aagagttttt attattgaaa
+    15301 ggtggattac ccttcatttt tagtgataaa aaatcacgac atattagtta tgtcactctc
+    15361 acaataccca catataatat gtgggtatgt agtatatgat tcgtctattt cttagagtac
+    15421 gacagacgaa tcgaatcttc ttattcttct atttaaggat aggataggta tgccatacac
+    15481 cccgcgggga ttgtagttca attggtcaga gcaccgccct gtcaaggcgg aagctgcggg
+    15541 ttcgagcccc gtcagtcccg aactagggtt caatgaatgg agaaattaac ccttccattt
+    15601 tccatgaaaa aagcgggggc aagatcaaat acccatgggg cgcccttact tcactttttt
+    15661 attttgcatc tctcattaaa gaggtagggg aggtgtatag gaattttttt cactacttcc
+    15721 gattcgataa agaaagacac gcatatgata tgcagattag tagaatttag gatataactc
+    15781 tacctttatg atgataccat cctcacctca tcttaacttc ctattcgact cttatcttat
+    15841 ggaatagagt cccggtattt taccgggatc catacataaa tcatattcat tttccttttt
+    15901 ttagttaaga cctcttttct ccatctcact tctactgctt atttggatgt ctatgtgacc
+    15961 tatagaaagt tggtcatata atacatacat acataattgt atgtataact attagaaaaa
+    16021 ggaagggaaa ttggataaga ttaagaaaga tcgtgggtta tagatctaga aaataaaaaa
+    16081 tagaaaagga ttaaaaaaag agggaattcc taatccaaat ccaatcaaaa acccattttg
+    16141 gtcttaatca ttttggtctt agtatggata gaggatcttc ctatgttata cttttccact
+    16201 ctcaaccatg aattgatttc atagatccga tattaataat attgaattga ttcagtatta
+    16261 tcagaatgca agtctcaccc ttgaatttac aggatacccc ttttttcctc tccatgggat
+    16321 tacatcccga gttattgtgc aaaaaaaata aagaggttat ggaagtcaat attctcgcat
+    16381 ttatcgctac tgcactgttc attttagttc ctactgcctt tttacttatt atttatgtaa
+    16441 aaacagtcag ccaaaataat taattggaat tccaattaat cattgaagaa atgaaaaagg
+    16501 gattaaataa aaaaaatcca agtcttaaat gaaaggatcc ggttggaatc ttaaagtgtg
+    16561 gtagaaagaa ctacatatag ttttttctac cacactttag agtcttttct ttctattata
+    16621 ttagctttga atctatatag aatagattag tggattgaaa tagtagtcta attcaatttc
+    16681 ttttttcatt gcatccactt aatttcaatc aagtcaaaat aaaaaaaatc gaagacaatt
+    16741 cttgaccaaa gaatctatgg agggagaaaa aattaatatt aagaatagac tatatatagt
+    16801 aaaaaagtat atagtaaaat atagtaaaaa agatatatag taaaaaggaa aaaaccagcg
+    16861 aacctttcat gcttaaacat gccgcgagat acttcaaaag agcagcaaaa ttatgctaag
+    16921 aaaaggaaag attataaaaa aaagggaaaa tgtatgatat gtcgtgaata gctccgtgga
+    16981 ataaaataga atttccttat gcatagaact tttttaccca tcggtcattt ctagtagaaa
+    17041 ttatgaattg ctgtaatgga tctttctatt ttctattttt ctatatagta gaatataatg
+    17101 gctctttctt acaatacaag agtttcttac aggagtgaaa caaaaccaaa gaaaaagaaa
+    17161 aaagaataac gtttgacaaa atgatcaatg caaaatgatc aattaaagaa aagacttgat
+    17221 acaacaattc gattactcaa tcaattagta gtagtatccc tagagtccac tcctccccca
+    17281 caccactagt gaaagagaaa atgtaaagac taccattaaa gcagcccaag caagacttac
+    17341 tatatccatc taaattacgt ctcctatttc tatgaaggaa tttttctact attgatcaat
+    17401 aatcatagcg gaatcaaggg tacagagtca aaaagggatt ctgccctaag actatggaca
+    17461 atcagttcca agaatttact cctaacaaat tattatagga attctggtag aattagagaa
+    17521 cattaaatat aaatacgata catagccctt tcttttccgt aaaaaagaat acgggaatga
+    17581 tgtcctgaat ataagaagcg ggaataggaa gattttttat tccttttgtt actccttttt
+    17641 tataagtaaa ggacgcccga atataccata aaattatgga taggatagat aaatatttat
+    17701 tggataccta ccttacctat gtttagtttt gacttaaatc ctacaacctc gctttctatc
+    17761 attctatgaa aaaatgaaga gactttatcc acaactccta aatttattta ggatcggcct
+    17821 atttaatctg attttcgcta gaataagtag cccttacttt agtgtatgta ggtaacataa
+    17881 gatgtacgat aaaaaaatgt atgataatta ggaagtcttg atattctttc gtggagtccc
+    17941 ttcttcaatc ttagattgaa aaaagcggaa tgccctttag ggacctttcc tttctttgga
+    18001 taccaagatt tctgaaatct tagcttcgta gtttttaatt ctaaaatagg atcaattaag
+    18061 aactaattca aattcatata ataaaagaat aagaaaacgc taccttatcc ctagtggtaa
+    18121 tggtttgggc cagtaccgcc aaaacaaacc ctagtttgag gatagaacta tggattctca
+    18181 aaatccagta tcgccaagcc tagttactct cttgcccgaa cttatgcgaa gtatgaattt
+    18241 ctcgagttcg atcagtacta taagcctaag tattttatcg atcaggcggc acccagattt
+    18301 gaactgggga taaaggattt gcagtcccct gccttaccac ttggccatgc cgccaaaaaa
+    18361 tccgatcgaa aattgagaaa agagcaagta ttcacccacg ttttcttacg aaaatcccct
+    18421 ttcttttatt ttgaatctaa ttctacttac ttttttccaa tctttttcaa aaaatctatt
+    18481 tctgcttctt tttgatcctg tttcgattat tctcctcgat ggattctatg ttaaaacata
+    18541 cattgctaac actagaaaac tttctgcttc tttctattga gatgaaaaag gagaaaaagt
+    18601 agatttctag ggctgcaaaa ttcataaaaa atgggaacca ttaactagaa ttctcttttt
+    18661 tttatttgca gtagtaaacg actcttaaat gtgtattttc ccccctcttc cttttaaagg
+    18721 cataataaag gattcttttt ttatacctaa tccgtgtata ggtaaactcc aggtccgaac
+    18781 agcattatta tccaaagatc ccccttatgt acatatctct atggggaatc gtgctttaat
+    18841 ttttcaaagc attaaatatc ttgaataaaa aaaaggaaat ttgctctgat ataatttgct
+    18901 ctgatataga gtataagctg actatcttga cccacccaag tgaaattacg aaaaaagaaa
+    18961 agcagggata tgtggagagg cggataacta gattggcatg tacttaaaag ggcacttact
+    19021 ttattttagg attctacaat gaaatcctaa atttgctagc aattctacta gaccgaaaca
+    19081 aaagcggaac cctcaaattc ttttttgaaa ttaaactaag cgcgctattc taaatcgaag
+    19141 taaagtcaac aaactctcta gtgtattata ttacggcttt atcgcattca tagaaaggag
+    19201 ataaaatgag aaatctttgc cattcaatct gactagaata tcatcattca atctgactag
+    19261 aatatcataa agtataagtt ataagtggca taattttttt ataagaatgt tttatcaatt
+    19321 cattttcatt ccatttgtac ccctggcaaa ttagaacttt cgtcgaaatt gtctctattc
+    19381 atatgtatga aatacatata tgaaatacgt atgtggagtt ccctagaatt tcatgtgatt
+    19441 cagtaaacag aatatagatt ccatgattgc tagatcgatc cgtaggggtt gatgaagagt
+    19501 gagctgataa tggaattttt cttcgataaa caggaaactt aagattaaga tgctccggaa
+    19561 tgggaatgag ggaatgtcca caatacccgg atttagtcag atccaatttg agggattttg
+    19621 taggttcatt aatcaaggct tggcagaaga gcttgagaag tttctaacaa ttaaagatcc
+    19681 agatcacgaa attgcatttc aattatttgc gaaaggatat caattgctag aaccctcgat
+    19741 aaaagaaagg gatgctgtgt atgaatcact cacctattct tccgaattat atgtatctgc
+    19801 gagattaatt tttggtttcg atgtgcaaaa gcaaaccatt tctattggaa acattcctat
+    19861 aatgaattcc ttaggaacct ttataataaa tggaatatac cgaattgtga tcaatcaaat
+    19921 attgctaagt cctggtattt actaccgctc ggaattagac cataagggaa tttctatcta
+    19981 caccgggact ataatatcag attggggagg gagatcggaa ttagcaattg ataaaaaaga
+    20041 aaggatatgg gctcgcgtga gtagaaaaca aaagatatct attctagttc tatcatcagc
+    20101 tatgggttcg aatctaagag aaattctaga taatgtttcc taccctgaaa ttttcttgtc
+    20161 tttcccgaat gctaaggaga agaagaggat tgagtcaaaa gaaaaagcta ttttagagtt
+    20221 ttatcaacaa tttgcttgtg taggtgggga cctggtattt tcggagtcct tatgtgagga
+    20281 attacaaaag aaattttttc aacaaaaatg tgaattagga aggattggtc gacgaaatat
+    20341 gaatcggaga ctgaatcttg atatacctca gaacaataca ttcttgttac cacgagatgt
+    20401 attggccgct acggatcagt tgattggaat gaaatttgga acgggtatac ttgacgatga
+    20461 cgatatgaat cacttgaaaa ataaacgtat tcgttcggtt gcagatctgt tacaagatca
+    20521 attcggactg gctcttggtc gtttacaaca tgcggttcaa aaaactatcc gtcgagtatt
+    20581 catacgtcaa tcgaaaccga ctccccatac tttagtaact ccaacttcaa cttcgatttt
+    20641 attaataact acttatgaga ccttttttgg cgcatacccc ttatctcaag tttttgatca
+    20701 aacgaatcca ttgacacaaa ctgttcatgg gcgaaaagtg agttgtttag gtcctggagg
+    20761 gttgactggg agaactgcaa gttttcggag ccgagatatt catccgagtc actatgggcg
+    20821 tatttgtcca attgacacgt ccgaaggaat caatgttgga cttactggat ccttagcaat
+    20881 tcatgcgaaa attgatcact tgtggggatc tgtagagagt ccgttttatg aaatatctgc
+    20941 tgagaaagca aaagaaaaaa aagagagaca ggtggtttat ctatcaccaa atagagatga
+    21001 atattatatg atagcagcag gaaattcttt atccttgaat caaggtattc aggaagagca
+    21061 ggttgttcca gctagatatc gtcaagaatt tctgactatt gtatgggaac agattcatgt
+    21121 tagaagtatt tttcctttcc aatatttttc tattgggggc tctctcattc cttttattga
+    21181 gcacaatgat gcgaatcggg ctttaatgag ttctaatatg cagcgccaag cagttccgct
+    21241 ttctcggtcc gagaagtgca ttgttggaac tggattggaa cgccaaacag ctctagattc
+    21301 gagggtttcc gttatagccg aacgcgaggg aaagatcatt tctactgata gtcataggat
+    21361 ccttttatca agtagtggga agaccataag tattccttta gtaaaccacc ggcgctctaa
+    21421 caaaaatact tgcatgcacc aaaaaccgcg ggtgccgcgg ggtaaatcca ttaaaaaagg
+    21481 acaaatttta gcagagggag ctgccacagt tgggggggaa cttgctttag gaaaaaacgt
+    21541 attagtcgct tatatgccat gggaaggtta caattttgaa gacgcggtac taattagcga
+    21601 acgtttggta tatgaagata tttatacctc ttttcacatc cgtaaatatg aaattcagac
+    21661 ggatacgaca agtcaaggct ctgctgaaaa aataactaaa gaaataccac atctagaaga
+    21721 acatttactc cgcaatttgg acagaaatgg agttgttagg ttgggatcct gggtagaaac
+    21781 tggcgatatt ttagtaggta aactaacgcc tcagatagcg agcgaatcgt cgtatatcgc
+    21841 ggaagctgga ttattacggg ctatatttgg ccttgaggta tccacttcaa aagaaacttc
+    21901 tctcaaatta cctataggtg gaagagggcg cgttatcgat gtgaaatgga tccagaggga
+    21961 ccccctcgac ataatggttc gtgtatatat tttacagaaa cgtgaaatca aagttgggga
+    22021 taaagtagcc ggaagacatg ggaataaggg gatcatttcc aaaattttga ctagacaaga
+    22081 tatgccctat ttgcaagatg gaacacctgt tgatgtggtc ttcaatccct taggagtacc
+    22141 ctcccgaatg aatgtgggac aaatatttga aagctcgctc ggattagccg gggatctgct
+    22201 aaagaaacat tatagaatag caccctttga tgagagatat gagcaagagg cttcaagaaa
+    22261 acttgtgttt tcagaattat atgaagccag taaggaaaca aaaaatccat gggtatttga
+    22321 acccgagtac ccgggaaaaa gcagaatatt tgatggaaga acaggagacc ccttcgaaca
+    22381 acctgttcta atagggaagt cctatatctt aaaattaatt catcaagttg atgagaaaat
+    22441 tcatgggcgt tctactgggc cctactcact tgttacacaa caacccgtta gaggaagagc
+    22501 caagcaaggg ggacaacgag taggagaaat ggaagtttgg gctttagaag gatttggtgt
+    22561 tgctcatatt ttacaagaga tacttactta taaatctgat catcttatag ctcgccaaga
+    22621 aatacttaat gctacgatct ggggaaaaag aatagctaat cacgaggatc ctccagaatc
+    22681 ttttcgagtg ctcgttcgag aactacgatc tttggctcta gaacttaatc atttccttgt
+    22741 atcggagaag aacttccaag ttaataggga ggaaatttga tcggaataaa tattaattat
+    22801 tttctttatt ttatgattga ccaatataaa catcaacaac ttcaaattgg actcgtctcc
+    22861 cctcaacaaa taaaggcttg ggctaacaaa aacctaccta atggagaagt cattggccaa
+    22921 gtcacaaggc cctctacttt tcattataaa accgataaac cagaaaaaga tggattgttt
+    22981 tgcgaaagaa tctttggacc cattaaaagc ggaatttgcg cttgtggaaa ttctcgagcg
+    23041 agcggggctg aaaacgaaga tgaaagattt tgccaaaaat gcggggtaga atttgcggat
+    23101 tctcggatac gaagatatca aatgggatac atcaaactcg catgtccggt gactcatgta
+    23161 tggtatttga aaggtcttcc tagttatatc gcgaatcttt tagataaacc tctgaagaag
+    23221 ttggagggct tagtatatgg agatttctct tttgctaggc ccagcactaa aaaacctact
+    23281 ttcttacgat tacgaggttt attcgaagag gaaattgcat cctgtaacca cagcatttct
+    23341 cccttttttt ctaccccgag ctttacaaca tttcgaaatc gggaaattgc gacaggagca
+    23401 ggtgctatta gagaacaatt agcagatttg gatttgcaaa ttattataga gaattcgttg
+    23461 gtcgaatgga aggaattaga agacgagggc tatagtggag atgaatggga agatagaaaa
+    23521 agacgaataa gaaaagtttt tttgattaga cgcatgcaat tggcgaaaca ttttattcaa
+    23581 acaaatgtag aacctgaatg gatggttttg tgcttattac cggttcttcc tcccgaattg
+    23641 aggcccattg tttataggtc tggggataaa gtagtgactt cggacattaa tgaactttat
+    23701 aagagagtta tccgccggaa caacaacctt gcctatctat taaaaagaag tgaattagcg
+    23761 ccagcagatt tagtaatgtg ccaggaaaaa ttggtacaag aagccgtgga tacacttctt
+    23821 gatagtgggt cccgcgggca accgacgagg gatggtcaca ataaagtata caaatcgctt
+    23881 tcagatgtaa ttgaaggtaa agagggaagg tttcgcgaga ctctccttgg gaaacgagtc
+    23941 gattactcgg gtcgttccgt cattgttgtg ggtccttcgc tttcattaca tcaatgtgga
+    24001 ttacccctag agatagcaat aaagcttttt cagctatttg taattcgcga tttaatcacg
+    24061 aaacgcgcta cttctaatgt caggattgct aaaaggaaaa tttgggaaaa ggaaccgatt
+    24121 gtatgggaaa tacttcaaga agttatgcgg ggacatcctg tactgttaaa tagagcacct
+    24181 accctgcata gattaggcat acaggccttc caacccactt tagtagaggg gcgtactatt
+    24241 tctttacacc cattagtgtg taagggtttc aatgcggact ttgatgggga tcaaatggct
+    24301 gttcatctac ctttatcctt ggaagctcag gcggaagctc gtttacttat gttttcgcat
+    24361 atgaatctct tatctcccgc tattggggat cctatttgcg taccaaccca agacatgctt
+    24421 atcgggcttt atgtattaac gattggaaac cctcgaggta tttgtgcaaa tagatataat
+    24481 agttgcggaa actatccaaa tcaaaaagta aattacaata ataataattc tacgtatacg
+    24541 agagataaag aacccatttt ttatagttct tatgatgcac taggagctta tagacagaaa
+    24601 ctaatcagtt tagacagtcc cttgtggcta cgatggaaac tagatcaacg cgccattgga
+    24661 tcaagagaag ttccgattga agttcaatat gaatctttgg ggacttatca tgagatttat
+    24721 gctcactatc taatagtggg aaatagaaaa aaggaaatct gttctatata cattcgaact
+    24781 actcttggtc atatttcttt ttatagagaa atagaggaag ccgtacaagg atttagtcag
+    24841 gcctattcat acactatcta aacaaggaag ttagattcgg ggatgccccg cccttttcgg
+    24901 ggggcattcc gatttcctta gtatcatcat tttatttttg ccgcgcgaat ccagattgag
+    24961 attgagaaaa tgaagctaat taaattttcg aatcactgac tcacgcccat tgtcgaatcc
+    25021 tactcagcaa ttctcgaatc ctactcagcc gaaaaagggg gtacttatgt atggcggaac
+    25081 gagccaatct ggtctttcat aataaagaaa tagacggaac tggtatgaaa cgacttatta
+    25141 gcagattaat agatcatttc ggaatgggat atacatccca tatactggat caactaaaga
+    25201 ctctgggctt ccatcaagcc actactacat cgatttcgtt aggaatcgag gatcttttaa
+    25261 caataccctc taagggatgg ttagtccaag acgcggaaca acagagtttt cttttggaga
+    25321 aacactatta ttatggggct gtacacgcgg tagaaaaatt acgccaatcc gttgagatat
+    25381 ggtatgcgac aagtgaatat ttgaaacaag aaatgaattc gaattttcgg ataacagatc
+    25441 cttctaatcc agtctatcta atgtcttttt caggagccag aggaaatgca tctcaggtac
+    25501 accaattagt aggtatgaga ggattaatgg cggaccctca aggacaaatg attgatttac
+    25561 ctattcaaag caatttacgc gagggacttt ctttgaccga atatataatt tcctgctacg
+    25621 gagcccgcaa aggggttgtg gatactgctg tacgaacagc agatgcagga tatcttacac
+    25681 gtagacttgt tgaagtagtt caacatatta ttgtgcgtag aagagattgt ggtactatac
+    25741 gaggtatttc tgtgagtcct caaaatggga tgacggaaaa actttttgtc caaacactca
+    25801 ttggtcgtgt attagcagac gatatatata tcggttcacg atgcatggcc gctcgaaatc
+    25861 aagacattgg agttggatta gtcaatctat tcataactgc ttttcgagca caaccatttc
+    25921 gagcacaacc aatatatatt agaaccccct ttacttgccg gagcacttct tggatctgtc
+    25981 aattatgtta tggtcggagt cctactcata ctgatctggt cgaattggga gaagccgtag
+    26041 gtattattgc gggtcaatca attggggagc ctgggactca actaacatta agaacttttc
+    26101 atacgggcgg agtattcaca gggggtactg ccgaccttgt acgatcccct tcgaatggaa
+    26161 aaatccaatt caatgagaat ttggttcacc ccacacgtac ccgtcatgga cagcctgctt
+    26221 ttctatgtta tatagacttg catgttacta ttcagagtca ggatattcta tatagtgtga
+    26281 atattccctc aaaaagcttg attctagtgc aaaatgatca atatgtaaaa tccgaacaag
+    26341 taattgcgga gattcgtgcc ggaacgtcca ctttacattt taaagaaagg gtacaaaaac
+    26401 atatttattc cgaatcagac ggagaaatgc actggagtac tgatgtttat catgcgcccg
+    26461 aatatcaata tggtaatcct cgtcgattac caaaaacaag tcatttatgg atattgtcag
+    26521 taagtatgtg cagatccagt atagggtctt tttcactcca caaggatcaa gatcaaatga
+    26581 atacttatgg taaaaaagat agggaaattc ttgattcttc aacgtcgaat cgaataatgt
+    26641 ccaacggcct ttggaatttt atctatcctt ctatttttca agatagttcg gatttgttgg
+    26701 cgaaaaagcg aagaaatagg ctcgccattc cattacaata tcatcaagaa caagagaaag
+    26761 aattcatatc ctgtttgggg atttcgattg aaataccttt tatgggtgtt ttacgtagaa
+    26821 atactatttt tgcttatttt gatgatccac aatacagaaa agataaaaag ggttcaggaa
+    26881 ttgttaaatt tagatatagg accctagaag acgaatatag gattcgagag gaatactcag
+    26941 aagacaaata tgagacccta gaagacgaat atgaaaccct atataaaaat gagatcctac
+    27001 aggacgaata cgaatatgaa accctagaag acgcatatgg gagcccagag aacgaatatg
+    27061 ggaatccaga gaacgaatat aggactttag agaaagattc agaagatgaa tataggagcc
+    27121 cagagagcaa atataggacc cgagaggaca aatatggaac tctagaggaa gactcagaag
+    27181 acgaatacga gagcctgggt gaaagctcag aggacaaata tgggaggact ttagaggaag
+    27241 actcagaaga agactcagaa gacgaatatg agagcccaga ggaggattcc atcttaaaaa
+    27301 aggaggattt gattgagcat caaggaacaa aagaatttag tataaaatac caaaaagaag
+    27361 tagatcggtt ttttttcatt cttcaagaac tgcatatctt gccgagatct tcatccctaa
+    27421 aggtatgcga caatagtatt attggggtgg atacacaact cacaaaaaat acaagaagtc
+    27481 gactaggtgg actggtccga gtgaagagaa aaaaaagcca tacggaactc aaaatatttt
+    27541 ccggagatat tcattttcct gaagaggcgg ataagatatt aggtggctgt ttgataccac
+    27601 cagaaagaca aaaaaaagat tctaaggaat caaaaaaaag gcaaaattgg gtctatgttc
+    27661 aacggaaaaa aattatcaag agcaaggaaa agtattttgt ttcggttcgc cctgcagtcg
+    27721 catatgaaat cgacggaggg ataaatttag caacactttt cccacaggat ctcttgcaag
+    27781 aagaagataa tctccaactt cgacttgtca attttatttc tcatgaaaat agcaagttaa
+    27841 ctcaaagaat ttatcaaaca actagtcaat ttgttagaac ttgcttagta gtgaattggg
+    27901 aacaagaaga aaaagaggag gctggtgctt cccttgtcgg ggtaagagcg aatgatctta
+    27961 ttcgccattt cctaagaatt gagttagtca agtccactat ttcatataca cgaaaaaggt
+    28021 atgataggac aagtgtaggg ccgatccccc ctaatgggtt agatcgcacc aataaaaatt
+    28081 ccttttattc caaggcaaag attgaatcac ttagccaata tcaagaaact attggcacct
+    28141 tgttgaatcg aaataaagac taccaatctt tgatgatttt gtcagcatcc aactgttttc
+    28201 gaattggttt attcaagaat tcaaaacatc ccaatgcaat aaaagaatcg aatcctaaaa
+    28261 ttcctattcg agatattttc gggcccctag gggctattgt acctagtata ttgaattttc
+    28321 cttcatctta ctatttacta acgcataatc agagccggtt aaaaaaatat ttgttgcttg
+    28381 acaatttaca acaaaccttc caagtacttc aaggacttaa atattcttta atagatgaaa
+    28441 atcaaaggat ttctaatttc gatagtaatc tcctgttgga tacattcttt ttgaattatc
+    28501 actttgccca tcatgattct tgggagaaca cattggcaat aattcacctt ggacaattta
+    28561 tttgtgaaaa tgtatgttta tttaaatcgc acataaaaaa atcaggtcaa attttcattg
+    28621 ttaatatgga ttcctttatt ataagagaag ctaaacctta tttggccact acaggggcaa
+    28681 ctgttaatgg tcattatgga gaaatccttt acaagggaga taggttagtt acgtttatat
+    28741 atgaaaaatc gagatcgagt gacataacgc aaggtcttcc aaaagtggaa caaatctttg
+    28801 aagcgcgttc aatcgattca ttatctccga atctggaaag gagaattgag gattggaatg
+    28861 agcgtatacc aagaattctt ggtgtccctt ggggattctt gattggagct gagctaacca
+    28921 tagcccaaag tcgtatctct ttggttaata aaatccaaaa ggtttatcga tcccaagggg
+    28981 tacagatcca taatagacat atagagatta ttatacgcca agtaacatca aaagtgcggg
+    29041 tttccgaaga tggaatgtct aatgtttttt cacttgggga gttaattgga ctattacgag
+    29101 cggaacgagc aggacgagct ttggatgaat cgatctatta tcgagcaatt ttattgggaa
+    29161 taacaagagc ttcccttaat acccaaagtt tcatatctga agcaagtttt caagaaactg
+    29221 ctcgggtttt agcaaaagct gccctacgag gtcgtattga ttggttgaaa ggcctaaaag
+    29281 aaaacgtagt tctgggggga attatacctg ttggtactgg attccaaaaa tttgtgcatc
+    29341 gttccccaca agacaagaat ctttatttcg aaattaaaaa aaaaaatata ttcgcttcgg
+    29401 aaatgagaga ttttttcttt ctccatacag aattagtttc ttctgattct gacgtaacaa
+    29461 acaatttcga tgagacatca gaacccccat ttaccccatt tataaccatt taaggataca
+    29521 taaagcagat tttttttact ttacctttac tatacttttt tactttacta tacttttgaa
+    29581 cttagactta gaacactaac aggtaaaatg tgagattttt attaagtaaa agaagtcagt
+    29641 taattcatta aggttatgtt tatatcatgt atgaatagcc aactctcagt agaaggttcc
+    29701 ctcggaacaa ttattatata tttcaagtta tttcggatct ttcttaatct tcaaaaagat
+    29761 attccctaat ggaatggtag gatgaaaaaa agaaaaaata aaaaggaagt gtggaaaaaa
+    29821 tgacaagaag atattggaac atcaatttga aagaaatgat agaagcggga gttcattttg
+    29881 gtcatggtat taagaaatgg aatcctaaaa tggcccctta catttcggca aagcgtaaag
+    29941 gtactcatat tacaaatctc gctagaacgg ctcgtttttt atcagaagct tgtgatttag
+    30001 tttttgatgc agcaagtcag ggaaaaagtt tcttaattgt tggtaccaaa aaaagagcag
+    30061 cggatttagt agcatcagct gcaataaggg ctcgttgtca ttatgttaat aaaaagtggt
+    30121 tcagtggtat gttaacgaat tggtcaatta cgaaaactag actttctcaa tttagagact
+    30181 taagagcaga agaaaagatg ggaaaattcc accatctccc aaaaagagat gtggcaatct
+    30241 tgaaaagaaa attatctacc ttgcaaagat atctcggcgg gatccaatat atgacgaggt
+    30301 tgccagacat tgtgatcgtc cttgatcagc aaaaagagta tatagctctt cgggaatgtg
+    30361 ccattttggg gattcctact atttctttag ttgatacaaa ttgtgaccca gatctcgcga
+    30421 atatatcgat tccagccaac gatgacacta tgacttcaat tcgattgatt cttaacaaat
+    30481 tagtatttgc tatttgtgag ggccgttctc tctatataag aaacctttaa ttaagaagaa
+    30541 tagtgaattc ttgggcaact ccatagattt ctggaatcac ttactattct tttttgtttt
+    30601 gcatagataa aagaagggga atattgatat atattagagg gtattgatat atattatgat
+    30661 ctgatgtgct ttcttagtac cctaaatata acattaatac ttcaagttgc tgagttgaga
+    30721 aagagatggt tgaatcaaaa caataccttt tttgaagttc aatttttatc agaggacaat
+    30781 atgaatatta taccttgttc cattaaaaca ctcaaggggt tatacgatat atcaggtgta
+    30841 gaagtaggcc aacacttcta ttggcaaata ggaggtttcc aaattcatgc ccaagtactc
+    30901 atcacttctt gggtcgtaat tactatcttg ctaggttcag ttctcatagc tgttcggaat
+    30961 ccacaaacca tcccgaccga cggtcagaat ttctttgaat atattcttga gtttattcga
+    31021 gacttgagca aaactcagat tggagaggaa tatggtccct gggttccttt tattggaact
+    31081 atgttccttt ttatttttgt ttcgaattgg tcgggtgctc ttttaccttg gaaaattata
+    31141 gagttacccc acggggaatt agcagcgccc acgaatgata taaatactac tgttgcttta
+    31201 gctttactca cgtcagcggc atatttttat gcgggtctta gcaaaaaagg attgagctat
+    31261 ttcgagaaat atattaaacc aaccccaatc cttttaccaa tcaacatcct ggaagatttc
+    31321 acaaaaccat tatcgcttag ctttcgactt ttcgggaata tattggcaga tgaattagtc
+    31381 gttgttgttc ttgtttcttt agtcccctta gtagtcccta taccggtcat gtttcttgga
+    31441 ttatttacaa gcggtattca agctcttatt tttgcaacat tagccgcagc ttatataggt
+    31501 gaatctatgg agggtcatca ttgaattgac tagttttgga aatagtcttt ttttccgctt
+    31561 agctcaattc atgcatggtt ccagataatc cgcttggttg caaaaaattg ttagaaatgc
+    31621 gtatgaatat acaacttaga gttgtaggac ttagaatccg attcaataga aaatgagaaa
+    31681 atacgcaaac caaatagaag aaacagatgt atataggata ttatatattc ctaagttaga
+    31741 ttgattatct aatccgatct atcgaattcc ctctatgtag ttcggacaat tcacattatc
+    31801 ttttcaattt gtacttttta gttacttctc cccaatagag cttagaagta agaatttctt
+    31861 ggttgattgt atccttaacc atttcttttt tttgacacga ggaactcacc atgaatccat
+    31921 taattgctgc tgcttctgtt attgctgctg gattggccgt agggcttgct tctattgggc
+    31981 ctggggttgg tcaaggtact gctgccggac aagctgtaga aggtattgcg agacagccag
+    32041 aagcagaagg taaaatacga ggtactttat tgcttagtct agcttttatg gaagctttaa
+    32101 caatttatgg actagttgtg gcactagcgc ttttatttgc gaaccctttt gtttaatcga
+    32161 aaaaataaaa taagttcttt cgattagata ctttgtttct ttttttagtc aattgttatt
+    32221 tgtttctgga attccaatta tatcaatacc ttatttaatt tactcctatt tattattccg
+    32281 ggaatttttt atttatcgag acagacaata tcccacccag gaagggctga gttgagtatg
+    32341 attaatttat agtatatgct cgccttcttc cttcccatcc ttagtttagg aaagtggaaa
+    32401 gtccttttcc ttttatttaa ggaagtcttt cacaggtcaa acgagaccta agacttaatc
+    32461 taaaataaat tactagattg aatctatttg cattaaaaaa accgatcaaa aaagggcgag
+    32521 cgaagcaagt gatcaaaaac tttgttcgtc ctatctataa gaggagagca tatgaaaaat
+    32581 gtaacccatt ctttcgtttt tttagctcac tggccatccg ctggcagttt cgggcttaat
+    32641 accgatattt tagcaacaaa tctaataaat ctaactgtag tggttggtgt tttgattttt
+    32701 tttggaaagg gagtgtgtgc gagttgtcta tttcaagaat aggttggatc tatccgactg
+    32761 cactttagaa tatttcgtag tatttttcgg ataaataagg gtgcgcaatc tcgacgaatt
+    32821 acttctgaat aaattcagaa atcatatgga agaaccatag catttcgcga ctcgttggta
+    32881 aatcaacttt gattctctat aaaccaatta atgtgagact attaacacgg ttaaagctaa
+    32941 actgcttgaa gtccaggcaa aaaggggtac tctttctaca cctatattag tattagtacc
+    33001 gaaatgcttt aaacgggaaa tagctaatgt agaatttatc tgatatagaa cactcatatc
+    33061 gataaaatgg tttgaactat ttactagaaa aaaggaggca ccctgccctt ttttatcgaa
+    33121 tgccgaatcg acaacctatg tataaaataa aaaaagagaa attttttgga tttgaagaaa
+    33181 aaaaagactt cgattcattt tctatttatt tcgttagttt ttcttaatga aattgaaatt
+    33241 cttaagtaaa gtgcaaatac aaataaagaa acaactttgc tgaccatgat agatttttat
+    33301 ctaggcggaa gagtcctctt aatatttatc taatcttata taggtttcag tatattgaaa
+    33361 tagaaagata aaatagaaga gagaggatag gctcattact taaaaaaaag atatggaaat
+    33421 agccatagca aaaaaagaaa aaaggagcgt gagagccaaa tgaatcgaaa gattcatgtt
+    33481 tggttcggga agagatcata aaagttgtaa acttaatagc aagataatct actttcatta
+    33541 aaagatttat tagataatcg aaaacagagg atcttgagta ctattcgaaa ttcggaagaa
+    33601 ttgcgtagag ggacctttga gcagctcgaa aaagctcgga ttcgattaca gaaagtcgaa
+    33661 ctagaagcgg atgagtatcg aatgaatgga tactctgaga tagaacgaga aaaagaaaat
+    33721 ttgattaatg ctacttctat tagtttggaa caattagaaa agtctaaaaa cgaaaccctt
+    33781 tattttgaaa aacaaagggc aatgaatcag gtccgacaac gggttttcca gcaggccgta
+    33841 caaggagctc taggaactct gaatagttgt ttgaataccg agttacattt ccgtacgatt
+    33901 cgtgctaata ttggcattct cgggtccatg gaatggaaga gataatgaaa ttaataaggc
+    33961 cttgagcttc tactttcgtt tagaatttag gcattatttt tccccttagc ttccgaaaaa
+    34021 aaagagtcaa gaaacactaa tggcaactct tcgagtcgac gaaattcata aaattctccg
+    34081 tgaacgtatt gaacaatata ataggaaaat agggattgag aatataggtc gcgtagttca
+    34141 agtgggggat gggattgctc gtattatagg tcttggtcaa ataatgtcag gtgaattagt
+    34201 cgaatttgca gaaggcacta ggggtattgc tcttaatttg gaatccaaaa atgttgggat
+    34261 tgtattaatg ggcgatgggt tgatgataca agagggaagt tttgtaaaag caacaggaag
+    34321 aattgctcag atacccgtga gcgaggctta cttgggtcgt gttataaatg ctctggctaa
+    34381 acctatagat gggagaggtg aaattatagc ttcggaatct cgcttaattg aatcccctgc
+    34441 tccaagtata atttccaggc gttccgtata tgaacccctt caaacagggc ttattgctat
+    34501 cgattcgatg atccctatag ggcgcggtca gcgagagtta attattgggg acagacagac
+    34561 tggcaaaaca gcagtagcca cagatacaat tctcaatcaa aaagggcaag atgtaatatg
+    34621 tgtttatgta gctattggtc aaagagcatc ctccgtggct caagtagtaa ctactttcca
+    34681 tgaggaggga gccatggaat acactattgt agttgctgaa atggcggatt cacctgctac
+    34741 attacaatac ctcgctcctt atacaggagc cgccctggct gagtatttta tgtaccgcga
+    34801 acggcatact ttaataattt atgatgatct ctccaaacag gcacaagctt atcgccaaat
+    34861 gtccctttta ttaagaagac ctcccggccg tgaagcttat ccaggggatg ttttttattt
+    34921 gcattcacgc cttttagaaa gagccgctaa attaaattct cttttaggcg aaggaagtat
+    34981 gaccgcttta ccaatagttg agactcaatc tggagacgtt tctgcctata ttcctactaa
+    35041 tgtaatctcc attacagatg gacaaatatt cttatccgcg gatctattca atgccggaat
+    35101 tcgacctgct attaatgtgg gtatttctgt ttccagagta ggatccgcgg ctcaaattaa
+    35161 agccatgaaa caagtagctg gcaaatcaaa attggaacta gctcaattcg cagagttaca
+    35221 agcctttgca caattcgcct ctgctctcga taaaacaagt cagaatcaat tggcaagggg
+    35281 gcgacgatta agggaattgc ttaaacaatc ccaggcaaac cctctcccag tggaagagca
+    35341 gatagctact atttataccg gaacgagagg atatcttgat tcgttagaaa ttgaacaggt
+    35401 aaataaattt ctaggtgagt tacgtaaaaa cctaaaagat actaaacctc aattcaaaga
+    35461 aattatatct tctagcaaga cattcaccga gcaagcggaa atccttttga aggaagctat
+    35521 tcaggaacag ctcgaacggt tttcccttca ggaacaaaca taaatttagc atgtctactc
+    35581 ttgttagtag aagaggaatt gttgagaaaa atttttgatt taaatcatca aaaaaaattt
+    35641 tcttagtttt taatatagtt atttaaagaa tagatagaaa taagattgcg tccaatagga
+    35701 tttgaaccta taccaaaggt ttagaagacc tctgtcctat ccattagaca atggacgctt
+    35761 ttcattagta ttttttagac aatggacgct tttcattagt attttcttgt tccgagaaaa
+    35821 aactgttaga acgaaactct tttaggaaat aaaaaaaccc atatacaaat gctagtggga
+    35881 atcgaaccca caaccccaag gttatgagac ttgtgagcta ccagactcct ctatcctctt
+    35941 aaactaaaga ggggagggta gaactagtgg ataaaagagt gttggatacg cccctctacc
+    36001 atatccatac aaatagaata gtccatttat acagaatggt aaagagggct gttctacgat
+    36061 catcaattca agaaatccat acaaatacga aagggtattt tatccttacc aactggatct
+    36121 tgttgcaccc ggtaacaaac attcataaac catttctcga agtacgtgcc cggatagccc
+    36181 aaaatctcga tagttagctc taggtcttcc agtcaaaaaa caacgtcgat gaaggcgtgt
+    36241 aggtgcacta ttacgtggta gggattgcaa tttttctcgc attttcgttt tttcactcaa
+    36301 actcaagggg gaaactttgc ttcttatctt tttttttaaa gattggcgaa tcaaatgata
+    36361 tttttgttct aatttctgcc gcttcttttc cctctgaatc aaactttttt ttgccataat
+    36421 gtcctgttac tattattcac aaatatacag ttctaatcct agatggaaaa ataaatagaa
+    36481 aaaaatctaa gaaggcgatc tccctctcta tcaagagtaa tgaactaggt gctaatacag
+    36541 tacaaaaaaa actaactaaa ttaaccaaac ttacctgatg ttgaggcaat caagaaagct
+    36601 gcataagtga atatataacc cacagaaaag tgggctaatc caaccaatct tgcttgcaca
+    36661 atggaaagag ccacgggctt atctctccag cgaattaaat tagccaaagg tgtgcgttca
+    36721 tgagcccatg ctaaagtctc aattaattcc tgccaatatc cacgccagga aattaagaac
+    36781 ataaatccag tagcccaaac aagatgtcca aataagaaca tccacgccca taccgataaa
+    36841 ctattcatcc caaaaggatt atatccattt ataagttgtg aagaatttaa ccataggtaa
+    36901 tctcttaacc atcccatcaa ataagtggag gattcattaa attgtgaaac gttgccctgc
+    36961 cataatgtga tatgtttcca atgccaataa aaagtaaccc atccaatagt atttaacatc
+    37021 cagaaaactg ccaaataaaa cgcgtcccaa gcagaaatat cacaagtacc gccgcgtcct
+    37081 ggaccgtcac aaggaaaact atacccaaaa tcctttttat ccggcattaa tttggaaccg
+    37141 cgtgcatcta aagcaccctt tactaaaatc aatgtagttg tatgcaaacc tagagcaata
+    37201 gcatgatgaa ccaagaaatc cccaggtcct attgttaaga aaagcgaatt actattctca
+    37261 ttaacagcat tcaaccatcc gggcaaccat aggcttcgac ctgcattgaa agcggggcca
+    37321 ttcgttgaag ataagagtat atcgaaccca tatgtcgtct tgccatgagc agattgtatc
+    37381 cattgggcaa atataggttc gatcaagatt tgcttttctg gagtaccaaa agcaagcatg
+    37441 acgtcgttat gaacataaag gcccaaggta tggaatccta gaaagaggct agcccaactt
+    37501 aaatgagata tgatagcttc tttatggtct aacattcttg ccaatacatt atcctcattc
+    37561 tgttctggat tgtaatccct aatgaaaaag atagctccat gagcaaaagc ccctgtcatg
+    37621 atgaaccctg caatatattg gtgatgagta tataaagcag cttgagtagt aaagtcttgc
+    37681 gctatgaatg cataagcagg taaagagtac atatgttgag ctactaagga agtaataacc
+    37741 cctaaagaag ctagagcaag acctaattga aaatgaatcg aattattgat tgtgtcgtaa
+    37801 aggcccttat gcccccgccc taatcgaccc cccggaggag tatgcgcttc taaaagatct
+    37861 ttgatactgt gtccaattcc gaagttagtt cgatacatgt gaccggcaat gagaaaaata
+    37921 aatgcaatag ctaaatgatg gtgcgcaata tcggtcagcc acaaactttg tgtttgtgga
+    37981 tggaatccac caagaagagt tagaatggca gttcccgctc cttgagtggt accaaataaa
+    38041 tggttactcg aatcagggtt ttgggcataa agattccact ggcccgtcaa aaggggcccc
+    38101 aacccctggg gatagggtaa tacatctaag aaattattcc atcgaacgta ctcccccctg
+    38161 gatgcgggaa tagcaacatg aattaaatgt cctgtccaag ctaaagaact taccccgaaa
+    38221 agtcctgaca aatgatgatt gagacgagat tccgcgtttt tgaaccacga aagacttggt
+    38281 ttccatttgg gttgtagatg taaccaaccc gctattaaag atagcgtaga aagaaataat
+    38341 agaaaaagag ctccagtata aagatcttca ttcgtgcgta atcctattgt ataccaccac
+    38401 tgataaaccc cagaataggc gatattcact ggaccggcag cacctcctcg agtaaaggct
+    38461 tccacagcgg gttgaccaaa atgaggatcc caaatcgcat gagcaatagg tcttacgtgt
+    38521 aaaggatcct gtatccatga ttcaaaattt ccttgccaag ctacatgaaa cagatttccg
+    38581 gacgtccata gaaagattat tgctaactgc ccaaagtgag aagcaaaaat gttctgataa
+    38641 agacgttcct cagtaatatc atcatgactt tcgaaatcat gtgcggtagc aataccaaac
+    38701 caaatacgac gagtagtggg gtcctgagct aagccttggc taaacctggg aaatcttaat
+    38761 tccataatgc ctttcaaatc ctcctagcca ctatcctact gcaataattc tcgctaagaa
+    38821 gaatgcccat gttgtggcaa ttccacctag aaggtaatgg gttactccta cagcacgtcc
+    38881 ttgtataatg ctcaaggctc taggctgagt agcaggagca acttttaatt tgttatgagc
+    38941 ccaaacgata gattcaataa gttcttgcca ataaccacgg ccgctgaata aaaacattaa
+    39001 actgaaggcc cagacaaaat gagcacctaa gaaaaaaaga ccatatgcag ataatgaaga
+    39061 accataagac tgaattactt gcgatgcctg tgcccacaag aaatctcgaa gccacccatt
+    39121 aatcgtaatg gaactctgtg caaagttccc ccctgtgata tgagttacca ccccttgatc
+    39181 acttatagta ccccaaacat ccgattgcat tttccaactg aaatggaaaa tgactaccga
+    39241 aattgcattg tacatccaga ataaacctaa gaaaacatga tcccaagcag atacttgaca
+    39301 tgttccgcct cgcccaggcc catcgcaagg aaagcgaaaa ccgagatttg ctttatcggg
+    39361 tatcaaacgg gaactgcgag caaataaaac acctttcaaa agtattaata cagtcacatg
+    39421 gatggtaaat gcgtgaatgt gatggactaa aaaatctgca gttcctaatg gaataggtaa
+    39481 caaagccact ttgccgccta ctgctactaa ctcgccacct ccccacgtta aactggtact
+    39541 tgttgttgca ccaggagctg ttacaccagg cgcgttagca tggatatttt gtacccattg
+    39601 agcaaagata ggttgtaatt gtatggcagt atccgaaaac atatcttgcg gacgtcctaa
+    39661 agcactcatg gtatcattat gaatgtacaa accaaaactg tgaaaaccta gaaatataca
+    39721 tacccagtta aggtgggata tgattgcatc acggtgtcta aggacgcgat ctaatagatc
+    39781 attgtatcga gtagttggat catagtctct taccataaaa attgctgcat gtgcagcagc
+    39841 accgactatt agaaatccgc caatccacat gtggtgtgtg aacaaggaaa gttgtgtacc
+    39901 atagtcagta gctaggtatg gatagggggg catagagtac atatgatgag ctacaacaat
+    39961 ggttgtcgag cctagcatag ctaggttaag agctaattga gcatgccatg atgttgttaa
+    40021 gatttcatag agacccttat ggccttgtcc tgtaaatggg cctttgtgag cttccaaaat
+    40081 atctttaagt ccatggccaa taccccagtt ggtcctatac atatgacctg caattaggaa
+    40141 aagaatagca atagctaagt gatggtgcgc aatatcggtc agccatagac caccggttac
+    40201 tggatctagt cctccgcgaa aagtaagaaa ttctgcgtat ttggaccaat ttaaggtgaa
+    40261 aaaaggggtt gctccttcgg caaaactagg ataaagttga gccaaaaggt cgcgattcaa
+    40321 gataaattca tgaggaagtg gtatctcttt aggatcaacc ccggcgtcaa gaaattggtt
+    40381 aattggtaaa gatacatgaa tttggtgtcc cgcccaagaa agagacccaa gtcctaataa
+    40441 tcccgctaag tggtgattca acatggattc tacatcttgg aaccaggcca attttggagc
+    40501 ggctttgtga taatggaacc aaccagcaaa aagcattaac gatgcaaaaa tcaatgcacc
+    40561 aattgcagta caatagagtt gtaattcact agttattcca gaggctcgcc aaatctgaaa
+    40621 aaacccagag gttatttgga ttcctcggaa acccccgcct acatcaccat tcaatatttc
+    40681 ttgccctact attggccaaa ctacctgagc actgggtcca atgtgagtag gatcacttag
+    40741 ccatgcttca taattggaaa aacgggcacc atggaagtac atgccactca accaaagaaa
+    40801 gataatggag agttgcccga aatgagcact aaagactttt cgagagatct cctccaaatc
+    40861 acccgtatga ctatcgaaat cgtgagcatc agcatgtagg ttccagatcc aagtggtagt
+    40921 atcagggccc ttagctagtg tttttgagaa atggccgggt ctggcccatt cctcaaaaga
+    40981 tgtttttaca ggatccctat ccacaataat ttttacttct ggttccggcg aacgaataat
+    41041 cattaagtcc tcctctttcc ggacaagaca tataaagaga cctgccaact gtctttttag
+    41101 tgaatctttg aaagatagat tttgaaagat agatattatg attagttctt ttctttacta
+    41161 tctaccgtcc ttctattttt ttatagttat tcactggagc aattatatat tgaagtcaat
+    41221 cctaggcaag tgttcggatc tattatgaca taaggattag gtgcctaacg gacattatat
+    41281 atcttgaaaa aaaaatatat atatatatgt atatatttcc cgatgtaaga aaaaaatctt
+    41341 tttaaaattt aataaactgg tgtatttttt tttgagagta taagctccta tctacatcta
+    41401 ctttccttga gcgtaatata ggatttttta tttgattcta aattccaaga taactcatta
+    41461 gaattattta agaattaata agatggtctt gatatattag cagtatttag attgcccctc
+    41521 tttttattcg ctttattact tctattctag atcctatccc tctggtttat ccttataaaa
+    41581 tctcatataa aatagaaggt agaagaaaga cgaacgggat ataatgaaat tcttgattcg
+    41641 atcttacgac ctaatttata tgaaaaagga acgtggtctt attcaaattc aaagcgcttc
+    41701 gtaatcttca accagttctg tgcttcaata taatttcccg gagtaagcgc tatagcttgt
+    41761 ttccaatact cagcagcttg atcaaaccaa gcttctgcaa tttctgaatc accctgtaga
+    41821 atggcctgtt ctcctcggtc ggaataggca gttccttccc ctagaaccgt acttgagagt
+    41881 ttcctacctc atacggctca gaaattgcta tcttaatttc ccctatctta actgaattcg
+    41941 atttttgaaa aatcgatcca atttgttttt gggttaagca gaagaagtta attacctaag
+    42001 tttcaaaccc taatttttat aactaatcag tttgatcttt tttcccacct tcagaagaat
+    42061 gaagcataga tagatcgaga gctttcgttc gaattttctg aaaagtaact atcccggttt
+    42121 catatatgaa atccctatag aatccttgaa aaagactttt tcccataaga taagaaagaa
+    42181 aaaagaactt actatctttg ggatctgata ctacaccgct gcttaatccc ttagtggatc
+    42241 ggctctatta cataagcaga ttcctaaact ttgccccata tcatgggata agtaagcagt
+    42301 tttttttagt tgtatcgacc aagtcgctca ctaattgatc tttacggtgc tttctctatc
+    42361 aatttgagaa ctttatccat agagtagtag tataggccat actttcttcc ttttttgatt
+    42421 ctcgtgaagt gtctttcctt cctacagctg atagggaaaa atcgttgttt ttacgacccc
+    42481 tatgtagaaa gacccttttg tctagtattt actagaaaat ttgattcttt ctttttttct
+    42541 ttctatagtg gagatagtcg cacgtaatga cagatcacgg ccatattatt aaaagcttgc
+    42601 ggtaagaagg ggtttcgctc tagtgcccgg aaataatatt ccaaagcctt tgtatgctct
+    42661 ccattgcttg tgtgtataag gcctatgtta tagagtatat aacttcgatc gtagggatcg
+    42721 atttctagtc gcgtagcttc ataataattt tgcaaagctt ccgcataatt tccttcggat
+    42781 tgagccaaca tccgttacgg tcgttcattc tattcaaaaa atctccgttc caaaaccgta
+    42841 catgaggttt tcatctcata cggctcctcc cttctgtaca tagtactaag cgaaataatc
+    42901 tatagaatca aattagtccc gtctcattat ggaccgaaag gggctggtat ttttccaaga
+    42961 aatctctagc caaccttccc gcaagaggtt tttcctaaca ccaatgaatt ctatgaattc
+    43021 tattaatgct agaggaaaat catagctcca agaatttctt tgttctcaac gccttctatt
+    43081 tagaggaatt agccacttca acgatctttg atggttatag gggtatccaa agtacaaacc
+    43141 tgatggttgt ttattatccc aaccattctt cccagccctg atatcgatca ggaaagggtt
+    43201 aatttataac aaagtttttc tcttgttgat tcctattttt aggtgtagtg cttttctccc
+    43261 ctatgtgctg cctattggta ctaatagagt aggattggcc tgtaatccat aacctatcct
+    43321 gttaggtgta acctttcgct caatacttaa atctacaatt gaagcatctg aggccgcatc
+    43381 aatcgaggat acacgataga aggaattgtt aattaacctc accttcccaa agcgtgggtt
+    43441 tgctttacta attttgttct ctctatgcga accccctctc cttatcagaa gactgaggtg
+    43501 taggtagggc taaaaaaaac aaaaaaaaag agtcaaatcg caccatctct ataataagta
+    43561 aatgcccttt tttcccctga ggttgttgga attattcgca ataaaatatt ggctacaatt
+    43621 gaggaggtct tatcaatgaa atttccattt acacgggatc taggcataat tcccaaccca
+    43681 ttctatgata aaattgtttt cattccttca caaaataaca taaaaacaaa cacatttgat
+    43741 tcttataact agatcgatcc atatgctcta aatcgataag agaggtatgg attttccgct
+    43801 cagctttaat tttttccttt tctttctgtt tggacaagaa gatatattaa atatttgact
+    43861 aagactgggt ttgattctac tttcctattt ctcaacaaca acttcgctca tcagctattt
+    43921 cgtgttttca aagttattaa ttgtctcata ccttattttc gatttcgata gtctggtgta
+    43981 gcgtacctta tgcaaacaga attctaaggt ttctttattt tattatgcaa taagaagaat
+    44041 tcttccattc tctttttctt tggttttagg aaaatccaaa ctaaaacttt tataggggaa
+    44101 gcaattccta gtaaaaaaat cctggatcct tccacttaac ttagatcaaa aggaattttt
+    44161 ccaatagaac tatggaaccc ctgagcggtt gtacttgtac tgcaggaata ggaaaactcg
+    44221 ctatttactc agtttatttg ccataatgag ttatgtggga gagatggccg agcggttcaa
+    44281 ggcgtagcat tggaactgct atgtagactt ttgtttaccg agggttcgaa tccctctctt
+    44341 tccgtttttc ttaattcatc aacgttaagg agcacagtgt atcaaatcaa ataacaattt
+    44401 attccagcaa taataccctt acccttattt aatagaaatt ctctatagca aattactgtg
+    44461 gtatgtaaaa atacacatag agaaaagaac aaaaaagaaa aaaggatcct cgggttaatc
+    44521 catttttgct agttgagtag gaaaatacga attagggcct taggtcgatt tagttcggga
+    44581 aaaggggaag aaaattctat gaacctttcc ttttttcgtt aagttcaagt ctgacgagag
+    44641 taatattcta caactaacaa ctcatttatt ttgagaccta cccacttcct atctaggatt
+    44701 ttatttacta gtcctttata ttccaatgtg tcaatcgtca aatgctttgg caattttccc
+    44761 gggtcggatg aagcaataga attttgaacc agactttgtg atctttggtt atctttcgta
+    44821 gtaataatat ctcgaggttt gcaacgaaaa cttggtatat taactatacg accattaacc
+    44881 aaaatatgtc tatggttgac taattggcgg gccccaggaa tggttgccgc catacccaat
+    44941 cgaaaaagga tattatccaa acgcatttca agtaattgta gtaaaacctg acctgtggac
+    45001 ctttttgctt ttccagcgat atgtacatat ctaagtaatt gtcgttctgt cagaccataa
+    45061 tgaaaacgca atttctgttt ttcttgaaga cgaatacgat attgctcctt tttcccagaa
+    45121 tggaatttct ttttcagatt acttccggat ttaggtgttt ttctagtgag tcctggtaaa
+    45181 gctcccagac ggcgtatttt ttttaaacga ggtcctcgat aacgggacat gaagactcct
+    45241 tttttatttt attgaaattt cattttacac aattaatttc attgtattta cattacggaa
+    45301 tacatcgaaa ttaaaactga attaaactaa aggataaaca gagtaaaatc aactaaagta
+    45361 ccataaaaaa tagaatttca tcaacatctg gattttttgt atatatatta tttattttat
+    45421 tcttttgtat ctagcaaaat tgtaaggtag aaaacaaaaa agatcctgga ttccccattt
+    45481 aatccgaaaa aaaaaagaga ttcttgttcg tagaacatcg ataacgaaaa aaaagccgac
+    45541 tatcggattt gaaccgatga ccctcgcatt acaaatgcga tgctctaacc tctgagctaa
+    45601 gtgggcttag atagcagaaa tagtgtaaca aatagaaata ggtatagtat agaaatccgt
+    45661 aaaatctgag atcttagtta ttaatcttag ctattaacta gttctcaatt tgaagttcta
+    45721 cttaaaaaaa tactagaact ttttaaagat aaagttagct tgatatgctt aactagagga
+    45781 tatccttaaa taaaagtata gaatttattg aactttcttt ttatttctct aattcgcaaa
+    45841 tcttttttct aagagttgat tccaatttct atattgaatt tgatttcaga tattttcaat
+    45901 ttgatatagc tcggacgaat aatctaatac atagaaaaga aatatatata tatattatga
+    45961 aatatattaa agatataata atatatatat attaaagaaa taataagggg aaaatacgaa
+    46021 tttattggtg ttttcattcg atcattatag acattttttt agatcttttt ttatttgtta
+    46081 ataatttgag gattcctatt tctctaagga gaacataaag tcatagcaaa taaaattgcc
+    46141 aattttgagt agaaaaaaaa tgaatatcaa gcgttatagt atgattttta atactctaaa
+    46201 aaagtaagat gagcggtggg ggagagaaaa attttgggat atattgattc ggattgaatt
+    46261 gcaaatacag caacgataga atcaatgcaa ttctgaattg caataaacaa gcgtggtctc
+    46321 tcaaatagaa tcgaactgct agatgacgtc gagtgatgaa ttcaacgatt ccaaaaaaac
+    46381 taagagatgg atgaaattac gcaaggaatc caggtctcaa aaaaaaagga aaatggggat
+    46441 atggcgaaat cggtagacgc tacggacttg attgtattga gccttagtat ggaaacctgc
+    46501 taagtgttaa cttccaaatt cagagaaacc ctggaattaa aaaagggcaa tcctgagcca
+    46561 aatccgtgtt ttgagaaaac aaggggttct cgaactagaa tccaaaggaa aaggataggt
+    46621 gcagagactc aatggaagct gttctaacga atcgagttaa tttatttagg ttgttttggt
+    46681 agtggaaatc cttttaaatt agagaaagaa gggattttta catctaataa acacgtatag
+    46741 atactaacat agtaaacgat taatcacaga atccaagtat aacataggtt ctttattctt
+    46801 ttttagaatg aaattaggaa ggattatgaa ataaaaaatt aataaatttt ttagaattat
+    46861 tgtgaatcca ttctaattga atcttgagta atcaaatcct tcaattcaaa gtacttgaga
+    46921 tcttttaaaa agtggattaa tcggacgagg acaaagagag agtcccattc tacatgtcaa
+    46981 tactgacaac aatgaaattt cgagtaaaag gaaaatccgt cgactttata agttgtgagg
+    47041 gttcaagtcc ctctatcccc aaatcctttt tattccccaa ctatcctctt ttattcccta
+    47101 acttttatcc tctttttttc tttttatcaa tgggtttaag attcattagc tttctcattc
+    47161 tactctttca caaaggagtg cgaagagaac tcaatggatc ttatcctatt cattgaatag
+    47221 atttcttttt tattagagta tccgcaagga ctctcggtta ttaactctat ttttaagtat
+    47281 tattaagtaa tccatgcaca atgcatagga ccaccccccc atttttcaat ttggaatttg
+    47341 aaatacttta attgattttt gagtcccttt aattgacata gatacaaata ctctactagg
+    47401 atgatgcaca agaaaaggtc aggatagctc agttggtaga gcagaggact gaaaatcctc
+    47461 gtgtcaccag ttcaaatctg gttcctggca gagaaaaaaa agatctaccg aataggtttt
+    47521 gataaaaatg cctcaagatg gattaggata catattcgtt aatactataa ataaagtctg
+    47581 atttattcat ctaggtggat aagtctctaa tatagaggca cttctttttc tttttagaga
+    47641 agggtaaaaa tctctggttc ttttctttat ggtacagaag gaggtgagat taggttcccc
+    47701 tttatttttt tttgcatttc ttaattttgt attctgcata ttacgacgaa tattttttta
+    47761 ttcttgctta tcttactttt ccaattgtgc taagtcatgc gcgcgataca aagttcgtgg
+    47821 tagagaactt ctttgagtca tcatattttt ctgttcatat gagggaaatt catatgtgat
+    47881 tttccaaata agggaatcca aatgaaaccc tttttttgct cagtctatct ggactacttt
+    47941 tgtataatag gaattaattc gaaataggta ttccgtttca tctaggaaca gaacgtaaaa
+    48001 attttccttt acttgaataa aatctggagt tgtgttgtat aagtccgcat gaatttctta
+    48061 tcattcaatg agcatcttgt atttcataga aattgggggt tatatagtcc ttacgtaagg
+    48121 gccagcctac ccaactttca ggcattagga tacgtttaag gcgcggatga ttatcataag
+    48181 agattcccac catatcataa gattcgcgtt cttgaaaatc ggcacttctc caaatccaga
+    48241 agacagacgg aattctagga ttatcctttt gggcaaagac ttttatgcat acttcttctg
+    48301 ggttatctat gccatactgt attctcgtaa gatgatacac gctagctaaa gatccaccgg
+    48361 gtgctacatc ataagcacat tgggagcgta aataattgta accatatacg tataaaatga
+    48421 cagcaatgga atcccaatcc cccgctttta tttgtaaagt ctctattcct cggtgatcaa
+    48481 agcccaaaga tctatgaacc accttatgtt tgactagcca attagataac caaccctgct
+    48541 gcattgtctt gatctctccc tctttgtttt gtataaatat ttcacatttc ggatgcaagt
+    48601 ttcaaagatt gccttgcttt ttatttttct agacaaaaga acccccctcc taattcacta
+    48661 atttgtagga aggtactata cttttggatt tgtaaaaatt ttcagaagat atatctaaag
+    48721 tagatggtga ttgatagagc aattcttgct cgtaagttcc agtatgagta ctgcgccgaa
+    48781 cataaagctt gtgactggta gtaaaacatc ggtttttatt ttgagatcga attcgatcct
+    48841 caactatttc tcgcgatatc ttcttacgaa gttttgttag ggcatctata accgcctccg
+    48901 gtttaggtgg gcaacccggc aagtagacat ccacaggaat taacttatca actcctcgaa
+    48961 cagtactata ggaatccgta ctgaacattc cccctgtaat agtacaagct cccatagcaa
+    49021 tgacgtattt tggttcaggc atttgctcgt ataacctcac taaagaagga gccattttca
+    49081 ttgttactgt accagctgtt aaaattaggt ccgcttgcct aggacttgat cttggtacca
+    49141 atccataacg atcaaagtcg aatcgcgagc ctattaatga agcaaattca atgaaacaac
+    49201 aactggtacc gtatagaagg ggccataaac tggagagtct tgaccaattt gaaagatcgt
+    49261 ttggtgtagt tgaaataaca gaattggaac ttgtttggtc aagtaaagga aactcaatca
+    49321 aactcataac tgtctcaatg gaatcttttt cttctttttt tttttctaaa tattcagtta
+    49381 agaccattcc aaggctcctt ttcgccatgc ataaactaaa ccaacaacta ggataagcac
+    49441 gaaaatgaaa gcttcgataa aaacggatac acccaatacg tcgaaactca ttgcccaagg
+    49501 gtagagaaag acggtttcca catcaaaaac aacaaaaact agcgcaaaca tgtaatagcg
+    49561 tattcggaat tgtagccaag cccctcccat gggttctata cccgattcat aactagaaag
+    49621 cttttcgggt ccttcactaa tcggggctaa aagccctgaa atccaaaatg ccaaaatcgg
+    49681 aataaggctt gctattatta gaaatgtcca aaaaatatca tattcgtgaa gcagaaacat
+    49741 aatgtactcc cattaatgta gaatagacga gacttaaatt aatcaattca attatgcatt
+    49801 gtcaattcat ccagaactta tctcttttcc tcggtgaaac aagaatctgt tttgttcaaa
+    49861 caaaatcgct tagtttagcc tttgttttct ctgtgctgtg tcttctttaa agattcatcc
+    49921 aatggaatcc caactcccct tctttttttt ccattctatt tagatatggt atagatctaa
+    49981 ttcttatata aaaaatactt tatcccttca ctttattttg ctttctctat aatctttaga
+    50041 acctaattaa cataagagga ctagtctatg cagtagactg agaagtaata ctataaaaaa
+    50101 ataaggaact ctatttcaga actatgagac ataatattct gttttcttat ttactcttta
+    50161 ctttaattct ttctattttt ttttctattt aggattttaa gtagatcgat ttagataatg
+    50221 tatatataag caaagtaata tacttaaaac aaagtataaa ttcgcaagat ggagaaaatc
+    50281 attgcagttt ttatagggaa gtctagagat accctatttg aagaagggcg ggattcaaat
+    50341 cagggaaggg ctcttttctt ctattgattt gatagaaatc actttttcgt ttcttatctc
+    50401 tatgattttt gatgaatgag cctgtggtaa tgcttttacg cctattctat gtcgcaggcg
+    50461 cccgcccagt ctataaacaa gtactaatgt gaaaataaaa gctatactaa ggaaaacata
+    50521 ggatatctat actaaaatcc aaaaatagga catattaggg ctatacggat tcgaaccgta
+    50581 gaccttctcg gtaaaacaga tcaaacagat tattatcgaa atgattcgaa ctgtttcaaa
+    50641 gacccaacat gcattttttt gcattgggct ctttcatcaa ctgatttaaa gatcagttag
+    50701 tccaccatag tttttcttta cggaaagata atgagatggc tccctgtgct ctgattgatt
+    50761 atttgtatta tggtctatct aggagcaata ccaaagtgtt tcaaaggagg attaccttga
+    50821 cttaggtctg cctccggcct aaattaaatc aacctaagtg aaatggagtc tctatcgttc
+    50881 cactgcaaga gttaactatg agacttcata caccttaaag ttcatagaac gaaaagaagt
+    50941 tttttggagg cccttatcct cattacgcct agcatttagt gggctggata tttaccttat
+    51001 caactagcaa atccataagg gttcgatttg attaggcacc agaatgggga cctgaatcgg
+    51061 actgaactga ctctttgtca ggctactgtt ctcctattct gtcgaatcta tgaagtaaga
+    51121 cattgatttt gcaataagat ccaaaatatt cattgcataa taagctcctt tgaaaagcat
+    51181 tggcgcacgt gtaaacgagt tgctctaccg aactgagcta tagcccttat cagagatatc
+    51241 ttaacatata gataatttat tgtcaagatg aatattctct aatgccagag ggtatctctt
+    51301 taaatatgta tctgtttagt atataacata ccaataagga agcgttattg cttagaaaag
+    51361 ggattcgata tataatcgat cgaagtaatg ggtcttcctt tgtgatcata aattgcctac
+    51421 ttaactcagt ggttagagta ttgctttcat acggcgggag tcattggttc aaatccaata
+    51481 gtaggtaggt aggtagaaaa attactagat agcattgggc ttatttcgct tcgctatcta
+    51541 ataacttttt ctacccctct tccctttatc tttgtatcaa ctataaacca ttggattgtc
+    51601 ttcaattgga tgggggaatc caattgacag cctcgattcg tatcctagct cgtctgagag
+    51661 ctagtttcgc ttcaaccaat tctttcgtac cctcagcttt actcaagtta tcttcggcta
+    51721 ttttaagtgc ctgttgagct tcttccggat caatatcact acccagttcc gcatcatttc
+    51781 ctaaaataat gatctcatta ttaactattc tcgcaaaacc gctccacaga accgccgtta
+    51841 accattggtc gttgaggagg cgtattctca aaggacccat atctactgct gtgttaatgg
+    51901 gggcatggtt tggtaatacc ccaatttgac cactattagt ggataaaatg atttctttca
+    51961 cttcacaatc ccaaataatt cgcttaggag tcagtacata aagatttaat ttcatttctt
+    52021 cgatttgttc tcctcttcta aggttatagc tttcgtgcta gcttcatcga tgttacccac
+    52081 caaataaaaa gcctgctcgg gtaggccatc taattctccg gaaaggatta gttgaaatcc
+    52141 cctaattgtt tctgcaagac caacatactt tcctgcagaa ccagtaaaaa cttctgctac
+    52201 aaagaacggt tgtgataaga aacgctcaat ttttcgcgct cttgctacag ttaaacgatc
+    52261 ctcctccgat aattcatcca atccaagaat tgcgataatg tcctgaagtt ccttgtaacg
+    52321 ttgtaaagtt tccttaactc tttgcgcagt ttcataatgt tcgttgccaa cgatccgagg
+    52381 ctgtaacata gttgaggttg aatctaaagg atctactgct ggataaatac ccttggaagc
+    52441 taatcctctg gaaagtacgg tagtagcatc caaatgggca aatgttgtgg caggagcagg
+    52501 gtcagtcaaa tcgtccgcag gtacataaac cgcttggatc gaagttatag atcccttttt
+    52561 agtagaagca attctttctt gcaaagaacc catttctgta ctaagagtag gttgataacc
+    52621 caccgcggag ggcattctcc ctaataaagc ggatacctcc gatcctgctt gaacaaaacg
+    52681 aaagatatta tcgatgaata aaagcacgtc ttgcttatta acatctcgga aatattccgc
+    52741 catagttagg gcagttaaac caactctcat acgagctccc ggtggttcat tcatttggcc
+    52801 atagactaga gctacctttg attcctcaat atttttttca ttaattactc cggattccct
+    52861 catttccata taaagatcat ttccttcacg agtccgttcc cctactccac caaatacgga
+    52921 tacgccccca tgagctttag caatgttgtt gattaattcc atgatgagta ctgttttacc
+    52981 tactccagcc cccccaaata gtcctatttt tcctccacgt cgataaggag ctaaaagatc
+    53041 gacgacctta atacctgttt caaagatgga taatttcgta tctaactcga taaaggcagg
+    53101 cgcagatcta tgaataggga acgttgcact actatctaca ggacccaaat tgtcaacagg
+    53161 ctccccaaga acgttgaaaa ttcgcccgag agtagctccg ccgaccggaa cactgagagg
+    53221 agctcctgtg tcaatcactt ccattcctct catcaaccca tctgtagcac tcatagctac
+    53281 agctctaact cgattatttc ctaataattg ttgtacctca caagtcacat taatttgctt
+    53341 atcggcagtg tctctactct ggactaccaa agcgttataa atataaggta acttaccggg
+    53401 gggaaaagtg acgtccagca cgggtccaat aatttgatcg atacggcctg tacttttttc
+    53461 ttcaattggg gaaaccccgg gacgagaagt agtaggattg gttctcataa ttatcacata
+    53521 ataaaaaaaa aggaatttgt cgaaattttt atttttttct tgttgaataa taccaaatcc
+    53581 aaaaaaatat ccaaaaatcc aaaagtaaaa aggaaatcaa ttagttaatt caataagaga
+    53641 aaaaagggga acaggacttg atttcgttgc ccaagcgaat ccctttcaac cctttactca
+    53701 tggaatgagg ccgttggaaa gttcaatcaa tctttttttc ataagataga tttttccttt
+    53761 tgtagaggat ctgtgcctac tctactttcc tatctaggac ttcgctatac aaaatatata
+    53821 ctactgtgaa gcatagattg ctgtcaacag aaaattttct tagtatttag ttaggtattt
+    53881 cttttcaaaa taagaaaggg gccctttaat aatttgtaaa aaaaaaggtt aaggattgat
+    53941 ttgggttgcg ctatatctat caaagagtat acaataatga tggatttgtt aaatcaaatc
+    54001 cttggtttaa taacgaacgg tgttaactta ccataacaac aactcaattc ctatcgaatt
+    54061 cctatagtga aattcctata ggatagaaca tacacagggt atacgcatta tatatgaatg
+    54121 aaaaatatta attaacttaa gcatgccctc aattttctgt aatgagttgc tattaattga
+    54181 atatctcttt ttttttatga gatttttgct aaagtttcat ttacgcctaa ttcacatcga
+    54241 gtagaccttg ttattgtgag aattcttaat tcaagagttg taggagggac ttatgtcacc
+    54301 acaaacagaa actaaagcaa gtgttggatt taaagctggt gttaaagatt atagattgac
+    54361 ttactacacc ccggagtatg aaaccaagga tactgatatc ttggcagcat tccgagtatc
+    54421 tcctcaacct ggggttccgc ccgaagaagc aggggctgca gtagctgccg aatcttctac
+    54481 tggtacatgg acaactgttt ggactgatgg acttactagt cttgatcgtt acaaaggacg
+    54541 atgctatcac atcgagcctg ttcctgggga agacagtcaa tggatctgtt atgtagctta
+    54601 tccattagat ctatttgaag agggttccgt tactaacatg tttacttcca ttgtaggtaa
+    54661 cgtatttggt ttcaaagccc tacgtgctct acgtctggag gatctacgaa ttccccctac
+    54721 ttattcaaaa actttccaag gcccgcctca cggtatccaa gtggaaagag ataagttgaa
+    54781 caagtatggt cgtcctttat tgggatgtac tattaagcca aaattgggat tatctgcaaa
+    54841 aaattacggt agagcgtgtt atgagtgtct acgtggtgga cttgatttta ccaaagatga
+    54901 tgaaaacgta aactcacaac catttatgcg ctggagagat cgttttgtct tttgtgccga
+    54961 agctatttat aaatcacagg cggaaaccgg tgaaatcaag gggcattact tgaatgcaac
+    55021 tgcgggtaca tgtgaagaaa tgatgaagag agctgttttt gcgagagaat taggtgttcc
+    55081 tattgtaatg catgactact taactggggg attcaccgca aatactactt tggctcatta
+    55141 ttgccgcgac aatggcttac ttcttcacat tcaccgtgca atgcatgcag ttattgatag
+    55201 acagaaaaat catggtatgc atttccgtgt attagctaaa gcattgcgta tgtctggggg
+    55261 agatcatatc cacgccggta cagtagtagg taagttagaa ggggaacgcg aaatcacttt
+    55321 aggttttgtt gatttattgc gcgacgattt tattgaaaaa gatcgtgctc gcggtatctt
+    55381 tttcactcag gactgggtat ccatgccagg tgttatacca gtagcttcag gtggtattca
+    55441 tgtttggcat atgccagctc tgaccgaaat ctttggggat gattctgtat tacaatttgg
+    55501 tggaggaact ttaggacatc cttggggaaa tgcacctggt gcagcagcta atcgagtggc
+    55561 tttagaagcc tgtgtacaag ctcgtaacga agggcgcgat cttgctcgtg aaggtaatga
+    55621 aattatccga gcagcttgca aatggagtcc tgaactagcc gcagcttgtg aagtatggaa
+    55681 ggcgatcaaa ttcgagttcg cgccggtaga tactatcgat taatagataa aactaaatat
+    55741 gaagaaggtc taaataaaaa gaaacaaaat aaaaagagaa aaaataagtt acgaaatgca
+    55801 gtaattcttc tttattcttc taattgactg caattaaact cggctcaatc ttttttttta
+    55861 gaaaaaaaaa gattgagccg aataaaaatg gatcatgata cgatcatgag acttcacaaa
+    55921 tcgagattcg cctattctat atatctagaa tatataaagg tataataaat aaatacaaat
+    55981 caaatatact attatcatat gataatagaa tcaaatacgc agtatttaca gaaaaaagtc
+    56041 ttctataaaa aatatttttt ttgcaaacta aaaaatacaa tagtcaatat tcctcataat
+    56101 agatatactt aattatatca taagaatctt aagacatttt tcgaatagat agaaatagtt
+    56161 aatttgaatt gagacaccta ttctatgacg gatttaaact taccttcgat tttcgtgcct
+    56221 ttagtaggct tagtatttcc ggcaattgca atggcttctt tatttcttta tgtgcagaaa
+    56281 aataagattg tctagtattt tttagtgtaa gtaagtgtaa gtaatagaat atggtagggt
+    56341 atgtggctct ttctacacac aaatgaaaaa cggctatgga tgcggatata ggctacaagc
+    56401 ataaatgcat gaatatgcgg agccgggtat agctattttt attttaattg aatcaacgaa
+    56461 tattttttga atagaaagtc agtgtatcta acctattatt tcacaagagt actagttgct
+    56521 gaaggcgatt tcagaatcaa aaaaagtaaa gtcaaaatca tttagcttat tctctcaatt
+    56581 tcaatcgact gctgctggat ttagtatatc taatatgaat tggcgatcag aacacatatg
+    56641 ggtagaactt ctaaaaggtt ctcgaaaaag gggtaatttt ttctgggcct ctattctttt
+    56701 tctaggttca ctaggattct tatcagttgg ggtttccagt tatcttggta agaatatgat
+    56761 atctatactt ccatctcaac aaattctttt ttttccgcag ggagtcgtga tgtctttcta
+    56821 cggaatcgcg ggcttattca ttagctccta cttgtggtgt gctattttgt ggaatgtagg
+    56881 tagtggttat gaccgattcg atagaaaaga gggaatcgtg tgcatttttc gttggggatt
+    56941 ccctggaata aaacgtcgcg tcttccttcg attccttatg cgggatatcc aatcaattag
+    57001 aattcaggtt aaagagggtt tttatcctcg tcgtatcctt tatatggaaa tccggggcca
+    57061 gggggtcatt cccttgactc gtactgatga taagtttttt actccacgag aaattgaaca
+    57121 aaaagctgcc gaattggcct atttcttgcg cgtaccaatt gaagtatttt gaatatccat
+    57181 tgtatttttt ggaactgaat agaatgaaga agaattggaa gaagaaaagt tttctcaaca
+    57241 tggggaggaa gtccctccga aatttgattt gttattgtat tgtaaggggc ttttttagta
+    57301 tttatctaaa ggaaggaaca aacgaggata agataaaatt tctttaaatt tattttgccc
+    57361 aagtgggata tatggcatac tattctttcc attttcatct ttttttctat tccactccat
+    57421 ctagatataa gaaagaaccc aatgcaatga aattccacta atatacaata caaaaaagaa
+    57481 gaatagatac agggtctcaa accttgctat agagtttttg cttcaaagaa aaaaaaatat
+    57541 catcatagag tcagcgaatg aagcggattc attaacaact caatttatag atcaaaaatg
+    57601 aaaaaaaaga aagcattgcc ttctttacta tatcttgtat ttatcgtact tttgccctgg
+    57661 ggggcctctt tctcagttaa caaatgtctg gaactttgga ttaagaattg gtggaatacc
+    57721 agacaatctg aaactctctt aactgatatt caagagaaaa ggattctaga aagattcata
+    57781 gaattagaag aactttctct cttggacgag atgataaaag agaaaccaaa gacacatgta
+    57841 caaaaacctc ctataggaat acacaaggaa ataatacaat gggtcaaaat agataatgaa
+    57901 gatcatctcc atatcatttt gcatttctcg acaaatataa tctgtttggc tattctaagt
+    57961 agttcttttt tttttggtaa agaggaactt gtcatttgga attcttgggt tcaggaattc
+    58021 ttccataact taaatgactc aataaaagct ttttttatcc ttttggttac tgattttttt
+    58081 gttggatttc actccacccg gggttgggaa ctagtaattc gttgggtcta caacgatctt
+    58141 ggatgggctc ctaacgagct aatttttact atttttgttt gtagttttcc agtaattcta
+    58201 gatacatgtt tgaaattttg ggtctttttt tgtttaaacc gtctatcccc ttcgcttgta
+    58261 gtcatttatc attcaattag tgaagcataa attcatttga tctcctgata ttaatcaaat
+    58321 tagcatcttt ctttctttag aaaaaggccc ctttccattt tagcaaaatt ctttctattt
+    58381 ctacctgctt aaaggtattc atcattccgg tacaactgtt gcagtagaat gacaacagac
+    58441 tcgtgtatag ggaactagat tagcttagct acctatctaa tttattgtag aaattctggg
+    58501 atctgcgatt ggacatggaa aatagaaata ctttttcttg ggtaaaggaa cagatgactc
+    58561 gatcgatttc tgtatcgatc atgatatacg taataactcg gacatctatt tcaaatgcat
+    58621 atcccatttt tgcgcagcag ggttatgaaa acccacgaga agcaactgga cgaattgtat
+    58681 gcgccaattg ccatttagct agcaagcccg tggatattga agttccccaa gctgtgcttc
+    58741 ccgatactgt atttgaagca gttctccgaa ttccttatga tatgcaactg aaacaagttc
+    58801 ttgctaatgg gaaaaaggga gggttaaatg tgggtgctgt tcttattttg cccgagggat
+    58861 tcgaattagc gccgcccgac cgtatttccc ctgagttgaa agaaaagata ggaaatctct
+    58921 cttttcagag ttatcgtccc gataaaaaaa atattcttgt gataggccct gttcccggta
+    58981 agaaatatag tgaaattgtc tttcccattc tttcccctga tcctgctacg aagaaagatg
+    59041 ctcatttctt aaaatatccc atatatgtag ggggaaaccg aggaagaggg cagatctatc
+    59101 ctgatggtag caagagtaac aatacggtct ataatgctac gtcaacaggt atagtaaaaa
+    59161 aaatactacg taaagaaaaa ggggggtatg aaatatccat agtggatgca tcggatggac
+    59221 gccaattgat tgatattata cctcccgggc cagaacttct tgtttcagag ggggaatcca
+    59281 tcaagcttga tcaaccatta acaagtaatc ccaatgtggg aggatttggt cagggggatg
+    59341 cagaaatagt gcttcaggat ccattacgcg tccaaggcct tttgttcttc ttcgcatccg
+    59401 ttattttggc acaagttttt ttggttctca aaaagaaaca gtttgaaaag gttcaattgt
+    59461 acgaaatgaa tttctaggtc ccgggatttc ttaccatcaa cttggtaaaa agccgggatt
+    59521 tattggcaat tgttagaatt atctatgatc tattttggaa atcctttttt tgtttagact
+    59581 tttttttgtt tgcgagatgt ctggaattcc ttatttctat ctcatgcaaa agaagagaat
+    59641 ccaaggcaaa ggcgagaaca ataaaaggat ttcttccttt tcgaagggat tgctggtctt
+    59701 gttaatcgtc tattcggcac aagaaaaaga caaaaaggcc tttttcttgt gccgattctt
+    59761 cttttcttgt ctcgaaataa gaatcctttt tctttctatt cgtcaaaggt tacaatttct
+    59821 tctttattcg ggtctgtctc ttggccctct tttgcttagg ttcaggggag gtagtgcaca
+    59881 aacagagggg aagggaatat ggcgggggac aaatttattg tgattgtgag caaatagaat
+    59941 tgcttgactt gttcgattaa gttcaattta gaacttacag aaattttgca aaaaaaacgt
+    60001 aaacttttcc gttgaagggt ggtttttttt aggctagttg agtagttttg attaaggttt
+    60061 tattagttta ttactctaag ctaaatcaat gatttccagg agactccctt cgtggaataa
+    60121 aatattgtat tggatcctcg attgatctct ttttcttatt gcttcataag agtgaatcga
+    60181 atagattaaa gtcgcgttat aagagtaaga attccgcggg tcctttccgc tctaatcaga
+    60241 taaaaaaaag ggggggtaag gacccgctaa gctcctactt tttcatgttt ccaatccgat
+    60301 ccctccgatt actatagaga tgaacccaat ccagaatatg aaccataaaa gaaaacacct
+    60361 actaaaccaa tcacaggaat accagttacc gtacctatca gccaaagagg aattcttcca
+    60421 gtagtatcgg ccatttcccc tactttcctc cacattttat caagtggtca tgctagagac
+    60481 aaaaacagtc atggatagtt atgttataag gatggtatcc ttccaaatgg gataagagag
+    60541 ttcttactac tctcttcttt tctctcaatt gaagaagtaa ttggaaaaca aaacagcaag
+    60601 tacaaaaatg agtaataaac cccagtatag actggtacga ttcaattcaa cattttgttc
+    60661 attcgggttt gattgtgtca tagttctata gttggaattt agtttatcgt tggatgaact
+    60721 gcattgctga tattgatccc aagaaaaaaa cagtaggtac agctagtccg tgaatagcca
+    60781 gccatcgcac tgtaaaaata ggataggttc gatctatggt cattgagggc ctcctaaaaa
+    60841 gatctactaa attcatcgag ttgttctaaa gaatcaaaac ggtcggttat taaaggaatt
+    60901 ccttgtcggc tttccgtgaa atactcgttt ggccgaggac ttccaaacac gtcataagct
+    60961 aaacccgtac tgacaaataa ccaacccgca atgaataggg aaggtatagt aatgctatga
+    61021 ataacccagt atcgaatact ggtaataata tcagcaaaag aacgttctcc cgtgcttcca
+    61081 gacatgctga gctccccaaa tttttgtaca ttcaaaaaag gaattgattc cgtaaaagat
+    61141 gggatcaacc agtaaataaa aaattactgg tatttcatcc ttgtgagatt gtcaattttg
+    61201 taccaaaggt gtattttgag tataccgaat tagtatagct atccttccta tggcacagca
+    61261 atccagtttt gcttggttcc gaaacataat tcctttttta tcttctttgt tctttgtcta
+    61321 taggtaagct atatgttgtt caaggcatca atagaaaacc cacttttttg gagtcctact
+    61381 tattttcatt ggcttcggaa tagtagaaga attcggaata gcggccaaaa tcttgggaaa
+    61441 atagaagttg aagttaatga tcaatagctt tggataaaga atttaggaaa gatattctca
+    61501 tacttacaca atacaaggac aagtatatgt gaaatctatc cttttttggt gaaaagtttt
+    61561 cttcgaatcc aatctttcct tttaaatcat ttataaataa tttaattggt taacataata
+    61621 tctaataaat agaaaatcga atagtggata atctgttatg aaagaaagaa aacattattt
+    61681 gaagaatcaa gatttgtgat taatccttgt cttgtttgtt ggattaggtc taactttctt
+    61741 gactaaattg cgagcgtgga actttacgag atgaaatagg gaaagacaga agatagaact
+    61801 tcaaaggata attgaagcga ctcgttttcg aaaaaggaat aaaaataaag taaatttaag
+    61861 gaagaggttt ctttttttaa gggcccttca ggggatagtg gaatgctttt cttctcctct
+    61921 tattccatat ggaatacaat cagttaaaat aagaaagaat agggggaaat tccccctttc
+    61981 actcaaaaaa gagggttaaa tcctaaagaa ataatccaaa ataggaagaa gttttttttt
+    62041 caaattcaat tgtttatttc tctcttattc ccaaattccc ctgaaaatcc aattgaattt
+    62101 ttcaatgggg ttagatgatg ttgtttttaa tattattact ttactcaatg gaaaaattcc
+    62161 acaacaaatc tcttgattcg gaattagtga ctcatgtatc atctgatgaa tccgctttct
+    62221 tttacacttc tgtatctcac tctatcttgt tttttagtat tatctaaaat aactgataaa
+    62281 ttatgaattt tccataactt aggtaagtgc tttaccaaca tatgtagtat agtaaaaaaa
+    62341 taaatggaat ttaacccttt catgcttact ataactagtt atttcggttt tctattggct
+    62401 gctttaacta taaccccagc tttatttatt ggtttgaaca agatacgtct tatttgaatt
+    62461 gactgaataa gtcagaaaat aaaaatattt cttttggatt ccgggtattc tacgactctt
+    62521 ttccccacta attacgaatt cttttcttgg tcattgagat tcgtggataa tttatagtac
+    62581 tatttaggga tagatcgtat ctattttttt atcccctcga acaaatcgaa atgattgaag
+    62641 tttttctatt tggaatcgtc ttaggcctaa ttcctattac tttagcggga ttattcgtga
+    62701 ctgcgtattt gcaatacagg cgtggggatc agttggatct ttgattgagt aatatttttt
+    62761 tttgattgac ctcctccttg gtctggagga ggtcaaattg gagttgcaat tcaactttct
+    62821 tttgttaagt tactttactc tggttcgaca taagatagat ggaatcacgc tctgtaggat
+    62881 ttgaacctac gacatcgggt tttggagacc cgcgttctac cgaactgaac taagagcgct
+    62941 gtcattcatt caaaaagaaa actcttttct actcctaacg tatctcacgt acgtatagtc
+    63001 tgcacaaatt caagttatac ccactttacc tttaatcaat ctcttcgcta cgcccataaa
+    63061 gaagaaataa gtaataggta gggatgacag gatttgaacc tgtgacattt tgtacccaaa
+    63121 acaaacgcgc taccaagctg cgctacatcc cttttccaaa ttgttgtaca atgccattgt
+    63181 acacaattcc tgtcttcttt tccatatcgt aattttcttc ttctttctct atctatatag
+    63241 aaccctcccg tcatttcttc tttttggtct catctcatat aatcaaggaa tgatatacat
+    63301 ttaaaatcca atcgaatttc gcctataaaa gaaagattac tatggtaatg tgtaggaaga
+    63361 agggtgtcat ctttttcttt tttagggata gggaaatttc gtctatatgg ttcattttat
+    63421 atatagcata acgttcttgg gcaagagttt ctgatcatat acgtattcca ataaggaagg
+    63481 aggattttca atgcggaata taaaaacata tctctctgta gcacctgtgc taagtactct
+    63541 atggtttgct gctttagcag gtttattgat agaaattaat cgtttattcc cagatgcttt
+    63601 gtcgttccct tttttttaat tctagttatt gctatgcgag aaatcgaatt cttcatgaca
+    63661 tgaagaaatt tttacccttt tcaatccttt tttagtatcg gaaggaaaaa gaacgaaatg
+    63721 ctggattggg ctgaacctca gagtcatgaa aaattttggt aaatcccatt ttggaaaacg
+    63781 gaaattcaat taaaagcgat atccaaagaa atcagagcat agaaaaaggc ccggctgact
+    63841 aattaaatga aaggatttcg aaacaaaatc tttgctaatt cgacaaggat tgtattcttt
+    63901 aattatttct ctatttttta ttacttaatt taagaatttc aaaaaaatta tattctaatg
+    63961 gattttattc ttcttcttcg gattcaaaat agaagaataa aagaataaat aagtagaaga
+    64021 attaagttaa gtcaatccaa ccaaaaagaa aaggaggttc atggccaagg ggaaagatgt
+    64081 tagaatcaga gttattttgg aatgcatcag ttgtgttcga aaaggtgcca atgaggaatc
+    64141 gacgggaatt tctagatata gtactgaaaa gaatcgccac aatacacccg gacaattaga
+    64201 attcaaaaaa ttttgtcgtt attgtcgcaa gcacacgact catcacgaaa taaagaaata
+    64261 ggaagatcgt gtgttcgatc tttccaaaga acagaaagag taagaacttc ctattttatt
+    64321 taatatataa ataaaacata gatacaatac aaaataaaaa tcaactcata ttattttagg
+    64381 tagatattat ttcatatgtc tagagggtat tcatatacta taatatgaat caaataagat
+    64441 taagaatatg aatcaaataa gattaagata tggatcaaag aaagactact tcttctcgat
+    64501 cctaaattaa taaaattctc gatcctaaat taataaaata aagaaatttc atttctttta
+    64561 ttaattttaa aattttaaat aaggaataaa tcatgtatac atctaaacaa ccttttctta
+    64621 aatctaagca accctttcgt aaatccaagc aaacttttaa taaatccaag caaccctttc
+    64681 gtaaatccaa gcaaactttt cgtaaatcca aacaaccttt tcgtaggcgt cctcggattg
+    64741 gcccgggaga tcgaattgat tatagaaaca tgagtttgat taatcgattt attagtgaac
+    64801 agggaaaaat attatcgaga cgaataaatc gattaacctt gaaacaacaa cgattaatta
+    64861 ctcttgctat aaaacaggct cgtattttat ctttcttacc atttcgtaac tatgagaacg
+    64921 aaaagcaatt tcaagcccag tcaatttcaa taattacagg ttctagaccc agaaaaaata
+    64981 gacatattcc tcaattaacg caaaagtaca gttccaatcg aaacgtaaga aactataacc
+    65041 aaaatttaag aaacaacaat cggaacttaa gttccgattg ttgatgtttt attcgaaagg
+    65101 gccaggccta tatatattat aaagaaagta atccagctcg ttgattccta ccacttaatc
+    65161 ttaaattatt gtgtcttccc ggagtcccct ctccgggaat tcggttttta ttattccagt
+    65221 atattacttt atttatcctt ttaattgatg atcttgattt tcttggaaat cgtgtaaagg
+    65281 ttatttggat ttgatacagc gacttgtgca agcattttac ggttaagaat caatttcttc
+    65341 ttatataggt tgtgtattaa tttactataa ctatcgaata ctttaaatat ccgcgttgct
+    65401 gcgtttatcc gagtgatcca caaacggcga aaatccctct tttgcctacc tctatctcta
+    65461 tgagaggaaa caaaagctct ttttacctgt tgggtaatca ttcgattaag tcttaaatga
+    65521 gcccctctaa aatttgaggc aaatgaacgc atttttgttc gtcgtctccg ggctatatat
+    65581 cctcgcggaa ctctggtcat tgaatcaaat taaccttaat gaataactaa tgatttctct
+    65641 tcttttagcc atccttttcc ccattaataa caaaacgaat tattccgata tataaaatat
+    65701 taattccaat ggcttttgct atagtaacct tcccaaccac gatttttttt ctactccctt
+    65761 cagttatttc tatgcgaaat aacaaattaa ttctaatgat actaaaaaaa tagtgggttc
+    65821 catcgtttct atggttccct tttaaacggc gaggccctct ctatacaccg gagccccttc
+    65881 ttttatcaaa aggtattgtg aacttgtata gttcacattc tttggctcta cctatccatt
+    65941 atagagtaaa tagctctttt cacaataaga gttatccata cagtgacggc atttaattat
+    66001 gaaagttagc taagtagctg accctgttag tccgttcttt taagataaag gaacataagc
+    66061 ctttttcttt ttattacttt ttcctccgct taatggataa ctatttgcta ccaatggagg
+    66121 aattgcttct tatttccaat ttagataact ggatttgcac caaaggaaac cacaaattcc
+    66181 atatatcata gaaatctagg atagagaagc tatatcctat tcattggtac caatcatggc
+    66241 tacttcaatt ttttttttat ttttttgaag tcatgatctg aacgagtcgc acatacaccc
+    66301 tagcacatgt tcctcgacgc tgaggacatc ctttaagcgc ggctgttttt ctagcagttc
+    66361 gtattggctg tcttgcgttt ctaataagtt gtttaaccgt tggcatgttg tatgtatata
+    66421 gaaaaaagta gattggttta gatccatctt aacctgatga ttgatcatca tgaagtcttt
+    66481 ctattttcta ttaaatcgaa gaaaacccga atttaggtgt gaaataactt tacaagaaat
+    66541 ccgggcacta ccaatcctta aacatttctg gaaaccacac tggatcagta tcgcagtgct
+    66601 cgtgaatcat ttcatcccct acaatatcga caagcccata agctttggct tcgtctgctg
+    66661 acataaaaac atccctttcc atgtcttcgg atacaaccca aaaaggcttg cctgttctta
+    66721 gtgcataaac ccttgtgatc atttcgcgaa ctttgtgtaa ctcttccact tctagtaaaa
+    66781 attctggtgt ccttgctcga taataagcac tagcaggttg gtgaagcata atcctcgcgt
+    66841 gagggaatgc tatacgcttg gtgggttctc ctccaagcag aatgaaggac gccatggacg
+    66901 cagctattcc gaggcatatt gtatatatat ccggtgtcac cgtttgcatc gtatcaaaaa
+    66961 tagccattcc tgagattagc catccgcctg gggagtttat aaacaaaaaa atatcactaa
+    67021 ttccatcttc tatactgaga tataccatga gacctgtaat atgattcgtg atctcgcaac
+    67081 gaatctcttg acctaaaaaa agtgtccttt ctcgatacat aacattgtat aagtcaaccc
+    67141 aagtcgcttc ttcatctccg ggaatctggt aaggtacttt tggaacacca atgggcatat
+    67201 tagattaata ttattaaatt taagtaagaa aactatactt taatatggaa acgtaagaat
+    67261 ggaagagaaa gaaagaatct ccgatttatt gtcttcattt ttattcttat tctatatgaa
+    67321 tactatatat tctattaata cgtagattga aataatacat agattgaaag gttatacata
+    67381 taaagaagat aacacagatt gaataaagaa aaaaggaatc ggtgattcga atcataacca
+    67441 aagaggggta gggatctatt cttggttttt tccaaatcgg ccaagttacc cattgcatat
+    67501 tggcacttat cgagtataga atagatctgc ttctttttcg tattataaac agaattagct
+    67561 tctttttttt aatggaatga aataaatatt cacgctttct gacacagaat cccatagaag
+    67621 ggttaggtcc ataggatatg gatagtcttt tacaatgcga taaaataaag cgacatcgtg
+    67681 tctatttttc tttgctaaag aggtatttcc atgggtttgc cttggtatcg tgttcatact
+    67741 gtcgtattga atgatccggg tcgattgctt gcggtgcata taatgcacac agctctagtt
+    67801 tctggttggg ctggctcgat ggctttatac gaattagcgg tttttgatcc ctctgatcct
+    67861 gttctggatc caatgtggag acaaggtatg ttcgtcattc ccttcatgac tcgtttagga
+    67921 ataacagatt cgtggggtgg ttggagtatt tcaggaggaa ctgtaacaaa tccgggtatt
+    67981 tggagttatg aaggtgtggc aggtacgcat attgtgtttt ctggcttgtg tttcttggca
+    68041 gctatctggc attgggtata ttgggaccta gcaatattct ctgatgatcg gacaggaaaa
+    68101 ccctctttag atttgcccaa gatctttgga attcatttat ttcttgcagg ggtggcttgc
+    68161 tttggctttg gggcatttca tgtaacgggt ttgtatggtc ctgggatatg ggtgtccgat
+    68221 ccttatggac taactggaaa agtacaagct gtaaatccgg cgtggggtgc agaaggtttt
+    68281 gatccttttg ttccgggggg aatagcttct catcatattg ctgcgggtac attgggtata
+    68341 ttagcgggcc tattccatct tagtgtccgt ccccctcaac gtctatacaa aggattacgt
+    68401 atgggcaata ttgaaactgt actttccagt agtattgctg ctgttttttt tgcagctttc
+    68461 gtagttgctg gaactatgtg gtatgggtca gcaaccaccc caatcgaatt atttgggcct
+    68521 actcgttatc agtgggatca gggatacttt cagcaagaaa tatatcgaag agttagcaat
+    68581 ggtttatccg aaaatcttag tttatcagaa gcttggtcta aaattcccga aaaattagcc
+    68641 ttttatgatt atattggtaa taatccagca aaagggggat tattcagagc aggctcaatg
+    68701 gacaatgggg atggaatagc tgttggatgg ttaggacatc ccgtctttag agataaagaa
+    68761 ggacgcgagc tttttgtacg ccgtatgcct actttttttg aaacatttcc ggttgttttg
+    68821 gtagatgaag agggaattgt gagagcggac gttcctttta gaagagcaga atccaaatat
+    68881 agtgttgaac aagtaggcgt aacagtagag ttctatggtg gcgaacttaa tggagtaagt
+    68941 tattctgatc ctgctactgt aaaaaaatat gcgaggcgtt ctcaattagg ggaaattttt
+    69001 gaattagatc gggctacttt gaaatcggat ggtgtttttc gcagcagtcc aaggggttgg
+    69061 ttcacttttg gtcatgctac ctttgctttg ctcttctttt tcggacacat ttggcatggc
+    69121 gctagaacct tgttccgaga tgtttttgct ggtattgatc cagatttgga tgctcaagtg
+    69181 gagtttggaa cattccaaaa agttggagat cctactacaa ggaaacaggc agtctgatac
+    69241 acattgttat ggtatctttc atttcacctt tcttttttga tttggcatgg gaaacatctc
+    69301 ccatcctttc ttttactttt tttctttgtt tatatggttt tctttcttta tatgggaaat
+    69361 tttcccaaat gaaaaatgaa taggtgtgga agttataatt gtaaataaac cacgatcgaa
+    69421 tctatggaag cattggttta tacgttcctt ttagtttcga ctttagggat aatttttttc
+    69481 gctatcttct tccgagaacc gcctaaggtt ccaactaaaa gagtaaaata attttatgga
+    69541 agtaagaagt ctacccatct ggtagacttc ttacttccat tagtccccgt gttcttcgaa
+    69601 tggatctctt aattgttgag agggttgccc aaacgcggta tataaggcat acccagtaaa
+    69661 gcttacaagt aaaccagata tggagatggc gactaaagtt gctgtttcca tttttataga
+    69721 atttaaagat tacaatggat ctacaaaaag atcgtgtatt tacaactaca acggaatagt
+    69781 atacaaagtc aacaccaacg attaaatcga atttatggct acgcaaaccg ttgaagatag
+    69841 ttctaaacct aaaccaagac gaactggtgc aggtagttta ttgaaaccct tgaattcgga
+    69901 atatgggaaa gtagctccag gttgggggac tactcctttt atgggggtcg caatggcttt
+    69961 attcgcgata ttcctatcta tcattttaga aatttataat tcttctgttt tattggacgg
+    70021 aattttaacc tattaggttt ctactaacta aaagtacgaa gtcgkagttt ttccatccaa
+    70081 aaaaagcctt tctagtttaa gctctacatt tctagacatt ctggtagttc gaccgcggaa
+    70141 tttttttgtt tcggtatctc tggaatatga gtgtgtgact tgttaaaatt gatcctattg
+    70201 ataatacata gaaagggcct gttatctcta tcaatatgat tctaattcgt cagatattat
+    70261 ttattctagt atctggaaca cgaaatagat agagtggatc aaaaaaaaaa tggaactatg
+    70321 attcataccc actattcaga cctcgcaacc agactgaaaa aattgaagta gttcttaata
+    70381 aaaaaaaaga aattttcttc cttccaattt tgtttgcaca aaagacaact ttattttctc
+    70441 tccattttgt cgagtcatta cacggattcc ataaatgatt atcaagtggt tcttattcga
+    70501 agaacccttg ccttttgttt agcttgagac tcaatcatcg tggctctagt atgaatctaa
+    70561 ggtttaaatt gaactgattc ataggatcgc aacangataa tttctatcag aaaactacta
+    70621 gaattttggc tttcttattt actagtaaat aaagagtaaa tccgcattac acacaaaaaa
+    70681 ataaatcaaa aatagggaag agaaaagtca agaggcctct aatgaccaat ataagggaaa
+    70741 ggaagaaaga cagatgagcc aacttgagat tttttggcat tagcattaca aagaggatat
+    70801 tccggatttt tcttatttca tatcttcaag gcaaatcgac ccaatccagt ggctgatgaa
+    70861 gttttgaacc ttttttctaa tattcgttga aaatttgtgt gtttctgctt gagccgtacg
+    70921 agatgaaatt ttcatatacg gttcttagag ggggacttag gttagttacc tatctcaata
+    70981 aagtatatga ttggtttgag gaacgtcttg agattcaggc aattgcagat gatataacta
+    71041 gtaaatatgt tcctcctcat gtcaacatat tttattgttt agggggaatt acacttactt
+    71101 gctttctagt acaagtcgct accggttttg ctatgacttt ttactatcgc ccaactgtta
+    71161 cagaggcttt ttcctcggtt caatacataa tgaccgaggc caactttggt tggttaatcc
+    71221 gatcagttca tcgatggtca gcaagtatga tggttctaat gatgatccta catgtatttc
+    71281 gtgtgtatct cacaggtgga tttaaaaaac cccgcgaatt aacttgggtc acaggtgtgg
+    71341 ttttggctgt tttgactgca tcgtttggtg taacgggtta ttctttgcct tgggatcaaa
+    71401 ttggttattg ggcagtcaaa attgtgacag gtgtacctga tgcgattccg gtaataggat
+    71461 cgcctctagt ggagttatta cgtggaagtg ctagtgtggg ccaatccact ttgactcgtt
+    71521 tttatagttt acataccttt gtacttcctc tgcttactgc cgtatttatg ttaatgcact
+    71581 ttccaatgat acgtaagcaa ggtatttcgg gtcctttata gggaaggcat atcatagaga
+    71641 attagaattc tcatatataa tattgggtag gttgtggtat ttcattgcta caaacatggg
+    71701 ttattgtaaa ataacacatg tcatttggat acttctcttc aactccgaag tattttgata
+    71761 taatacaaat agttgaagtt aattttacaa aagaaaaaaa ggcggattat gggagtgtgt
+    71821 gacttgaatt atagatttgg ccatgcagat aaagaattgg atctgccaca ttagaattca
+    71881 caaccaaagg tgtctccgca tccaatcaac acgtaagtcc cctacctagg aaggataggc
+    71941 tggttcactt gaggagaata ttttctatga tcatacccca accatgtcat ccatgaaaag
+    72001 gctccgtaag atcccataga gtagaaatgg aataagtcat gtgacatgat ccaattctct
+    72061 atttattaca cttacctttt tttattatgg tatggaaatg cattcatttt ctttgcatcg
+    72121 attgtgattc gcaatactat cggagtaaaa gaagggatct aaggaagagc ataggctaaa
+    72181 ctttttgatt tttttattag taacaagtaa atactttgtt tgggcgtaag aaacttgcga
+    72241 tagtgagggg ataaagacca actaatcaag agacatgaga caatccacaa agcaattgat
+    72301 catgatcaaa tttgtaagcc cacttggata ttgagcattt acccataaga ataggattat
+    72361 tttcaatgag tagttgtagg tgcaacttcg gaaaagataa tctgataaag cttttcttgc
+    72421 ctagagtcat tgagtaatta tataccttat tctattatta ttatggatct tccgcggtct
+    72481 tatttctttc tttattgctc gagccggatg atgataaatt ctcatgtccg gttcctttgg
+    72541 gggatggatc ctaaagagtt cacctatccc aataacaaag aaaccagact taaatgatcc
+    72601 tgtattaaga gcaaaattag ctaaagggat gggacataat tattacggcg aacccgcgtg
+    72661 gcccaacgat cttttatata tttttccagt agtaattcta ggtactattg catgtaatgt
+    72721 aggtttagct gttctcgagc catcaatgat tggtgaaccc gcggatccgt ttgcaactcc
+    72781 tttggaaata ttacccgagt ggtacttctt tcccgtgttt caaatactcc gtacggtacc
+    72841 caataagtta ttgggcgttc tcttaatggt ttctgtgcca acaggcttat tgacagtacc
+    72901 ttttctagag aatgtcaaca aattccaaaa tccatttcgt cgcccggtag ctacgaccgt
+    72961 ttttttaatc ggtactgcag tagctctttg gttaggtatt ggagcaacat tacccattga
+    73021 taaatcctta actttaggcc ttttttaggt atttttcagg ttgattcatt caaccgtgaa
+    73081 gtaccgtgca taggtatcta ggaaatagtt acttcgaagt gaattttccc tagataccta
+    73141 aaatccattt tattatgatc catttcgcga aaatatagat tctcctgaag atgcaaactt
+    73201 gtttttttct ttttatccta actcgaaaaa gaagaagagc caaaaattgc aatggattta
+    73261 aaacgagagc ttattcttaa gtaaatcaac tgggagatgc ttctctagag tgtcccatat
+    73321 ctgttttcca tcttccatac gaaaactgtc aattctcata agatcttctt cagtcttact
+    73381 caaaaggtcc aatagtgtat gtatattggc ccttttgaga taattatacg ttctagaagg
+    73441 caattctaat tgatcaataa aaataaaatt caatggaatt ccttttttgt ttttctttcg
+    73501 attagtcaat cttttttgaa aagtaaaaag gggtggagta aacctgtttt tattttcttc
+    73561 gaaaccagtt ccctcttcct ctgcgtgtag aaaaggaaga aataaatcaa tcaaattacg
+    73621 agaagcctca taaagcgctt ccttaggggt taaacttcca ttagtccata tttcgagaaa
+    73681 aagtatctcg tgtttttcat ttccattccc acaagaaaaa atactataat tcacatttcg
+    73741 aacaggcatg gatacagcat ctataggata acttccatct tgatagttct ttctaagttc
+    73801 cgtctgatat ccacgatctc tcttgatctg taactgaata cagaaatcaa tgggctcggt
+    73861 caagttagct ataggctgtg ccgtatcaac gacttctacg gaaggtggta agatgatatc
+    73921 ttgagcagtt atgcatctgg gacctttgac gcaaatggat gcgtctctaa ctccatagag
+    73981 attacttctc aatacaattt ctttcaaatt tactaaaatt tcttgtacgg attcttcaat
+    74041 acccgctatt gtagaatatt cgtgtggcac gcttccaaat tttgcacgtg tgatacatgt
+    74101 tccttctatt tctccaagta aagctcttcg caaggcaata ccgacggtat ctgcttgacc
+    74161 ttttataagc ggggacagaa tgaaacgacc ataataaaga cgcttactat ctactcttga
+    74221 ttcaacacac ttccactgta atgtttgagt ggatcctgct acctcctctc gaaccataat
+    74281 agactagtat tattatttga tcattgaatc gtttatttct cttgaaagcg ggttaattct
+    74341 tttacagacg ccttttttta ggcggtcgac atccattatg cggcataggt gttacatcgc
+    74401 gtatacaact taagcgcaca ccacttttag caatggctcg taatgcggca tctcttccac
+    74461 taccagcgcc ctttaccata acttctgctc gttgtaaacc tactgtacga atagcatcga
+    74521 ctgctgttct ttgaccagca tagggtgatg cttttcttga gcttttgaat ccacaagtac
+    74581 ccgcagagga ccagaaaacc actcgacctt gtgggtctgt aacagttata atggtattgt
+    74641 tgaaactagc ttgaacatga ataacccctt ttgttattct acgtgcactc ttccgtaaac
+    74701 taaaacgtgc attcctacgt aaaccaatac gcactctctt acgtgaacct atttttggta
+    74761 cagcttttgc catattttat tatctcataa atctcataaa tatgagtaaa aaaaataaaa
+    74821 aaaagataca aagatatccg tttcagggta aaatataccc tttactttaa ttatttcaaa
+    74881 ttattttatt attaatttaa acattcccgc aggtattctt tttttttact ttttagaaag
+    74941 taaagtgctt tttcgaaaga ttatccctgt ctttgtttat gtttcgggtt ggagcaaatg
+    75001 actctaattc ggccacgcct acgaatcagt cgacattttg tacaaatttt acgaacggaa
+    75061 gctcttattt tcatatttcc gtatcctttc ttaaaccatg aatctaatct tttggaaaaa
+    75121 ataagtctct tcgctgtaat ttttgaactt tgcatttatt attctagaaa aaagaaaaac
+    75181 ctaatccttc aaatcttcgc tatccttcaa atcttcgcta tccttcgagt cttcgatacg
+    75241 cttcgaatcc ttatggggaa gtctataaat gatacgtccc ttgcttgaat cataacgact
+    75301 tacttcaatt ttgaccctat cccccatcag tattcgtata gaactagacc gaatctttcc
+    75361 tgaaatatag cccaggatga tggtgtcatt ctctagacga acgcggaaca ttccgttggg
+    75421 tagggcttcc gtaactaaac cttcgaaagt tacttttgct tctctcgggt ttttcttttc
+    75481 tcgcctattt tttttttctg tcattttttt tttctgctat ttttttcttt ttatttgaat
+    75541 aataggaagt tcgagagaga attcgggcac tataggcaag gcgattacca tatataacat
+    75601 aagacttctc ccccaattct gtttagtcga gcctctcgat ctgtcattat ccctcgagaa
+    75661 gtagaaagaa tagcaattcc cattccaccc aaaactttag gaattccttg atagttggta
+    75721 taaattcgta agccgggtcg gctgatacgc tttaaaaaag ttcttgttct atatattcct
+    75781 tttctagtct ttctcttttg atgtcgcaaa gttaaaacca agaaatatct gttacgttcc
+    75841 tgatgtttcc gaacactttc aataaaaccc tctcgtagaa gtatttttac aatgttttca
+    75901 gtaatatttg tagatactac tcgaactgtt gcttttttat tcatgtccgc gtttcttata
+    75961 gaggttagta aatcagcaat agtgtctttg cccataagat tctaattcta ggttcctccc
+    76021 aatttttcta taatcaacat gttttctttt ttttcttttc attttagatt ttaaaacata
+    76081 tacgtgaaac acaatctact aattcactct ttgatctaaa tttcgcctac tagtatttat
+    76141 aatacttcag gagctaatga aactattttg gtaaaattca attctctcaa ttcctcggtg
+    76201 atcgccccaa aaactcgagt tccttttgga tttccttttt gatcaattat aaccgctgca
+    76261 ttgtcatcat agcggattat tataccgtct tcacatttga actctttaca tgtacgtaca
+    76321 attacagctc gaattacttc ggatctttct agaggcattt ggggcactgc gtctttgatt
+    76381 acagcaacaa taacatcacc aatacgagca tatcgctgat taccagcagt tcctatgact
+    76441 cgaatacaca tcaattttcg agctccacta ttatctgcta catttaaaag ggtctgaggt
+    76501 tgaatcatat tatttggatt tcaatttttt atttcgatgc aaaaggatga aagaaatatt
+    76561 gtctttccag aaagaaaaac ccgtttttgg ggttctatat ctctaatcga ataaattgac
+    76621 ttcgtatggg cattttactg gcagctatgg agatagctgc tctagctaca gtttcggata
+    76681 ctccacccat ttcataaagt atacgacctg gtttaacaac agctacccaa tattcggggg
+    76741 acccctttcc cgagcccata cgtgtttccg tgggtcttag tgtaactggt ttgtcgggaa
+    76801 atatacgtac ccatattttt ccaccacgac gtgcatatcg tgttattgct cttcgtcccg
+    76861 cttctatctg tctcgccgtg atccaagtgg gttcaagtgc ttgaagagca tatctaccaa
+    76921 aacaaatacg attgcctcgg caggattttc ctttcattct tcctctatgt tgtttgcgaa
+    76981 atttggttct tttggggtta tagtcgatgg ttctttcgta gttccatctc tactgcaaaa
+    77041 ctggacatga gagtttcttc tcatccagct cctcgcgaat taaatgagaa agcgtgcaaa
+    77101 ttgctctaat tccataatat tcaaaaatat tatggataga tacacattaa taggtaatag
+    77161 aaaaagttag ttttttttat ttttcatagt taattttgtt caaatagaaa aatatatagt
+    77221 caagaaagaa gatctagaat atatctagat gtgtgtgtct atttatctat attctatttt
+    77281 taacgtaatc cttcttaaaa aaaatatctt tctttttact tttattgaat ttattgaatt
+    77341 attgaattgc ggtaaagtat tctaattcaa taaggatttc gcgggcgaat atttactcta
+    77401 ttcctgtctt atttggtaat ttataacctt accaaataag acaatttttg gggtttgttc
+    77461 cgccatcccg tccaatgagg tttttggatc tttgcataaa tcctatggag tcataggttc
+    77521 tgtcgttccc actgcttctc cttgaatggt taggtctgaa tcccgcaacg gagcttcaaa
+    77581 aaaatgtctt tccgagttaa ttttctcagt tttattaacc cgggtggctc tttaattatt
+    77641 gctttaaatt tgtagttctt gtttcaagtt acgatttcta attctctgtt atttttatta
+    77701 tattatattg atgctttatc acattgcctt ttttgatgca attcatagac catacatatt
+    77761 ggaatcctat atcttactta ttcttctttc tatcatcttt ccctttatct acatcccttt
+    77821 agttttgctt cagaacctag aatctcgttt cttttttaga gaaaaaattg cagttgctac
+    77881 aactatatga tagatctact catttatgat agagatattt attcagatag tgactgcttc
+    77941 ttagttagga tctcgacaat acgaagcaat aggttggtta ttagttaatt ttctataatt
+    78001 actaaatttt tttctttttt taaagaaaaa aataacgagt cacacactaa gcatagcaat
+    78061 tatattaaat gatttatcaa ttttcattaa atcttataga aagaggtata atttcttctt
+    78121 ttttttaggg atttcgggaa aaaaggctct tgtcattttt tattctatca ctgcacagaa
+    78181 tgcgaagaca agattagtta ttcttcatct acgaatatcc aaatttttac acctaatact
+    78241 ccatagatag ttcgaattgg atagcaacaa taatcaattt tagcgcgaat tgtttggaga
+    78301 ggaagtctac cctttttgat gcattccgca cgtgcaattt cttttcctcc gagacgaccc
+    78361 gctattttta ctttgactcc ccttatatct gcttttttag ttaattcaat ggcttttttt
+    78421 attgcctttc ggaatgaaac tcgatttttt aattgaaaag ctatatattc tgcaagaatg
+    78481 ttaggttgtc tataaggctc tttaactttt tcgatagaaa tattaagtct ctggtttaca
+    78541 gagttaattt ctttttgtag atctttctct aattcttcga ttactccctt tttctttaat
+    78601 aaatttggaa atcctatatg gattatgacg tggatcgtat caatttcttt ttgaatttct
+    78661 atatgtgtaa ttacttcgga acttgaacct gagtccattt ttctattatg tgtaattact
+    78721 tcggaacttg agtctgattc tatttttcta ttcgagccct ttttcctatt tttttgtata
+    78781 tagttcttga tacaattcct tattttttta tcttcctgta gaccctcaga ataatttttt
+    78841 ggttgtgcga accaaaagga atggtgtttt tgggttgtac caagtctgaa accaagtgga
+    78901 tttatttttt gtcccatatt tttcctattc tatttttttt tacggggaat cgaatcttag
+    78961 ctggatctaa gggttattta gatctcttta ctatatttag tgcaattgtt atatgacaca
+    79021 tgcttttttt tatggggaaa ctgcgccctc gagcccgagg tctgaatttt ttcataatag
+    79081 tacttctact gacttcggct ttagttatga ataaattcgc tttgtcgaaa tccctataat
+    79141 gagcagcatt tgctgctgcc gaataaacca actttaagat gggataagat gctcgataag
+    79201 gcatgaggtt cagtatcata actgtttcct catagtaacg ccagcgaatc tcatcaagaa
+    79261 ccctttgtgc tttgaagaca gacatatgga tacgtttttg tgctttgaaa actcgctcga
+    79321 acttaagtag acgatcggtt ggaactttcc ttgcaagttt ccttagccca cttttcttct
+    79381 tctttatcct agggatatac tttactaatt tgaaacttgt cataaataag gttattcccc
+    79441 gcctaccttt actttgcatc ttttttttat tctgaatctt tctattctga attcagttaa
+    79501 cgacgagatt tagtatcctt tcttgcattt tcataactcg tgaaatgccg agtaggtacg
+    79561 aattccccca atttgcgacc taccatagga tttgttatgt aaataggtat atgttccttt
+    79621 ccattatgaa tcgcgattgt atggccaacc attgtgggta gaatgctaga tgcccgggac
+    79681 cacgttacta ttgtttcttt ctcctccttc atattgacct tttctatttt tgccaataaa
+    79741 tgatgagcta caaaaggatt cgtttttttt cgtgtcacag ctgattactc cttttttttc
+    79801 ctttttaaag agcggcaatc tatgtccaat atctcgatcg aagtatggag gtcagaataa
+    79861 atagaataat gatgaatgga aaaaagagaa aaatcctgta gctggataag gggcggatgt
+    79921 agccaagtgg atcaaggcag tggattgtga atccaccatg cgcgggttca attcccgtcg
+    79981 ttcgcccatc gcattattgc aaatgcaaaa aatgcaattt tccatattcc tagttacgta
+    80041 tttacttacg gcgacgaaga ataaaactat cgctatattt tttccttttc ctagttcttc
+    80101 ttccaagcgc aggataaccc caaggggttg tgggtttttt tctaccaatg ggggctttcc
+    80161 cttcaccgcc cccatggggg tggtccacag ggttcataac tacccctctt actatggggc
+    80221 gtttacctag ccaacactta gatccggctc tacccaaact tttttggttc accccaacat
+    80281 tacccacttg tccgactgtt gctaagcagt tttgggatac taaacggacc tccccagatg
+    80341 gtaatcttaa agtggctgat ttaccctctt ttgcaataag tttcgctaca gcacctgctg
+    80401 ctctagctaa ttggccaccc cttccacgtg tgatttctat gttatgcatg gccgtgccta
+    80461 agggcatatc ggttgaagta gattcttctt ttctctcaaa aaaccccttc ccaaactgta
+    80521 caagcttctt ccaaagcata cggctttcta gatgtatatg acgatctcta gacagatgga
+    80581 tcttatataa atcatatgat gaagtaccac atgagtggat atataggaaa ggaatccaaa
+    80641 tctgccgaat cgctcatgtt aggatcttct acatcctagg tctccgcgtt ccgtcatctg
+    80701 gcttatgttc ttcatgtagc attcagatcg aatgactcta tgaaattacg ttgatacttc
+    80761 cacatattat gggtaacgta ggagacatcc cttttttccc cgggggtctt aattaccact
+    80821 gcttagcttt caattcgcct ctgaccatca aattaaatgt gaataacccg tcctactctc
+    80881 tttgaaacaa ggggcgcttc cggttctgtg cgtgcttcaa acaattttgt cttctccata
+    80941 ttaccatatc tctagagtca ataattttct atgaggaact actgaactca atcacttgct
+    81001 gccgttactc aacagttttc tgttaaggtc tatcccgtag aggtagtcaa attggatcag
+    81061 tgatcgattt ctaggtttcg tcgtaaacct aattggttac ttccaattac gtaaatcaat
+    81121 agttcaaacc gcactcaaag gtagggcatt tcccattgat ataggaactt ttgtaccaga
+    81181 aacaatagta tctccaatta tagcccctct gggatgtaaa atatatctct tctcaccatc
+    81241 cccatagtgt atgagacaaa tgtatgcatt tcgattaggg tcgtattcta tggttacgat
+    81301 tctaccagat atgtcttttt gattccgtcg aaaatcgatt ttacggtata ggcgtttatg
+    81361 acctccccct ctatgccttg cggtaatgat tcctctggaa ttacgacctt taccacaacg
+    81421 gtgccgtcca tggatcaaat tatttcgtgg attggatttc acttgcctgt ctacggttcc
+    81481 cttgcgtgta ctcgagatag gtgttttgta taaatgtttc gccgtattat taagtattct
+    81541 cctttagttt ttttctctat ctagaagtgg aatagaataa cccggttgaa gggtaatgat
+    81601 catacgtctg taatgcattg tatgtcccag aataggtcct attcttctac cctttccggg
+    81661 tagtcgatgg ctattcacag ctactacctt aacaccaaag aagagttcga cccaatgctt
+    81721 tatttctgtc ttagtgaatc ctgattcgac attaaaagta tattgattct ttcccaataa
+    81781 acgaagactt ttttctgtaa atactgcgta tttgattcca tccataaatc gactttccct
+    81841 cctatgctct gagttccagt atcgataaga attcgagttc ttattgttct tatgttatgg
+    81901 tatgaatata ccataccaat tcgttatgta tggatgatgg atgagattcc atggatagag
+    81961 agccagttcc aatagactta tggaacgttc ccgttcgcgt gcatccagca ggaattgaac
+    82021 ccgcaaattt accaattatg agttgggcgc tttaaccatt cagccatgga tgcttaacag
+    82081 ggatcatcct acatcgtaaa taaccaattt tcatatagaa agacatatca tagaaaaatg
+    82141 aaatcgaaaa tattcggaga tggcaaatat tcggagatga ctatgaaaac acctctctgg
+    82201 atcctcgaat tgaaagagag attgagaggg atcaagaatc ctaattctct ctatttggaa
+    82261 tggatccaat tctattgagt ctgactcata gtgatcattt ctctttagca aagaatgacc
+    82321 ttggttatca aaggattgaa caaccgggat ccatttactt atgataccta gttggcattg
+    82381 ataacaagga tctaatgaat tatgagttta atagatcctc tttagcagaa agacgtatat
+    82441 tccttgctca ttatcagaca atcacttatt cccaaacctc gtgtggggct aatcgttttc
+    82501 atttaccatc tcatggaaaa cccttttcgt tccgcttagc cctatcgggt attttagtga
+    82561 taggttctat aagaactgga cgatcctatt tggtcaaata cctaacgaaa aattacgatt
+    82621 ttcctttcat taaggtacga gggcttctta ttccacaaga acgaaagcac cttttcattc
+    82681 tttcatatac taggggtttt tacttagaaa agacaatgtt ccatactaaa agattcgggt
+    82741 gcataaccac gagttccagt gcactagatc ttgtagcact tagcaacgag gccctatcca
+    82801 ttagtattcc acataagaaa tccattatag aaaaaaatac aattagatta actcttcata
+    82861 gacaaacttg tggtttgcga gccaaggtaa gatcggctcg ggatcatggg acctttttct
+    82921 atcagatagg aggggctctt gtacaaaata gacttataag taataacccc atagaatcaa
+    82981 tctatctata taaagaggcg atcgtgtcag gaagcgggtt tttctttggc caaaaggtac
+    83041 ttcgaacttg gaacgagcat gaagagatta acgagacttc tttctctttt gcgtttttat
+    83101 ggcggacctg ccgcgcaaga tctttggtct tcccctggaa ccgatgaaaa aaagtggatc
+    83161 gcttcttatg gactcgctca gaatgattct tctctatcta tagttcatgg cctattagaa
+    83221 gtagaaggtg ctctggtgca atccttaccg acagaaaaag attgcagtca ggttgataat
+    83281 aatcgagtgc cattacttcg tcggtccgaa ccaaggaatc cgttagaaat gttttgaaat
+    83341 ggatattgtt ctctctttga tcagggattg ctatatgaaa agaagtggag tttgaaaaag
+    83401 ggaacggaat ggtcaaaccg gaactgctag aggaacgaat tttcaatagc ataacttggg
+    83461 ctcctagaat atggcgccct tgggacaatc catttgattg cagggttttg ttccgaagca
+    83521 aagatatccg cggaggccag ttcgttcgtc ctattctgat attcaggacc aagaggtact
+    83581 ggattctctt tcggataggc cctgaaagga gaagaaaggc tgaaatgcca acggacctct
+    83641 gtctattctc taattcaccc gagccgatag tacccgtttt tggaacgtcc agtgccaaag
+    83701 tcactgaatg ggtaagtcac caatccaacc cctttgacaa atcgggtgtc atattagata
+    83761 tcatattcta tatatataga aatatcatag aatagacata tagaattttt ggtctggaaa
+    83821 ttagaaagaa tcattgagtg aaaaaggagc aaagaatgac aaaagacgag actctactag
+    83881 tcttcactct tgtggtttcc tcggtttctg ttttcttatt cgggatcttg cttttcatga
+    83941 ttctcatctc tgcaactcgc gattttagcg agagaaccaa atccaagttg gtgaagatca
+    84001 tgatttgggc tggcatagta gttattacct ttgcaattgc ggttcgaatc tatccgatct
+    84061 ttatcttttt gctcaaagaa cgaataaaac cccttgtcga agccctttat gataagcttc
+    84121 cctggatctg ggaagtttct ctttcacggt attgggatcg tttgctcgat ttccttgatt
+    84181 tgatcgctac ttatgggcgt gcgctcaaag gatacaaaca gggattcgca aacaaaaagg
+    84241 ggaattcgta gtcacttttt cctgtcgcgt aaaaaaaagt ctttacgcga gagcaataga
+    84301 ggttgggata catctatctc ttctgagcaa cctcttttgg attcttaaga ccacccttgc
+    84361 agtaggatac catccgcttt gggttcttta ttatctcctt cgagggattt ttaggatcgt
+    84421 tcaggctata tttagtctat tttggctttt actgtctact tttttcagag agatggttaa
+    84481 ggacctcaga agatagagga gagcgccagg cgcagatttc cggaatactt ctacggggaa
+    84541 tgctcattga atgagcattc tccatattat gccttgaaga ggactcgaac ctccacgctc
+    84601 ttcagcacga gattttgagt ctcgcgtgtc taccatttca ccatcaaggc atcttgaaag
+    84661 tgaatcgtat tccatgaata tgatatctat ctaatgcgat atatggaata tatgacaaag
+    84721 gtggagtctt ggagtatttc gatcgatcgg tcatataggc ctgagtcaga catcaaatag
+    84781 cttcgatttg cattatccgt aggacacctt atatgtatca aaatcgatat caaaatcaaa
+    84841 aagatgaaag atgtacaatc caatttctcg attcaataga agcccaaaga ggtgcatatg
+    84901 gtacccaaat aaaaatagga tagatatgtc aaaagcaggt ctgcttacac ctattcctaa
+    84961 tcctaaatag aatgtaagga cgtagggatt tctatgtaaa cagagtatcc tatttccata
+    85021 ggctcgaatg accccttctc ataataagaa tgtgcacggt ctagtccggt atggaatgaa
+    85081 cttataatct gatgatcgag tcgattccat gattataagt tcataaccct agcgcccatt
+    85141 cccatttttg gcggaacaga tctactaatt cttttattcc agttagtaag agggatcttg
+    85201 aactaagaaa tagacctagc agctaaaaga gggtatcctg agcaattgca agaatgggat
+    85261 tcattgatat tcctggtata gtagatgcta tcacacatac agtcatactc aattcgatgg
+    85321 aattgtttga tcttaaaggg gatcttctat aatttctcac ataaggggtt atttcttggt
+    85381 ttcgtccagt cattaataac tttattattt ttagataata gtagatagaa agaacgctcg
+    85441 taaggagtcc tattgaaacc aagaaatata ggcctgcttg ccatccacac cagaatagat
+    85501 agagttttcc gaagaaacct gctagtggag gaaggcctcc tagggataag agacataggg
+    85561 ctaaagagag agccaaaaaa ggatctttcg tgtataatcc tgcataatct cgaatgttat
+    85621 cagttccggt acgtagacca aataatacaa tgcaagcaaa agttcctaga ttcatggaga
+    85681 tatagaacag catataagtt atcatgcttg catatccatc atttgagtct ccaacaatta
+    85741 ttccaataat tacatatccg atttgcccta tggacgaata tgcaagcata cgtttcatgc
+    85801 ttgtttgagt aatagcaagg agattcccca aaatcatgct aagaatagct aggatttcca
+    85861 gaagaagatg ccattcgttt gatgagaaat aaaaaggaat atcgagaatt cgcgtggctg
+    85921 aagctgaagc agctactttc gaagtaacag aaagaaaagc aacgactgga gtgggggagt
+    85981 cagagtcgaa aagaggattc ctcgcttctt tctctcatgc aaaaccgtgc atgagacttt
+    86041 catctcgcac ggctcctaag tgataaaaga aagaagaact cgtcttcttt cttttttgat
+    86101 taccttcctc gcgtatgtat aagaccaaat ccattctttt tcgaaatcga tttcgaaaaa
+    86161 gaactactaa tccttaactt ttcgaggaat ccttcatcag tggttgtgaa tgactgactt
+    86221 tttcaatcct ttcgaccttg gttccgtagg agcaagtcag aaaggttgag aaatagaacc
+    86281 atctgatttg attcgttccc aatagccatg agatgatcat cttagggcga tccttttgtc
+    86341 aacggatgct cctattacac tcgtagtctc tgaaggatga gaacccacta tgtagcatct
+    86401 acatcgataa ttcaagcatt gtatacgtca ttagtccgat tctttgtagg aactacccgt
+    86461 aataacgaac ttgcaaaatg gatctgttta tcataaagag attcgttgtt cctgaccctg
+    86521 cttcacctta attgttattt gaacaaaaag atcacaataa acttttggta aaagttctgt
+    86581 cttggtcgga gtggggatag catttctctt ctgcatgtct atggagtttt gcaaaaccca
+    86641 aacacctcgg agatagatat agaggtagga atgaatttgt cgaacgaacc acactccttc
+    86701 gtagacgtca ggagtccatt gatgaaaagg ggctggggaa agcttgaacc caagtcctac
+    86761 agtgatggat ataagcgcaa ttgaaattcc tggggagtta tacatttgtg tattgataag
+    86821 accgttcaca atttcttgaa gctcgatctc ccccccagat gaaccatata gccaagagaa
+    86881 accatgaacc agaatagaag agcttgcccc acccatgagt aaatatttca tagtagcctc
+    86941 attagaccgt agatctctct tggtatatcc agacaatagg taggaacata aactgaaaca
+    87001 ttctgaagct acaaagatag ttattaaatc gttagcacca cataaaaaca ttccccctag
+    87061 agtagctgtt aatacgaata acagaaactc tgttatagcc atttctgtac attcaatgta
+    87121 ctctacggat agaggaatac ataaagttga acataataaa atgagaaatt gaaagatttc
+    87181 gttgaaattg ttcgtttgga aatttcccga aaagctaatt ataggttctt ctctccatcg
+    87241 gaacaatagg gccgttatgc ttattactaa acttgttgaa gagatgaaat agaaccaagg
+    87301 tctatctttt tgatcagagg ttgaatcgat catcagaaga agaattaggc caaaaattag
+    87361 gatacattct gggaaaatga aacttccatg gaagagaagc aaatgaagcg ctttcataaa
+    87421 aattctcgta gaatcgagaa tgaagttttc attctgtaca tgccagatca tgaattagta
+    87481 actgcatcca atctccgaaa agtcccgatt gtttctattt ttggaatggc atatttacgg
+    87541 aatccccatg aataggatca aaccttattc catttccata agattcttct ttcttattct
+    87601 taagcaagcc ctcgagaggg cttagttgat catgattttt gttttctctt tcttttcctt
+    87661 tttgtttgtt tcgagaaaga tatcgtccga ttctccttct attgattctt ttccgatcga
+    87721 gatgtatgga tccatgtgtc tacataccta gattctgttc atggattaac gaaaatgtgc
+    87781 aagagctcta tttgcctctg ccattctatg agtcgcttcc tttttgcgta tggcaccccc
+    87841 actccctttg gcagcatcta ctaattcgga acttaatttg aaagccatat ttcgacccgg
+    87901 acgcttttgg gatgcttcta ataaccaacg aatggcaagt gctcttcctt gtttagatcc
+    87961 tatttcaatc ggaactttcc gcgtcgatcc ttttttatta cgtcttgttt ttactcctat
+    88021 attgggagtt actctacgta ttgcttgacg taaaaccaat agtggatttg tttctgtctt
+    88081 ttgttgaatc tttttgacgg ctcgatagag aatttgataa gccaatgatt tttttccgtc
+    88141 tttcataata cggttaacca ccatgttaac taatcgatta cgaaaaattg gatcggattt
+    88201 tgcagttctt ttttctgcag tacctcgacg tgacatgagc gtgaaagagg ttcaagaatc
+    88261 cgttttcttt ttataagggc taaaatcact tatttttttg gctttttgac cccatattgt
+    88321 agggtggatc tcgaaagata ggaaagatct ccctccaagc cgtacatacg actttcatcg
+    88381 aatacggctt tccacagaat tctataggga tctatgagat cgagtatgga attctgttta
+    88441 ctcactttaa attgagtatc cgtttccctc cttttcccgc taggatcgga aatcctgtat
+    88501 tttccatatc catacgatcg agtccttagg tttccgaaat agtgtaatgg aaaaagaagt
+    88561 gcttcgaatc attgctattt gactcggacc tgttctgaaa aagtcgaggt atttcgaatt
+    88621 gtttgttgac acggacaaag taagggaaaa cctctgaaag aatttccata ttgaccttgg
+    88681 acatataaga gttccgaatc gaatctcttt agaaagagga tcttttgtct catggtagcc
+    88741 tgctccagtc cccttacgaa actttcgtta ttgggttagc catacacttc acatgtttct
+    88801 agcgattcac atggcatcat caaatgatac aagtcttgga taagaatcta caacgcacta
+    88861 gaacgccctt gttgacgatt ctttactgcg acagcatcta gggttccccg aataatgcga
+    88921 tatctcacac cgggtaaatc cttaaccctt cctcctctta ctaatactac agaatgttct
+    88981 tgtaaattat ggccaatacc aggtatataa gcagtgattt caaatccaga ggttaatcgt
+    89041 actctggcaa ctttacgtaa ggcagagttg ggttttttgg ggttgatagt ggaaaagtcg
+    89101 acagataagt cacccttact gtccctttac agaaccgtac atgagatttt caccgcatac
+    89161 ggctcctcgg tcaattcggg atccttttcc tcgttcgaga gtctccgccc ttcttccact
+    89221 ccgtcccgaa gactaactaa gaccaattga gtcacgtttt catgttctaa ttgaacactt
+    89281 tccatttatg atatgattaa aggagaagat tgttctttta ccaaacatat gcggatcaaa
+    89341 tcacgtctta taataagaag aaatctttct cggtatcaat ccccttgccc ctcattcttt
+    89401 gagaatcaga aggatccttt tcgagtttcc gtttcttcat ttggaatctg ggctcttcta
+    89461 tcttcgactt attttttttt gctttattct ttatttattc cattccaatt tcttctcgaa
+    89521 acttcccaag aaaaatcccg aattggatcc aaaattgacg ggttaatgtg agcttatcca
+    89581 tgcggttagg cactcttcaa ataggaatcc attttctaac tggctttcgt gctttggtga
+    89641 gtcgtccgag atcttttcga tgacctatgt tgtgttgaag ggatatctat atgatccgct
+    89701 cgattgcata agacccccgg tagcaataga acggggaaag tatacagaaa agacagttct
+    89761 tttcaatttc gattatctat atattagttc gtttctattt ctagatatct atttctatat
+    89821 attagtatta gttagtagta ctattctatt agttaccgat cccggctctg tgagttcttt
+    89881 cttccgtgat gaactgtcgg caccagtcct acattttttt ctctgtggac cgaggagaaa
+    89941 gggggctcgg caggaagagg attgtaccat gagagaagca cggaggtcaa cccgcttcaa
+    90001 atatggaaca tggattctgg caatgcaacg gagttgggtc ctcatatcga tccgatccga
+    90061 atgaatcagt ctttctacag aggtcaatct ttgcctatta ggcaagagga tagcaagttc
+    90121 gaaattctgt ctcggtagga catggatttc tattactatc aaattcataa atgaaaatga
+    90181 agtagttaat gggagggcta ccattatcct ttttcttgta tgtgttccta agagaagtaa
+    90241 tttgtcctca tgtttcgagg tctcaaaaaa aaggcgtgga aacagataga aactcttgaa
+    90301 tggaaattga aaagaaatgt agccccagtt ccttcggaaa tggtaagatc tttggcgcaa
+    90361 gaagaagggg cgacccatat catcttgact tggttctgct tcccctcttt ttttaagaat
+    90421 accgagtcgg gttcttctcc taccagtatc gaatagaaca tgctgaacaa gatcttcttc
+    90481 atggaaacct gctcgattta gatcgggaaa atcgtacaga ttttatgaaa ccatgtgcta
+    90541 tggctcgaat ccatagccaa tcctactttc gataggaccg gttgacaatt gaatccaatt
+    90601 tttcccatta tttgactatc cataatagtg cggaaagaaa gcccggagga agagtggcct
+    90661 tgagtttctc gcccctttgc cttaggattc gttaattctc tttctcgatg ggacggggaa
+    90721 gggatataac tcagcggtag agtgtcacct tgacgtggtg gaagtcatca gttcgagcct
+    90781 gattatccct aaacccaatg tgagtttttt ctattttgac ttactccccc gccacgagcg
+    90841 aacgagaatg gataagaggc ttgtgggatt gacgtgatag ggtagggttg gctatactgc
+    90901 tggtggcgaa ctccaggcta ataatctgaa gcgcatggat acaagttttc cttggaagga
+    90961 aagacaattc cgaatccgct ttgtctacga ataaggaagc tataagtaat gcaactatga
+    91021 atctcatgga gagttcgatc ctggctcagg atgaacgctg gcggcatgct taacacatgc
+    91081 aagtcgaacg ggaagtggtg tttccagtgg cgaacgggtg agtaacgcgt aagaacctgc
+    91141 ccttgggagg ggaacaacaa ctggaaacgg ttgctaatac cccgtaggct gaggagcaaa
+    91201 aggagaaatc cgcccaagga ggggctcgcg tctgattagc tagttggtga ggcaatagct
+    91261 taccaaggcg atgatcagta gctggtccga gaggatgatc agccacactg ggactgagac
+    91321 acggcccaga ctcctacggg aggcagcagt ggggaatttt ccgcaatggg cgaaagcctg
+    91381 acggagcaat gccgcgtgga ggtggaaggc ctacgggtcg tcaacttctt ttctcggaga
+    91441 agaaacaatg acggtatctg aggaataagc atcggctaac tctgtgccag cagccgcggt
+    91501 aagacagagg atgcaagcgt tatccggaat gattgggcgt aaagcgtctg taggtggctt
+    91561 ttcaagtccg ccgtcaaatc ccagggctca accctggaca ggcggtggaa actaccaagc
+    91621 tggagtacgg taggggcaga gggaatttcc ggtggagcgg tgaaatgcat tgagatcgga
+    91681 aagaacacca acggcgaaag cactctgctg ggccgacact gacactgaga gacgaaagct
+    91741 aggggagcaa atgggattag agaccccagt agtcctagcc gtaaacgatg gatactaggt
+    91801 gctgtgcgac tcgacccgtg cagtgctgta gctaacgcgt taagtatccc gcctggggag
+    91861 tacgttcgca agaatgaaac tcaaaggaat tgacgggggc ccgcacaagc ggtggagcat
+    91921 gtggtttaat tcgatgcaaa gcgaagaacc ttaccagggc ttgacatgcc gcgaatcctc
+    91981 ttgaaagaga ggggtgccct cgggaacgcg gacacaggtg gtgcatggct gtcgtcagct
+    92041 cgtgccgtaa ggtgttgggt taagtctcgc aacgagcgca accctcgtgt ttagttgcca
+    92101 ctatgagttt ggaaccctga acagaccgcc ggtgttaagc cggaggaagg agaggatgag
+    92161 gccaagtcat catgcccctt atgccctggg cgacacacgt gctacaatgg gcgggacaaa
+    92221 gggtcgcgat ctcgcgaggg tgagctaact ccaaaaaccc gtcctcagtt cggattgcag
+    92281 gctgcaactc gcctgcatga agcaggaatc gctagtaatc gccggtcagc catacggcgg
+    92341 tgaatccgtt cccgggcctt gtacacaccg cccgtcacac tataggagct ggccatgttt
+    92401 gaagtcatta cccttaaccg taaggagggg gatgcctaag gctaggcttg cgactggagt
+    92461 gaagtcgtaa caaggtagcc gtactggaag gtgcggctgg atcacctcct tttcagggag
+    92521 agctaatgct tatgcttatt gggtattttg gtttgacact gcttcacgcc caaaaagaag
+    92581 gcagctacgt ctgagctaaa cttggatatg gaagtcttct ttcgtttagg gtgaagtaag
+    92641 accaagctca tgagcttatt atcctaggtc ggaacaaatt agttgataag tgataggatc
+    92701 ccttttttga cgcccccatg tcccccccct gtggtgtggc ggcatgggga tgtcaaaagg
+    92761 aaagggatgg agtttttctc gcttttggcg tagcaggcct ccctttggga ggcccgcgcg
+    92821 acgggctatt agctcagtgg tagagcgcgc ccctgataat tgcgtcgttg tgcctgggct
+    92881 gtgagggctc tcagccacat ggatagttca atgtgctcat cagcgcctga cccgaagatg
+    92941 tggatcatcc aaggcacatt agcatggcgt actcctcctg tttgaatcgg agtttgaaac
+    93001 caaacaaact tctcctcagg aggatagatg gggcgattca ggtgagatcc catgtagatc
+    93061 taactttcta ttcactcgtg ggatccgggc ggtccggggg gggccaccac agctcctctc
+    93121 ttctcgagaa tccatacacc ccttatcagt gtatggagag ctatctctcg accacaggtt
+    93181 gaggtccgtc ctcaatggga aaatggagca cctaacaacg catcttcaca gaccaagaac
+    93241 tacgagatca cccctttcat tctggggtga cggagggatc gtaccattcg agcctttttt
+    93301 tcatgctttt cccggcggtc tggagaaagc agcaatcaat agcactttcc taatcctccc
+    93361 ttcctttcag gaagaacgtg aaattctttt tccttaaatg ggagcagagc aggtttgaaa
+    93421 aaggatctta gagtgtctag ggttgggcca ggagggtctc ttaacgcctt cctttttctg
+    93481 cccatcggag ttatttccca aggacttgcc acggtaagag ggggaagggg gaagaagcac
+    93541 acttgaagag cgcagtacaa cggggagttg tatgctgcgt tcgggaagga tgaatcgctc
+    93601 ccgaaaagga gtctattgat tctctcccaa ttggttggat cgtaggggcg atgatttact
+    93661 tcacgggcga ggtctctggt tcaagtccag gatggcccag ctgcgccagg gaaaagaata
+    93721 gaagaagcat ctgactcttt catgcatact ccacttggct cgggggggat atagctcagt
+    93781 tggtagagct ccgctcttgc aattgggtcg ttgcgattac gggttggctg tctaattgtc
+    93841 caggcggtaa tgatagtatc ttgtacctga accggtggct cactttttct aagtaatggg
+    93901 gaagaggact gaaacatgcc actgaaagac tctactgaga caaaaagatg ggctgtcaaa
+    93961 aaggtagagg aggtaggatg ggcagttggt cagatctagt atggatcgta catggacgat
+    94021 agttggagtc ggcggctctc ctaggcttcc ctcatctggg atccctgggg aagaggatca
+    94081 agttggccct tgcgaataac ttgatgcact atctcccttc aaccctttga gcgaaatgta
+    94141 gcaaaaggaa gcaaaatcca tggaccgacc ccattgtctc caccccgtag gaactacgag
+    94201 atcaccccaa ggacgccttc ggcgtccagg ggtcacggac cgaccataga ccctgttcaa
+    94261 taagtggaac acattagccg tccgctctcc ggttgggcag taagggtcgg agaagggcaa
+    94321 tcactcgttc ttaaaaccag cattcttaag tttaagatca aagagtcggg cggaaaaagg
+    94381 ggagagctcc ccgttcctgg ttctcctgta gctggattcc ccggaaccac aagaatcctt
+    94441 agaatgggat tccaactcag caccttttgt tttgagattt tgagaagagt tgctctttgg
+    94501 agagcacagt acgatgaaag ttgtaagctg tgttcggggg ggagttattg tctatcgttg
+    94561 gcctctatgg tagaacccgt cggggaggcc tgagaggcgg tggtttaccc tgtggcggat
+    94621 gtcagcggtt cgagtccgct tatctccagc ccgtgaactt agcggatact atgatagcac
+    94681 cgaattttgc caattcggca gttcgatcta tgatttcgca ttcatggacg ttgataagat
+    94741 ccttccattt agtagcacct taggatggca tagccttaac gttaatggcg aggttcaaaa
+    94801 gaggaaaggc ttgcggtgga tacctaggca cccagagacg aggaagggcg tagcaagcga
+    94861 cgaaatgctt cggggagttg aaaataagca tagatccgga gattcccaaa taggtcaacc
+    94921 ttttaaactg cctgctgaat ccatgagcag gcaagagaca acctggcgaa ctgaaacatc
+    94981 ttagtagcca gaggaaaaga aagcaaaagc gattcccgta gtagcggcga gcgaaatggg
+    95041 agcagcctaa accgtgaaaa cggggttgtg ggagagcaat acaagcgttg tgctgctagg
+    95101 cgaagcggtt gagtgccgca ccctagatgg ctaaagtcca gtagccgaaa gcatcactag
+    95161 cttacgctct gacccgagta gcatggggca cgtggaatcc cgtgtgaatc agcaaggacc
+    95221 accttgcaag gctaaatact cctgggtgac cgatagcgaa gtagtaccgt gagggaaagg
+    95281 tgaaaagaac ccccagtggg tagtgaaata gaacgtgaaa ccgtgctgag ctcccaagca
+    95341 gtgggagggg aaagtgatct ctgaccgcgt gcctgttgaa gaatgagccg gcgactcata
+    95401 ggcagtggct tggttaaggg aacggaaccc accggagccg tagcgaaagc gagtcttcat
+    95461 agggcgattg tcactgctta tggacccgaa cctgggtgat ctatccatga ccaggatgaa
+    95521 gcttggatga aactaagcag aggtccgaac cgactgatgt tgaagaatca gcggatgagt
+    95581 tgtggttagg ggtgaaatgc cactcgaacc cagagctagc tggttctccc cgaaatgcgt
+    95641 tgaggcgcag cagttgactg gacatctagg ggtaaagcac tgtttcggtg cgggctgcgc
+    95701 gagcggtacc aaatcgaggc aaactctgaa tactagatat gaccccaaaa taacaggggt
+    95761 caaggtcggc cagtgagacg atgggggata agcttcatcg tcgagaggga aacagcccgg
+    95821 atcaccagct aaggccccta aatgaccgct cagtgataaa ggaggtgggg gtgcaaagac
+    95881 agccaggagg tttgcctaga agcagccacc ctttaaagag tgcgtaatag ctcactgatc
+    95941 gagcgccctt gcgctgaaga tgaacggggc taagcgatct gccgaagctg tgggatgtca
+    96001 aaatgcatcg gtaggggagc gttccgcctt agagggaagc aaccgcgaaa gcgggggtcg
+    96061 acgaagcgga agcgagaatg tcggcttgag taacgaaaac attggtgaga atccaatgcc
+    96121 ccgaaaaccc aaggtttcct ccgcaaggtt cgtccacgga gggtgagtca gggcctaaga
+    96181 tcaggccgaa aggcgtagtc gatggacaac aggtcaatat tcctgtacta ccccttgttg
+    96241 gtacggaggg acggaggagg ctaggttagc cgaaagatgg ttataggttt aaggacacaa
+    96301 ggtgaccctg ctttttcagg gtaagaaggg gtagagaaaa tgcctcgagc cgaggtccga
+    96361 gtaccaagcg ctgcagcgct gaagtatgag ccccgtggac tagcgattgc ttctccacga
+    96421 ggctcatacc aggcgctacg gcactgaagt atgtaaccga tgccatactc ccaggaaaag
+    96481 ctcgaacgac cttcaacaaa agggtacctg tacccgaaac cgacacaggt gggtaggtag
+    96541 agaataccta ggggcgcgag acaactctct ctaaggaact cggcaaaata gccccgtaac
+    96601 ttcgggagaa ggggtgcccc ctcacaaaag ggggtcgcag tgaccaggcc cgggcgactg
+    96661 tttaccaaaa acacaggtct ccgcaaagtc gtaagaccat gtatgggggc tgacgcctgc
+    96721 ccagtgccgg aaggtcaagg aagttggtga actgatgaca gggaagccgg cgaccgaagc
+    96781 cccggtgaac ggcggccgta actataacgg tcctaaggta gcgaaattcc ttgtcgggta
+    96841 agttccgacc cgcacgaaag gcgtaacgat ctgggcactg tctcggagag aggctcggtg
+    96901 aaatagacat gtctgtgaag atgcggacta cctgcacctg gacagaaaga ccctatgaag
+    96961 ctttactgtt ccctgggatt ggctttgggc ctttcctgcg cagcttaggt ggaaggcgaa
+    97021 gaaggccccc ttccgggggg gcccgagcca tcagtgagat accactctgg aagagctcgg
+    97081 attctaacct tgtgtcagac ccgcgggcca agggacagtc tcaggtagac agtttctatg
+    97141 gggcgtaggc ctcccaaaag gtaacggagg cgtgcaaagg tttcctcggg ccagacggac
+    97201 attggtcctc gagtgcaaag gcagaaggga gcttgactgc aagactcacc cgtcgagcag
+    97261 agacgaaagt cggccttagt gatccgacgg tgccgagtgg aagggccgtc gctcaacgga
+    97321 taaaagttac tctagggata acaggctgat cttccccaag agtccacatc gacgggaagg
+    97381 tttggcacct cgatgtcggc tcttcgccac ctggagctgt aggtggttcc aagggttggg
+    97441 ctgttcgccc attaatgcgg tacgtgagct gggttcagaa cgtcgtgaga cagttcggtc
+    97501 catatccggt gtgggcgtta gagcattgag aggacctttc cctagtacga gaggaccggg
+    97561 aaggacgcac ctctggtgta ccagttatcg tgcctacggt aaacgctggg tagccaagtg
+    97621 cggagaggat aactgctgaa agcatataag tagtaagccc accccaagat gagtgctctc
+    97681 tcctccgact tccctagagc ctccggtatc acagccgaga cagcgacggg ttctccaccc
+    97741 atacggggat ggagcgacag aagtatggaa ataggataag gtagcggcga gacgagccgt
+    97801 ttaaataggt gtcaagtgga agtgcagtga tgtatgcagc tgaggcatcc taacgaacga
+    97861 acgatttgaa ccttgttcct acacggcctg atcaaatcga tcaggcactt gccatctatc
+    97921 ttcattgttc aactctttga tgaaaagatg aaaaaaccaa aaaaagctct gcccttccat
+    97981 ctcttggata gatagagagg gagggcagag gcctttggtg tccttttcag tcaagaattg
+    98041 gggcttcaca attactagcc aatatttctc tcatgccttt cctcattcat ggttcgatat
+    98101 tctggtgtcc taggcgtaga ggaaccacac caatccatcc cgaatttggt ggttaaactc
+    98161 tactgcggtg acgatactgt aggggaggtc ctgcggcaaa atagctcgat gccagaatga
+    98221 taaaaagctt aacacctctt atttgacttt ttcactattt tgaaatacga aaaagatcca
+    98281 aatctaaaat gcaaaggtcg tcttattcaa aacctcaatc atcagatccc ctctctccca
+    98341 cttcacacct cggaacgcgc tgttcttata gagagaaagg cgctttctca tcttcttaac
+    98401 ccgaaatgaa ggggtacccc cgagaagaga gccagtagag acgggtgggc ctgtagctca
+    98461 gaggattaga gcacgtggct acgaaccacg gtgtcggggg ttcgaatccc tcctcgccca
+    98521 cagctttcca aagggggaaa gtaaaggtcc ttccccctga gggtaggaaa atcatgatcg
+    98581 ggatagcgga cgtaaagcta ttgaacttag gtatgctctt tccttttgtc gaagtggaat
+    98641 cgtagaacag aatgtgatac gatgagatag aatgcaatag aaatagaaac aaggatagcg
+    98701 aacgggttac ctactcctaa gggtcaaagc aagcccttta attcaattct ttattcttac
+    98761 attaaagaat gaatcaaatc tccccaagta ggattcgaac ctacgaccag tcagttaaca
+    98821 gccgaccgct ctaccactga gctactgagg aacaaggggg gattccccct cctagggttc
+    98881 aactcccgct ctcaacccat gaacaatatg ggtccgaagc tcttcgtact cccagaattt
+    98941 cttcataggt ggctccgttc catgcctcat ttcataggga agcccaaagt ggctctattt
+    99001 cattctattt cacttcctag cacttcctat catttaatat ccatcccttt ggtcttattg
+    99061 acatatgaga tgtcatttat agtctatctc tttctatata tggaaagtca agaaattctc
+    99121 atcaaaacat cgagaaattc tgcatataga aaactctaaa gaaagaaaaa aaggagaccc
+    99181 atgccatgat tttcaaatct tttccattta gtagtctaag tttctcgatg aggataatta
+    99241 attcggtcgt tgtggtcgga ctctattaag gatttctgac cacattcccc atagggccct
+    99301 cttagatctt ctttctccaa tcttggatta gggaagaagg ggatattcgc gactactggc
+    99361 ggtttcatta tggggcagct catgatcttc atatcgatct attatccacc tctgtatcta
+    99421 ttctttctta gctaaacggg tggaagatcc atccaatttg gttatatcat ggactgaaaa
+    99481 aacaaacgga tctgaatttg actgaaatgc acgatcttca caggtatcac ttttcacgat
+    99541 acctaaaagg tggaatagcg atttgcgagc catttcctat aagagaatgg tttccattac
+    99601 tttgagaaat agattcttat atcaaactat agctattgca ttaaagaaga aaagaaacta
+    99661 atagaagtcg aagacgcgga atggtagtga atagagagaa agattcttcc gattttcttg
+    99721 ttcctgaaaa tattctatct atctcctaga cgccgtagat aattgagaat tttcatctct
+    99781 ttcaattctc gtactcgtaa ttggaaagtt acggaaggag acccgtcatt ttgcaatgaa
+    99841 aacaacatat aaaactctgg acaattttga aatcaggcca agcgtcttaa tacatatgca
+    99901 aaaaaattca ttagtggccc accattgatt agaagattta gcttgtatga atcgctattg
+    99961 gtttgatacg aataatggca atcgtttcag tatgttaagg atacagatgt atccacaatt
+   100021 catttcgagt tacttaatag cctatttctt ataccatatc tctatcccgt gaaattctcg
+   100081 agcccaaaga tggatgcata tgctatgttt cattttgcta aatgatatca attaaattgt
+   100141 gtatcaattc cataaattgg atatagcaat aaaaaaatca gcaaaattat tttattttag
+   100201 atagaagaaa tgtttcttct atctaaaata agagaatgta cccttctatc caaatccaat
+   100261 ttgcatcgat aaaataaatc caaattccag tagtagatga ataattgcaa atttttgtgt
+   100321 gtacgagatt agaataactt caaaataact gacataatgt tttatttttc ctgatcagaa
+   100381 aaatacatga aaaagaaagg aggtagaaaa atctttggat ttatggttaa agaagaaaaa
+   100441 gaagaaaaaa agggttctgt tgaatttcaa gtattcagtt tcaccaataa gatacggaga
+   100501 cttgcttcac atttggaatt acacaaaaaa gatttttcat cggaaagagg tctacgaaga
+   100561 cttttgggaa aacgtcgacg tttgctggct tatttggcaa agaaaaatag agtacgttat
+   100621 aagaaattaa tcagtcagtt gaatattcgg gagcagtaat ttaatcgttc gaattttttt
+   100681 acttatttta tttagtagcc ttatagtagt cttagatttt gcattttgat gagcctcgtt
+   100741 ttgaggaatt catggaataa cgaattaagg aagaaaggat atgagtctac cgcttacaag
+   100801 aaaagatctc atgatagtca atatgggccc tcaacaccca tcaatgcatg gtgttcttcg
+   100861 actgatcgtt actctcgatg gtgaagatgt tattgattgt gaacccatat tagggtattt
+   100921 acacagagga atggaaaaaa tcgcggaaaa ccgaactatt atacaatact taccttatgt
+   100981 aacacggtga aaaagagacc tggaaattcc ttcagttaag aaagaaaaaa gaacagttaa
+   101041 gaaagaaaaa agaacagtta agaaagaaaa aagaataaaa acacagatac ataacataga
+   101101 aaaaagaata aataagatga gattcgtcct ccccctacat atttaatttc ttctcctata
+   101161 caaaaactag caagacccac tccattggta atcccatcaa tgacaccctt atcgaaaaac
+   101221 tccgttagtt cggttaatcc tcttataccc aaggtaaaga gcctactata gaaaatatct
+   101281 atataaccac gattatatga ccaactgtat atcttttttt ttacttgata aaaaaagttc
+   101341 ttttttggac ttcctttgta aaaggaattt tgtaaatcca aattctgaaa aaaagaataa
+   101401 gcagatccat agaaaatata tgctatgaat aaaccgagga taactagact tacagaagat
+   101461 attgcattag taataaattc atatgaattt atagaagagt tggaactttc ctgagtaaag
+   101521 tttattgaag gaattaacca ctttgataat atggttaccc ccgctattcc attatccatt
+   101581 gtttcattat caaaagggat tcctatgaat ccaatgaaga aagtaaaaag cagtaatata
+   101641 agaagaggaa ataacatagt atttcccgtt tcatgcggat aggtaaaaac atttttagac
+   101701 ccaaaggaag tactaaaaga ttctatccta tttcttgtat taccttgacc tttggatatg
+   101761 gatatatttt gtgaaaaaaa ataaacttca ctcttcgttg ttgataaaac gaaatcttta
+   101821 ctcactcctt tgggtatcct atttccccat aaagatattg aatacaagga accttcttta
+   101881 gtgctactat aattttgaaa atgaaaacga aaatacccgt caaacgtaag taaatatatc
+   101941 cgaaacatat aaaaggcagt taacccagca gtaaaggaag ctattattcc aaaaaagggc
+   102001 gaatacaacc aactattact aaggatttca tctttggacc agaagcaagc aagaggcgga
+   102061 ataccacaaa tagaaagcgt accccataaa aaagcggttc ttgtaattgg aatgtatttt
+   102121 cttaaaccac ccataagagc catattctga cttttatctg gtgaatatcc aacaagcggt
+   102181 tccattgaat gaataatgga tccggatccc aagaacaata aagcttttga ataagcatga
+   102241 gtgatcaaat ggaataaagc agcttgataa gaacctatac ctaaagctaa catcatataa
+   102301 cccaattgag acattgtaga ataagctaaa gttcttttaa tatctctctg agcaagagct
+   102361 aaagtagctc ctaagaagag tgttattgta cctactaaag aaatgaaagt cattatcaaa
+   102421 ggtagagata tgaaaagagg gagaaggcga gctagaagaa aaatccccgc agcaaccata
+   102481 gttgctgcgt gtataagagc cgaaatggga gtgggtccct ccattgcatc gggtaaccat
+   102541 acgtgaagag ggaattgtgc ggatttcgca actgccccaa ggaataataa aaaagcacat
+   102601 aaagtagtaa gtaaagaggt cgtcccatta ttaggaatcc agttattagc tgtttggaac
+   102661 aaatccctaa attctaaact acctgttatc caaaaaaaac ctaaaattcc taataaaaga
+   102721 ccaaaatcac ctatacgatt agttacaaaa gctttttgac aagcgctcgc tgcgattggt
+   102781 cgtgtaaacc aaaagcctat caataaatag gaacacattc ccacaagttc ccaaaaaaaa
+   102841 taaatttgta tcaaatttga actagtaacc aatcccaaca tggaaatatt gaaaaaactt
+   102901 atataaataa aaaatctcaa atatccttca tcatgagaca tataaccatc actataaata
+   102961 agaaccagga ttcctacagt agtaattagc attaacataa tcgaagtaag cgggtcaatc
+   103021 aagtatccaa attctaagga aaaatcatta ttgatggtcc aagaccatag atattgatag
+   103081 atagaacttc catttatttg ttgaatagac aattgaactg agaataccat agctatactt
+   103141 aagagtaaaa cactaggaaa agcccatatg cgacgaaaat tttttgttgc gatcggaata
+   103201 agaaaaaggc caaaccccat tgacagaata actggaagtg ggagaagagg gattacccaa
+   103261 gcatattgat atgtatgttc cataagaaaa gaaattaaaa tttttacttg aaatttttac
+   103321 ttcaattttt tataaaaaaa ttgtttctga ttcaccaaac ctattcttat ctctttctga
+   103381 aggaataaat aataagtaaa aaaaataaga aaaaatactg gaattcttaa tttttgaaaa
+   103441 tttatatcat tgaaataatc caaaattaag aatgggttta gttggttaaa ttcaaaaaaa
+   103501 gttaatcaac taacttcgtt acctagttat tatctaaata aggatattta tgaaaaaaaa
+   103561 agtggaatca tttaactttc tattcatttt tctatttctt taaaacaaag atgaagcagc
+   103621 tctcttgttt agagaactaa aatcataatt actataatta cctaagtttt ataatgtctt
+   103681 gtttaagaga ctcagtattt tttgtttttt aattcgaatt ccattatgga ataccattct
+   103741 taacttaatt aaataaatta aatatttgca ttttccgttc tttttacccc ctcgtcttat
+   103801 atgggggata gacttccgta ccgtatatct atatatggag tatccttgat atataaatat
+   103861 atagataaat agatttaaat ggaaaacctt tctatatatt ctatattatt aaaacaaagt
+   103921 ttaaaatata tacggaaaaa gtgctaacaa attcttgtct tatctgcatt agacaaaatg
+   103981 aagtaaaaaa taattcagaa tttaaatatc tttcagtata taagtataaa tactaagaag
+   104041 aaatactaag aaaaagaaga aagaaggatt gatttgtggc aatagatgtc tttcacatac
+   104101 aactagaaaa aagtaatttc ctttttgaat ggcagttcca aaaaaacgta cttcaatgtc
+   104161 aaaaaagcgt attcgcaaaa atatttggaa aaataagact tatttttcca tagtacaatc
+   104221 ttattgttta gcaaaatcaa gatcattttc cagcggtaac gagcatccaa aaccaaaggg
+   104281 tttttctggg aaacaaacaa acaaataatc tggttttgga ataatctgaa ttgacctatc
+   104341 aaaaaacaat tccaattatt taatatgaat aatttggatt aattaatgaa tgtactttta
+   104401 tgtgtcgaat tcctcggtac aatattctta gaacaaaccc gtccgatata tagaataata
+   104461 gtttttggta tactgtgtgc taagtattct tttcctatca atgaactttt cataaaagaa
+   104521 ttctcataat aaaatatgag aattctttta tgaaaagtga agtattcttg caataggatt
+   104581 taaaacttcc acctatctta tccaaaatca ttgctttaag gttggtaaat cctattaata
+   104641 agagcataaa agctttcatt ctataaattt gtctaaaata aaaaagggtt tctatttaat
+   104701 gatgaaatta aaatgcataa atagaaaaga gtttttggat tttctccatt gtatcaaaag
+   104761 aatttaaaaa atggaaacga gaaactaatt aaaaaaaaat ttcttctata ttccaactta
+   104821 gaaaaaagga gttccaactc tttcaagcag tgtttctatt aggcaaagca agagtttatt
+   104881 gtaaaaaaaa tcgcaatgat actaccaaac gaagtctatt taaatgaaga ctctaatgtt
+   104941 cctaaatttt atggactttc ccaatctgga cggttcgtga gataataact attattcttt
+   105001 taagttacct attatttgaa gttagccgcc atggtgaaat tggtagacac gctgctctta
+   105061 ggaagcagtg ctcaagcatc tcggttcgaa tccgagtggc ggcattctcg aaaaagaata
+   105121 caatagatta taaaatggat tcaattcgaa atttacaatt ttgtaatggg accttcccct
+   105181 tatgctattt gcaactttag aacatatact aactcatatt tctttctcaa ccatttcaat
+   105241 tgtgattacg attcatttga gagccttatt agttcgtgaa cttgggggat tacgcgattc
+   105301 gtcagaaaaa ggaatgatag ctactttttt ctctataaca ggattcctag tttctcgttg
+   105361 gctttcttcg ggacattttc cattaagtaa tttatatgag tcattgatct tcctttcctg
+   105421 ggctctgtat attcttcata cgattcctaa ggtacagaac tctaaaaatg atttaagcac
+   105481 aataactacg ccaagtacta ttttaacgca aggctttgcc acgtcaggtc ttttaactga
+   105541 aatgcatcaa tccacaatac tagtacccgc tctacaatct cagtggttaa tgatgcatgt
+   105601 cagtatgatg ttactaagct atgcaactct tttgtgtgga tctttattat ctgccgctat
+   105661 tctaatcatt agatttcgaa ataatttcaa ttttttttct aaaaagaata aaaatgtttt
+   105721 aaaaaaaaca tttttattta gtaagatgga atatttctat gcaaaaagaa gttattttaa
+   105781 aagcgcctct gttccttcat ttccaaatta ttacaaatat caattaactg agcgtttgga
+   105841 ttcttggagt tatcgtgtga ttagcctagg atttaccctt ttaaccatag gtattctttg
+   105901 tggagcagta tgggccaatg aggcgtgggg atcctattgg aattgggatc ctaaagaaac
+   105961 ttgggctttt attacttgga ccatattcgc aatttattta catagtagaa caaatcaaaa
+   106021 ttggaagggt acgaattccg cacttgtagc ttcgatagga ttccttataa tttggatctg
+   106081 ctatttcggt atcaatctat taggaatagg tttacatagt tatggttcgt ttacattaac
+   106141 acctaattga ttacataaaa taaaaccttc atttcattaa ggtttttact ttttcgtttt
+   106201 atttgagaac cccttgagcg ccttctcaaa gggttctcaa aaatgcgaga tagatctaat
+   106261 tagacttttt tatttttttt tctccattaa tagagcgggc tagttaaaaa aacctattta
+   106321 gggtaataat tggataagag agcctccacc ctgtcaacgg atagggagag aacaaaatct
+   106381 ggataaatac caattcctat tactggtaaa aagatacaga ttaaaagaaa gagttctcgt
+   106441 ggtccagaat ccataaaatt tgcgtttgga acattaaata gtttgtatcc atagaacatc
+   106501 tggcgtaaca tagataataa ataaatagga gttaatatca ttccaattgc cattacaaaa
+   106561 gtaattagcg tttttggcat taacagaaat tttggactag taattagtcc aaaaaatact
+   106621 aataattctg cgacaaaacc gctcattcct ggtaatgcaa gagaagccat tgaaaagcta
+   106681 ctaaacatgg taaaaatttt cggtattaga atagatatcc cccccagttc ttcgagataa
+   106741 acaagacgca ttctatcaca agccgttcct gccaagaaaa aaagtgtagc gccaataaat
+   106801 ccgtgggata atatttgtaa aatagctcca ttgagtccaa tgttggttat ggaaccaatt
+   106861 cctataatta tgaaacccat gtgagataca gaggaatagg ctattctttt tttgaaattt
+   106921 cgttgaccaa gagaagttga ggctgcatag attatttgga tcgctcctat tattaccaac
+   106981 cagggcgaaa atagataatg agcatgaggt aacaattcca tgttgatacg aatcaaccca
+   107041 tatgctccca tctttaatag gattcccgct aaaagcatac acgtactata atgtgcttcc
+   107101 ccatgggtat ctggtaacca cgtatggagg ggtataatcg gcaatttgac agcataagca
+   107161 ataaggaagc caaaatataa aagtatttcc aaggttgcag ggtatgattg attaattaat
+   107221 ctttccaaat ctaatcccgg ttcgttggaa ccgtacaagc ccatacccag aactccgatt
+   107281 aagaaaaaaa tggaaccgcc tgcagtatac aaaataaact ttgtagctga atatagacgc
+   107341 ctctttcccc cccacatgga taaaagtaag tacacaggaa ttaattctaa ctcccacatg
+   107401 ataaaaaaaa gtaaaaggtc tcgcgaagaa aataatccta tttgaccact atacattgct
+   107461 agcatcagga aatagaataa tcgcgaattc cgggtaacag gccaagcagc taaagtagct
+   107521 aaagtagtga taaatcctgt caataaaatg gatcctaatg aaagtccatc aattcccaat
+   107581 ctccagtgga aatcgaagac atctatccat ttagaatcct cttttaattg gattaaggga
+   107641 tcctccagtt ggaaatgata acagaatgca taagtcatta gaaggaattc taataaacaa
+   107701 atggatatag tataccacct aacgattttg tttcccctat gaggtaaaaa gaaaattaat
+   107761 gaacctgcaa atatcggcaa aactacaagt attgttaacc aaggaaaata actcatgata
+   107821 aagtaataaa gataagatac gttttgccca caaaagcccg tgctcgatta tttcgagcac
+   107881 aggcttcttc ggtaaagagg aatcagacga ttcaagtgga gttttttgta acgtatcaat
+   107941 aagatagagc catgctacgg gttgtttcag gccctaaata aacgcggacg cttaaaaaat
+   108001 ctgtcggaca ggcggattcg catctcttgc aacccacaca atcttcggtt cttggcgcgg
+   108061 aagcaatttg cttggcttta catccatccc agggtatcat ttctaataca tctgttggac
+   108121 aagctcgtac acattgagtg catcctatac atgtatcata aatttttaca gaatgtgaca
+   108181 ttggatctat aaatttttct tttcaacata aaatttttcc gatctggtaa attagtactg
+   108241 tatgagtcat atgtattgta gacaccagac gaagcaatgg tttgtccaaa cttcaaaaaa
+   108301 aataataatc tattttttaa tctgtttgtg agaaagcgtg aaaagagcca agagacttaa
+   108361 attttggact tcaacaatca taattatacg aatttagaat tcgccaataa attggctacc
+   108421 gtcttttcaa tataaattat tgcaatattc aaattgcaat atcaatgaat tagaaaaatt
+   108481 catttaagta aaaaagaata ctatgcaata acctactaaa aaaaggatat tctcaaataa
+   108541 taataagaaa atcgtattcg atttctattc atcttacata ttagagattc ttattatatg
+   108601 tactcctttg tttagagtat tctatgtcta attattcaag aaattagatt gattgatacg
+   108661 agttgatttc ctattacgat ggatggaaga aagaatggat agtccaatag cggcttcagc
+   108721 agccgcaagg gctataacaa aaattgcgaa aatgtctcct tttaattggc gactatcaaa
+   108781 tagatcagaa aatgttacga gatttagatt aattgaattc agtataagtt caagacatat
+   108841 tagagctcta accatgtttc ggcttgtgat caatccatag ataccaatcg aaaataaata
+   108901 gacactcaaa aaaagtacat gctcaaacat cattaacgaa ctccttatca atctcgattc
+   108961 atttcaatat gaggacaaga attgaatcga ttcaattaat tacaataaaa caattacaca
+   109021 acaaaagaga aaagaaggta tttgttggca gtagatgggt tttactaaat caaaattgtg
+   109081 attctttagt tatttttttt agatttgtaa ttcttataat ttttactctt tctaagtttt
+   109141 cttattgccg agccatagta atagcaccta ttaaagaaac tagaagaatt atggaaatga
+   109201 gttcaaacgg aagataaaaa tcggttgcta aatgaatccc aatttgttga acattattta
+   109261 tgagaccctg ctctactatt tggttggatc ttgtagtcca aagaattcca taccatgacg
+   109321 tatctgggat agtagtcatt agtgaaaaaa caatagttat acaaacgagt gaagtgaacc
+   109381 catctccaat agtccaagaa ttcttatctt tagaccattc tgaaccattt acgaacatta
+   109441 cagcgaatat gatcaagaca tttatggctc ctacataaat aagaagttgt gcgacagcta
+   109501 caaagtagga attcaataaa aaatagaata aggatataca aacaagaact aatcccagcg
+   109561 aaaaggcaga ataaatgggg ttggtaagta atactactcc tagaccccct agtagaagaa
+   109621 caaatcccaa aaatagcaca agaatctcgt gtattggtcc gggtaaatcc attatggata
+   109681 aaaataaatt aatagtataa aatttttcat gaattgacta aaactaaagg attcaaggga
+   109741 ggaaaaaggg attaggatat ttttttgtgt ataagctgta tagttagaaa ttctatcacg
+   109801 aaaatctagt atgatttaaa ataagaaata atttgcaata aaataagcgg tagttattag
+   109861 cttttcttta tagttagtaa agaattgttc gatttttata acaaaaaaga aaaaatccta
+   109921 gtttagtaat cagtaatcgt tcttgaattt gaagataaat cttcgtctat ttgactttca
+   109981 gccgaatttc gaattgtttg aattgtgtaa tcccccatta tggagattgg taaccggctt
+   110041 aaagcaattt gattataatt caattcatgc cgatcataag tagacagttc atattcttcc
+   110101 gtcattgata aacagcttgt tggacagtac tcaacacaat taccacaaaa tatacaaact
+   110161 ccgaaatcaa tactataatt aagcaattgt ttccttttaa cagccttttc aaatctccaa
+   110221 tccacaatgg ggagatctat cggacatacg cgaacacaaa cttcacaagc aatacattta
+   110281 tcaaattcaa agtggattcg tccccgaaaa cgctccggtg taattgattt ttcgtaaggg
+   110341 tagtgaatcg ttataggtaa acgatttgtg tgggataagg tagttatgaa actttgacca
+   110401 atgtaccttg tagcacgtat tgtttgttgg ccataactca tgaacccagt taccataggg
+   110461 aacatattct aaatatctat gaaaaaggta tgtttctttc tcttgtttga gagagctttt
+   110521 gtgttgaaaa tattcttact gttattctat tatcttattt agagtgaaac aagttgggaa
+   110581 gaggttgtta ataagagatt acccagggaa ataggtaaaa gaaatttcca tccaagattt
+   110641 aataactgat cgattctcat cctgggtaaa gtccatctta ttgtgataga aatgaagaga
+   110701 aataaataag ctttagttaa tgtaataaag atacccattg tcatttctaa aatcccaact
+   110761 gctttattca tttggaaaaa atcaaaaaag gatatatagg gaatagataa atcccacccg
+   110821 cctaagtaga gaactgttac aaataaagag gaaactaata aatttaggta agaaacaaga
+   110881 taaaataaac catattttat accggaatat tcggtttgat aacctgctac taattcttct
+   110941 tctgcttctg gtaaatcaaa gggtaatctt tcacattctg ccaaagaaga aattagaaaa
+   111001 accagaaaac ctataggctg gcgccaaata ttccacccaa aaaaaccata tttggactgt
+   111061 gcttcaacta tatcaactgt acttgaactg ttagataatc atagtcgatg ataacatcac
+   111121 agttcccacc gctattccaa aaccgtacat gaaaccttag cttcatacgg cttctctatg
+   111181 atcagaaaaa gggaagggct gtttcctttc ggtatgagcc tctggggcgt agatagaatt
+   111241 attttctagg caaaataaaa tcgattggaa agccctaaat tagaccaaag gaattctgtc
+   111301 tgctagaata agagcgcttc cgaattgatc tcatccttta taatataatg aaaattgttc
+   111361 tttgttaagt actaacttaa tcttggaata aaacactcgt tataggaatt ctattaataa
+   111421 atggaaagaa ttgggcatta gttcaggaag aattctgtat gaatatggat agaggaagga
+   111481 aataattaaa aaaaatattt tttatgtatt gcattctata tcttttgtcc tattcttctt
+   111541 tccccgggga ggggtattta aaaagaaaaa agaaataaag gattaattcg ttcttgatag
+   111601 ccatttcctt aacaagtgaa tggaaacata ctctggatcg gaatcccaag aaagtactac
+   111661 ttgatcattt ccactaattt caagtcctta ttatgattcc ttttatggga aaaatctcta
+   111721 attcttagat ttccccatta ctaatccttt atgtacttta gtgttcctga cctttcacta
+   111781 acttttgatg gattcttttt atgtttataa gttatagtaa taattaggga tattttacta
+   111841 atggaattct atatcgtcct ttcgtaaatc ctttattctt gcccgcttca agacatgatg
+   111901 actaattaaa aaatagcaat cttggggtaa agagtttaca ctgcttatgt ttacttcaat
+   111961 ttttttcttg tacgtaggaa atgagatttt tttttactgc aaattaataa gctgttttat
+   112021 ttcactcata tagctatcta gtttaactta ccaacccgaa tacagaataa gaaaaagaag
+   112081 ataaatattt aatggatttt agaggaaaag gatcccattt taacgaatca cacgtagaga
+   112141 tattgctaat acacaaaaag ttaatggtat ttcataacta atcgattgag cagcagctcg
+   112201 tagaccgcct gaaaaagaat atttattatt tgagctatat cctgccataa gaagaccaat
+   112261 aggagcaata cttgaaatgg caatccataa aaaaacacca atactaagat cagctaaagc
+   112321 aaaacgatat cccaaaggga tcactaaaaa acttaataaa attgatatga ctgctataga
+   112381 gggtccaatg ctaaataaag gaatatcccc tcgagatggt agaatatcct cttttaaaag
+   112441 tagcttagtc ccatctgcta tagcttgaag tagtcctagg ggaccggcat attcaggacc
+   112501 aatgcgttgt tggatcgaag cggatatttc tctttctaac caaacaatta cgagtacttc
+   112561 tattgtgatt cccaaaagaa gggtcaaaat gggtagaatc catataagtc catagatttc
+   112621 ttttaataat tctgatttcg aaaaagaatt gagagtttct acctctaccc tatctattat
+   112681 catttcaacg atcaacttcc cccataatga tatctatact acctaatatc gtcatgatat
+   112741 cagccaattt cattttttta actaactgag gaagaatttg caaattaata aaaccgggtg
+   112801 gacgaatttt ccatctccag ggaaaaaggc catcatctcc tactagataa atccctaatt
+   112861 cacctttggg ggcttctatt cttacgtaaa gctcttgctt tgacaattcg aaattgggtg
+   112921 aaggtttttt accaagaaat cgatattcaa aatcattcca ttcggaattc ttttctttct
+   112981 taaagcgacg gacttctaaa ttttcataag gtcctccagg aattttctct acagcttgtt
+   113041 gaataatttt gatagattct ctcatttcac cgattcgtac taaatagcga gctaatgaat
+   113101 ctccttcttt ttgccattgg actttccaac caaattggtt gtaagactca taaagatcta
+   113161 ctttacgaag atcccatcgt attccagaag ctcgtaacat gggtcctgat aagccccaat
+   113221 ttactgcttc ttctccgcta ataaaaccta ctcgctcaac tcgttccaaa aaaataggat
+   113281 tctgtgtaat aagttgttga tattcaacaa ctccccgtaa aaaataatca cagaaatcta
+   113341 agcatttctc gatccatcca taaggtagat cggcggctac tcctccgatg cgaaagtaat
+   113401 tgtgcatcat tcgcatacct gtagcagctt caaatagatc gtatattaac tctctctctc
+   113461 taaaaatgta gaaaaaagga gtctgtgcgc cgagatccgc cataaaaggc ccaagccata
+   113521 ataagtgaga agctatacgg ctcaactcta acataattac cctaatatag ctggctcttt
+   113581 ggggtatttg aatattttct aagaattctg gtgcatttac cgttattgct tctgtaaaca
+   113641 tagtagctaa ataatcccac cgtgttacat aaggtaagta ttgtataata gttcggtttt
+   113701 ccgcgatttt ttccattcct ctgtgtaaat accctaatat gggttcacaa tcaataacat
+   113761 cttcaccatc gagagtaacg atcagtcgaa gaacaccatg cattgatggg tgttgagggc
+   113821 ccatattgac tatcatgaga tcttttcttg taagcggtag actcatatcc tttcttcctt
+   113881 aattcgttat tccatgaatt cctcaaaacg aggctcatca aaatgcaaaa tctaagacta
+   113941 ctataaggct actaaataaa ataagtaaaa aaattcgaac gattaaatta ctgctcccga
+   114001 atattcaact gactgattaa tttcttataa cgtactctat ttttctttgc caaataagcc
+   114061 agcaaacgtc gacgttttcc caaaagtctt cgtagacctc tttccgatga aaaatctttt
+   114121 ttgtgtaatt ccaaatgtga agcaagtctc cgtatcttat tggtgaaact gaatacttga
+   114181 aattcaacag aacccttttt ttcttctttt tcttctttaa ccataaatcc aaagattttt
+   114241 ctacctcctt tctttttcat gtatttttct gatcaggaaa aataaaacat tatgtcagtt
+   114301 attttgaagt tattctaatc tcgtacacac aaaaatttgc aattattcat ctactactgg
+   114361 aatttggatt tattttatcg atgcaaattg gatttggata gaagggtaca ttctcttatt
+   114421 ttagatagaa gaaacatttc ttctatctaa aataaaataa ttttgctgat ttttttattg
+   114481 ctatatccaa tttatggaat tgatacacaa tttaattgat atcatttagc aaaatgaaac
+   114541 atagcatatg catccatctt tgggctcgag aatttcacgg gatagagata tggtataaga
+   114601 aataggctat taagtaactc gaaatgaatt gtggatacat ctgtatcctt aacatactga
+   114661 aacgattgcc attattcgta tcaaaccaat agcgattcat acaagctaaa tcttctaatc
+   114721 aatggtgggc cactaatgaa tttttttgca tatgtattaa gacgcttggc ctgatttcaa
+   114781 aattgtccag agttttatat gttgttttca ttgcaaaatg acgggtctcc ttccgtaact
+   114841 ttccaattac gagtacgaga attgaaagag atgaaaattc tcaattatct acggcgtcta
+   114901 ggagatagat agaatatttt caggaacaag aaaatcggaa gaatctttct ctctattcac
+   114961 taccattccg cgtcttcgac ttctattagt ttcttttctt ctttaatgca atagctatag
+   115021 tttgatataa gaatctattt ctcaaagtaa tggaaaccat tctcttatag gaaatggctc
+   115081 gcaaatcgct attccacctt ttaggtatcg tgaaaagtga tacctgtgaa gatcgtgcat
+   115141 ttcagtcaaa ttcagatccg tttgtttttt cagtccatga tataaccaaa ttggatggat
+   115201 cttccacccg tttagctaag aaagaataga tacagaggtg gataatagat cgatatgaag
+   115261 atcatgagct gccccataat gaaaccgcca gtagtcgcga atatcccctt cttccctaat
+   115321 ccaagattgg agaaagaaga tctaagaggg ccctatgggg aatgtggtca gaaatcctta
+   115381 atagagtccg accacaacga ccgaattaat tatcctcatc gagaaactta gactactaaa
+   115441 tggaaaagat ttgaaaatca tggcatgggt ctcctttttt tctttcttta gagttttcta
+   115501 tatgcagaat ttctcgatgt tttgatgaga atttcttgac tttccatata tagaaagaga
+   115561 tagactataa atgacatctc atatgtcaat aagaccaaag ggatggatat taaatgatag
+   115621 gaagtgctag gaagtgaaat agaatgaaat agagccactt tgggcttccc tatgaaatga
+   115681 ggcatggaac ggagccacta tgaagaaatt ctgggagtac gaaagaagct tcggacccat
+   115741 attgttcatg ggttgagagc gggagttgaa ccctaggagg gggaatcccc ccttgttcct
+   115801 cagtagctca gtggtagagc ggtcggctgt taactgactg gtcgtaggtt cgaatcctac
+   115861 ttggggagat ttgattcatt ctttaatgta agaataaaga attgaattaa agggcttgct
+   115921 ttgaccctta ggagtaggta acccgttcgc tatccttgtt tctatttcta ttgcattcta
+   115981 tctcatcgta tcacattctg ttctacgatt ccacttcgac aaaaggaaag agcataccta
+   116041 agttcaatag ctttacgtcc gctatcccga tcatgatttt cctaccctca gggggaagga
+   116101 cctttacttt ccccctttgg aaagctgtgg gcgaggaggg attcgaaccc ccgacaccgt
+   116161 ggttcgtagc cacgtgctct aatcctctga gctacaggcc cacccgtctc tactggctct
+   116221 cttctcgggg gtaccccttc atttcgggtt aagaagatga gaaagcgcct ttctctctat
+   116281 aagaacagcg cgttccgagg tgtgaagtgg gagagagggg atctgatgat tgaggttttg
+   116341 aataagacga cctttgcatt ttagatttgg atctttttcg tatttcaaaa tagtgaaaaa
+   116401 gtcaaataag aggtgttaag ctttttatca ttctggcatc gagctatttt gccgcaggac
+   116461 ctcccctaca gtatcgtcac cgcagtagag tttaaccacc aaattcggga tggattggtg
+   116521 tggttcctct acgcctagga caccagaata tcgaaccatg aatgaggaaa ggcatgagag
+   116581 aaatattggc tagtaattgt gaagccccaa ttcttgactg aaaaggacac caaaggcctc
+   116641 tgccctccct ctctatctat ccaagagatg gaagggcaga gctttttttg gttttttcat
+   116701 cttttcatca aagagttgaa caatgaagat agatggcaag tgcctgatcg atttgatcag
+   116761 gccgtgtagg aacaaggttc aaatcgttcg ttcgttagga tgcctcagct gcatacatca
+   116821 ctgcacttcc acttgacacc tatttaaacg gctcgtctcg ccgctacctt atcctatttc
+   116881 catacttctg tcgctccatc cccgtatggg tggagaaccc gtcgctgtct cggctgtgat
+   116941 accggaggct ctagggaagt cggaggagag agcactcatc ttggggtggg cttactactt
+   117001 atatgctttc agcagttatc ctctccgcac ttggctaccc agcgtttacc gtaggcacga
+   117061 taactggtac accagaggtg cgtccttccc ggtcctctcg tactagggaa aggtcctctc
+   117121 aatgctctaa cgcccacacc ggatatggac cgaactgtct cacgacgttc tgaacccagc
+   117181 tcacgtaccg cattaatggg cgaacagccc aacccttgga accacctaca gctccaggtg
+   117241 gcgaagagcc gacatcgagg tgccaaacct tcccgtcgat gtggactctt ggggaagatc
+   117301 agcctgttat ccctagagta acttttatcc gttgagcgac ggcccttcca ctcggcaccg
+   117361 tcggatcact aaggccgact ttcgtctctg ctcgacgggt gagtcttgca gtcaagctcc
+   117421 cttctgcctt tgcactcgag gaccaatgtc cgtctggccc gaggaaacct ttgcacgcct
+   117481 ccgttacctt ttgggaggcc tacgccccat agaaactgtc tacctgagac tgtcccttgg
+   117541 cccgcgggtc tgacacaagg ttagaatccg agctcttcca gagtggtatc tcactgatgg
+   117601 ctcgggcccc cccggaaggg ggccttcttc gccttccacc taagctgcgc aggaaaggcc
+   117661 caaagccaat cccagggaac agtaaagctt catagggtct ttctgtcagg tgcaggtagt
+   117721 ccgcatcttc acagacatgt ctatttcacc gagcctctct ccgagacagt gcccagatcg
+   117781 ttacgccttt cgtgcgggtc ggaacttacc cgacaaggaa tttcgctacc ttaggaccgt
+   117841 tatagttacg gccgccgttc accggggctt cggtcgccgg cttccctgtc atcagttcac
+   117901 caacttcctt gaccttccgg cactgggcag gcgtcagccc ccatacatgg tcttacgact
+   117961 ttgcggagac ctgtgttttt ggtaaacagt cgcccgggcc tggtcactgc gacccccttt
+   118021 tgtgaggggg caccccttct cccgaagtta cggggctatt ttgccgagtt ccttagagag
+   118081 agttgtctcg cgcccctagg tattctctac ctacccacct gtgtcggttt cgggtacagg
+   118141 tacccttttg ttgaaggtcg ttcgagcttt tcctgggagt atggcatcgg ttacatactt
+   118201 cagtgccgta gcgcctggta tgagcctcgt ggagaagcaa tcgctagtcc acggggctca
+   118261 tacttcagcg ctgcagcgct tggtactcgg acctcggctc gaggcatttt ctctacccct
+   118321 tcttaccctg aaaaagcagg gtcaccttgt gtccttaaac ctataaccat ctttcggcta
+   118381 acctagcctc ctccgtccct ccgtaccaac aaggggtagt acaggaatat tgacctgttg
+   118441 tccatcgact acgcctttcg gcctgatctt aggccctgac tcaccctccg tggacgaacc
+   118501 ttgcggagga aaccttgggt tttcggggca ttggattctc accaatgttt tcgttactca
+   118561 agccgacatt ctcgcttccg cttcgtcgac ccccgctttc gcggttgctt ccctctaagg
+   118621 cggaacgctc ccctaccgat gcattttgac atcccacagc ttcggcagat cgcttagccc
+   118681 cgttcatctt cagcgcaagg gcgctcgatc agtgagctat tacgcactct ttaaagggtg
+   118741 gctgcttcta ggcaaacctc ctggctgtct ttgcaccccc acctccttta tcactgagcg
+   118801 gtcatttagg ggccttagct ggtgatccgg gctgtttccc tctcgacgat gaagcttatc
+   118861 ccccatcgtc tcactggccg accttgaccc ctgttatttt ggggtcatat ctagtattca
+   118921 gagtttgcct cgatttggta ccgctcgcgc agcccgcacc gaaacagtgc tttaccccta
+   118981 gatgtccagt caactgctgc gcctcaacgc atttcgggga gaaccagcta gctctgggtt
+   119041 cgagtggcat ttcaccccta accacaactc atccgctgat tcttcaacat cagtcggttc
+   119101 ggacctctgc ttagtttcat ccaagcttca tcctggtcat ggatagatca cccaggttcg
+   119161 ggtccataag cagtgacaat cgccctatga agactcgctt tcgctacggc tccggtgggt
+   119221 tccgttccct taaccaagcc actgcctatg agtcgccggc tcattcttca acaggcacgc
+   119281 ggtcagagat cactttcccc tcccactgct tgggagctca gcacggtttc acgttctatt
+   119341 tcactaccca ctgggggttc ttttcacctt tccctcacgg tactacttcg ctatcggtca
+   119401 cccaggagta tttagccttg caaggtggtc cttgctgatt cacacgggat tccacgtgcc
+   119461 ccatgctact cgggtcagag cgtaagctag tgatgctttc ggctactgga ctttagccat
+   119521 ctagggtgcg gcactcaacc gcttcgccta gcagcacaac gcttgtattg ctctcccaca
+   119581 accccgtttt cacggtttag gctgctccca tttcgctcgc cgctactacg ggaatcgctt
+   119641 ttgctttctt ttcctctggc tactaagatg tttcagttcg ccaggttgtc tcttgcctgc
+   119701 tcatggattc agcaggcagt ttaaaaggtt gacctatttg ggaatctccg gatctatgct
+   119761 tattttcaac tccccgaagc atttcgtcgc ttgctacgcc cttcctcgtc tctgggtgcc
+   119821 taggtatcca ccgcaagcct ttcctctttt gaacctcgcc attaacgtta aggctatgcc
+   119881 atcctaaggt gctactaaat ggaaggatct tatcaacgtc catgaatgcg aaatcataga
+   119941 tcgaactgcc gaattggcaa aattcggtgc tatcatagta tccgctaagt tcacgggctg
+   120001 gagataagcg gactcgaacc gctgacatcc gccacagggt aaaccaccgc ctctcaggcc
+   120061 tccccgacgg gttctaccat agaggccaac gatagacaat aactcccccc cgaacacagc
+   120121 ttacaacttt catcgtactg tgctctccaa agagcaactc ttctcaaaat ctcaaaacaa
+   120181 aaggtgctga gttggaatcc cattctaagg attcttgtgg ttccggggaa tccagctaca
+   120241 ggagaaccag gaacggggag ctctcccctt tttccgcccg actctttgat cttaaactta
+   120301 agaatgctgg ttttaagaac gagtgattgc ccttctccga cccttactgc ccaaccggag
+   120361 agcggacggc taatgtgttc cacttattga acagggtcta tggtcggtcc gtgacccctg
+   120421 gacgccgaag gcgtccttgg ggtgatctcg tagttcctac ggggtggaga caatggggtc
+   120481 ggtccatgga ttttgcttcc ttttgctaca tttcgctcaa agggttgaag ggagatagtg
+   120541 catcaagtta ttcgcaaggg ccaacttgat cctcttcccc agggatccca gatgagggaa
+   120601 gcctaggaga gccgccgact ccaactatcg tccatgtacg atccatacta gatctgacca
+   120661 actgcccatc ctacctcctc tacctttttg acagcccatc tttttgtctc agtagagtct
+   120721 ttcagtggca tgtttcagtc ctcttcccca ttacttagaa aaagtgagcc accggttcag
+   120781 gtacaagata ctatcattac cgcctggaca attagacagc caacccgtaa tcgcaacgac
+   120841 ccaattgcaa gagcggagct ctaccaactg agctatatcc cccccgagcc aagtggagta
+   120901 tgcatgaaag agtcagatgc ttcttctatt cttttccctg gcgcagctgg gccatcctgg
+   120961 acttgaacca gagacctcgc ccgtgaagta aatcatcgcc cctacgatcc aaccaattgg
+   121021 gagagaatca atagactcct tttcgggagc gattcatcct tcccgaacgc agcatacaac
+   121081 tccccgttgt actgcgctct tcaagtgtgc ttcttccccc ttccccctct taccgtggca
+   121141 agtccttggg aaataactcc gatgggcaga aaaaggaagg cgttaagaga ccctcctggc
+   121201 ccaaccctag acactctaag atcctttttc aaacctgctc tgctcccatt taaggaaaaa
+   121261 gaatttcacg ttcttcctga aaggaaggga ggattaggaa agtgctattg attgctgctt
+   121321 tctccagacc gccgggaaaa gcatgaaaaa aaggctcgaa tggtacgatc cctccgtcac
+   121381 cccagaatga aaggggtgat ctcgtagttc ttggtctgtg aagatgcgtt gttaggtgct
+   121441 ccattttccc attgaggacg gacctcaacc tgtggtcgag agatagctct ccatacactg
+   121501 ataaggggtg tatggattct cgagaagaga ggagctgtgg tggccccccc cggaccgccc
+   121561 ggatcccacg agtgaataga aagttagatc tacatgggat ctcacctgaa tcgccccatc
+   121621 tatcctcctg aggagaagtt tgtttggttt caaactccga ttcaaacagg aggagtacgc
+   121681 catgctaatg tgccttggat gatccacatc ttcgggtcag gcgctgatga gcacattgaa
+   121741 ctatccatgt ggctgagagc cctcacagcc caggcacaac gacgcaatta tcaggggcgc
+   121801 gctctaccac tgagctaata gcccgtcgcg cgggcctccc aaagggaggc ctgctacgcc
+   121861 aaaagcgaga aaaactccat ccctttcctt ttgacatccc catgccgcca caccacaggg
+   121921 gggggacatg ggggcgtcaa aaaagggatc ctatcactta tcaactaatt tgttccgacc
+   121981 taggataata agctcatgag cttggtctta cttcacccta aacgaaagaa gacttccata
+   122041 tccaagttta gctcagacgt agctgccttc tttttgggcg tgaagcagtg tcaaaccaaa
+   122101 atacccaata agcataagca ttagctctcc ctgaaaagga ggtgatccag ccgcaccttc
+   122161 cagtacggct accttgttac gacttcactc cagtcgcaag cctagcctta ggcatccccc
+   122221 tccttacggt taagggtaat gacttcaaac atggccagct cctatagtgt gacgggcggt
+   122281 gtgtacaagg cccgggaacg gattcaccgc cgtatggctg accggcgatt actagcgatt
+   122341 cctgcttcat gcaggcgagt tgcagcctgc aatccgaact gaggacgggt ttttggagtt
+   122401 agctcaccct cgcgagatcg cgaccctttg tcccgcccat tgtagcacgt gtgtcgccca
+   122461 gggcataagg ggcatgatga cttggcctca tcctctcctt cctccggctt aacaccggcg
+   122521 gtctgttcag ggttccaaac tcatagtggc aactaaacac gagggttgcg ctcgttgcga
+   122581 gacttaaccc aacaccttac ggcacgagct gacgacagcc atgcaccacc tgtgtccgcg
+   122641 ttcccgaggg cacccctctc tttcaagagg attcgcggca tgtcaagccc tggtaaggtt
+   122701 cttcgctttg catcgaatta aaccacatgc tccaccgctt gtgcgggccc ccgtcaattc
+   122761 ctttgagttt cattcttgcg aacgtactcc ccaggcggga tacttaacgc gttagctaca
+   122821 gcactgcacg ggtcgagtcg cacagcacct agtatccatc gtttacggct aggactactg
+   122881 gggtctctaa tcccatttgc tcccctagct ttcgtctctc agtgtcagtg tcggcccagc
+   122941 agagtgcttt cgccgttggt gttctttccg atctcaatgc atttcaccgc tccaccggaa
+   123001 attccctctg cccctaccgt actccagctt ggtagtttcc accgcctgtc cagggttgag
+   123061 ccctgggatt tgacggcgga cttgaaaagc cacctacaga cgctttacgc ccaatcattc
+   123121 cggataacgc ttgcatcctc tgtcttaccg cggctgctgg cacagagtta gccgatgctt
+   123181 attcctcaga taccgtcatt gtttcttctc cgagaaaaga agttgacgac ccgtaggcct
+   123241 tccacctcca cgcggcattg ctccgtcagg ctttcgccca ttgcggaaaa ttccccactg
+   123301 ctgcctcccg taggagttct gggccgtgtc tcagtcccag tgtggctgat catcctctcg
+   123361 gaccagctac tgatcatcgc cttggtaagc tattgcctca ccaactagct aatcagacgc
+   123421 gagcccctcc ttgggcggat ttctcctttt gctcctcagc ctacggggta ttagcaaccg
+   123481 tttccagttg ttgttcccct cccaagggca ggttcttacg cgttactcac ccgttcgcca
+   123541 ctggaaacac cacttcccgt tcgacttgca tgtgttaagc atgccgccag cgttcatcct
+   123601 gagccaggat cgaactctcc atgagattca tagttgcatt acttatagct tccttattcg
+   123661 tagacaaagc ggattcggaa ttgtctttcc ttccaaggaa aacttgtatc catgcgcttc
+   123721 agattattag cctggagttc gccaccagca gtatagccaa ccctacccta tcacgtcaat
+   123781 cccacaagcc tcttatccat tctcgttcgc tcgtggcggg ggagtaagtc aaaatagaaa
+   123841 aaactcacat tgggtttagg gataatcagg ctcgaactga tgacttccac cacgtcaagg
+   123901 tgacactcta ccgctgagtt atatcccttc cccgtcccat cgagaaagag aattaacgaa
+   123961 tcctaaggca aaggggcgag aaactcaagg ccactcttcc tccgggcttt ctttccgcac
+   124021 tattatggat agtcaaataa tgggaaaaat tggattcaat tgtcaaccgg tcctatcgaa
+   124081 agtaggattg gctatggatt cgagccatag cacatggttt cataaaatct gtacgatttt
+   124141 cccgatctaa atcgagcagg tttccatgaa gaagatcttg ttcagcatgt tctattcgat
+   124201 actggtagga gaagaacccg actcggtatt cttaaaaaaa gaggggaagc agaaccaagt
+   124261 caagatgata tgggtcgccc cttcttcttg cgccaaagat cttaccattt ccgaaggaac
+   124321 tggggctaca tttcttttca atttccattc aagagtttct atctgtttcc acgccttttt
+   124381 tttgagacct cgaaacatga ggacaaatta cttctcttag gaacacatac aagaaaaagg
+   124441 ataatggtag ccctcccatt aactacttca ttttcattta tgaatttgat agtaatagaa
+   124501 atccatgtcc taccgagaca gaatttcgaa cttgctatcc tcttgcctaa taggcaaaga
+   124561 ttgacctctg tagaaagact gattcattcg gatcggatcg atatgaggac ccaactccgt
+   124621 tgcattgcca gaatccatgt tccatatttg aagcgggttg acctccgtgc ttctctcatg
+   124681 gtacaatcct cttcctgccg agcccccttt ctcctcggtc cacagagaaa aaaatgtagg
+   124741 actggtgccg acagttcatc acggaagaaa gaactcacag agccgggatc ggtaactaat
+   124801 agaatagtac tactaactaa tactaatata tagaaataga tatctagaaa tagaaacgaa
+   124861 ctaatatata gataatcgaa attgaaaaga actgtctttt ctgtatactt tccccgttct
+   124921 attgctaccg ggggtcttat gcaatcgagc ggatcatata gatatccctt caacacaaca
+   124981 taggtcatcg aaaagatctc ggacgactca ccaaagcacg aaagccagtt agaaaatgga
+   125041 ttcctatttg aagagtgcct aaccgcatgg ataagctcac attaacccgt caattttgga
+   125101 tccaattcgg gatttttctt gggaagtttc gagaagaaat tggaatggaa taaataaaga
+   125161 ataaagcaaa aaaaaataag tcgaagatag aagagcccag attccaaatg aagaaacgga
+   125221 aactcgaaaa ggatccttct gattctcaaa gaatgagggg caaggggatt gataccgaga
+   125281 aagatttctt cttattataa gacgtgattt gatccgcata tgtttggtaa aagaacaatc
+   125341 ttctccttta atcatatcat aaatggaaag tgttcaatta gaacatgaaa acgtgactca
+   125401 attggtctta gttagtcttc gggacggagt ggaagaaggg cggagactct cgaacgagga
+   125461 aaaggatccc gaattgaccg aggagccgta tgcggtgaaa atctcatgta cggttctgta
+   125521 aagggacagt aagggtgact tatctgtcga cttttccact atcaacccca aaaaacccaa
+   125581 ctctgcctta cgtaaagttg ccagagtacg attaacctct ggatttgaaa tcactgctta
+   125641 tatacctggt attggccata atttacaaga acattctgta gtattagtaa gaggaggaag
+   125701 ggttaaggat ttacccggtg tgagatatcg cattattcgg ggaaccctag atgctgtcgc
+   125761 agtaaagaat cgtcaacaag ggcgttctag tgcgttgtag attcttatcc aagacttgta
+   125821 tcatttgatg atgccatgtg aatcgctaga aacatgtgaa gtgtatggct aacccaataa
+   125881 cgaaagtttc gtaaggggac tggagcaggc taccatgaga caaaagatcc tctttctaaa
+   125941 gagattcgat tcggaactct tatatgtcca aggtcaatat ggaaattctt tcagaggttt
+   126001 tcccttactt tgtccgtgtc aacaaacaat tcgaaatacc tcgacttttt cagaacaggt
+   126061 ccgagtcaaa tagcaatgat tcgaagcact tctttttcca ttacactatt tcggaaacct
+   126121 aaggactcga tcgtatggat atggaaaata caggatttcc gatcctagcg ggaaaaggag
+   126181 ggaaacggat actcaattta aagtgagtaa acagaattcc atactcgatc tcatagatcc
+   126241 ctatagaatt ctgtggaaag ccgtattcga tgaaagtcgt atgtacggct tggagggaga
+   126301 tctttcctat ctttcgagat ccaccctaca atatggggtc aaaaagccaa aaaaataagt
+   126361 gattttagcc cttataaaaa gaaaacggat tcttgaacct ctttcacgct catgtcacgt
+   126421 cgaggtactg cagaaaaaag aactgcaaaa tccgatccaa tttttcgtaa tcgattagtt
+   126481 aacatggtgg ttaaccgtat tatgaaagac ggaaaaaaat cattggctta tcaaattctc
+   126541 tatcgagccg tcaaaaagat tcaacaaaag acagaaacaa atccactatt ggttttacgt
+   126601 caagcaatac gtagagtaac tcccaatata ggagtaaaaa caagacgtaa taaaaaagga
+   126661 tcgacgcgga aagttccgat tgaaatagga tctaaacaag gaagagcact tgccattcgt
+   126721 tggttattag aagcatccca aaagcgtccg ggtcgaaata tggctttcaa attaagttcc
+   126781 gaattagtag atgctgccaa agggagtggg ggtgccatac gcaaaaagga agcgactcat
+   126841 agaatggcag aggcaaatag agctcttgca cattttcgtt aatccatgaa cagaatctag
+   126901 gtatgtagac acatcggggg atccatacat ctcgatcgga aaagaatcaa tagaaggaga
+   126961 atcggacgat atctttctcg aaacaaacaa aaaggaaaag aaagagaaaa caaaaatcat
+   127021 gatcaactaa gccctctcga gggcttgctt aagaataaga aagaagaatc ttatggaaat
+   127081 ggaataaggt ttgatcctat tcatggggat tccgtaaata tgccattcca aaaatagaaa
+   127141 caatcgggac ttttcggaga ttggatgcag ttactaattc atgatctggc atgtacagaa
+   127201 tgaaaacttc attctcgatt ctacgagaat ttttatgaaa gcgcttcatt tgcttctctt
+   127261 ccatggaagt ttcattttcc cagaatgtat cctaattttt ggcctaattc ttcttctgat
+   127321 gatcgattca acctctgatc aaaaagatag accttggttc tatttcatct cttcaacaag
+   127381 tttagtaata agcataacgg ccctattgtt ccgatggaga gaagaaccta taattagctt
+   127441 ttcgggaaat ttccaaacga acaatttcaa cgaaatcttt caatttctca ttttattatg
+   127501 ttcaacttta tgtattcctc tatccgtaga gtacattgaa tgtacagaaa tggctataac
+   127561 agagtttctg ttattcgtat taacagctac tctaggggga atgtttttat gtggtgctaa
+   127621 cgatttaata actatctttg tagcttcaga atgtttcagt ttatgttcct acctattgtc
+   127681 tggatatacc aagagagatc tacggtctaa tgaggctact atgaaatatt tactcatggg
+   127741 tggggcaagc tcttctattc tggttcatgg tttctcttgg ctatatggtt catctggggg
+   127801 ggagatcgag cttcaagaaa ttgtgaacgg tcttatcaat acacaaatgt ataactcccc
+   127861 aggaatttca attgcgctta tatccatcac tgtaggactt gggttcaagc tttccccagc
+   127921 cccttttcat caatggactc ctgacgtcta cgaaggagtg tggttcgttc gacaaattca
+   127981 ttcctacctc tatatctatc tccgaggtgt ttgggttttg caaaactcca tagacatgca
+   128041 gaagagaaat gctatcccca ctccgaccaa gacagaactt ttaccaaaag tttattgtga
+   128101 tctttttgtt caaataacaa ttaaggtgaa gcagggtcag gaacaacgaa tctctttatg
+   128161 ataaacagat ccattttgca agttcgttat tacgggtagt tcctacaaag aatcggacta
+   128221 atgacgtata caatgcttga attatcgatg tagatgctac atagtgggtt ctcatccttc
+   128281 agagactacg agtgtaatag gagcatccgt tgacaaaagg atcgccctaa gatgatcatc
+   128341 tcatggctat tgggaacgaa tcaaatcaga tggttctatt tctcaacctt tctgacttgc
+   128401 tcctacggaa ccaaggtcga aaggattgaa aaagtcagtc attcacaacc actgatgaag
+   128461 gattcctcga aaagttaagg attagtagtt ctttttcgaa atcgatttcg aaaaagaatg
+   128521 gatttggtct tatacatacg cgaggaaggt aatcaaaaaa gaaagaagac gagttcttct
+   128581 ttcttttatc acttaggagc cgtgcgagat gaaagtctca tgcacggttt tgcatgagag
+   128641 aaagaagcga ggaatcctct tttcgactct gactccccca ctccagtcgt tgcttttctt
+   128701 tctgttactt cgaaagtagc tgcttcagct tcagccacgc gaattctcga tattcctttt
+   128761 tatttctcat caaacgaatg gcatcttctt ctggaaatcc tagctattct tagcatgatt
+   128821 ttggggaatc tccttgctat tactcaaaca agcatgaaac gtatgcttgc atattcgtcc
+   128881 atagggcaaa tcggatatgt aattattgga ataattgttg gagactcaaa tgatggatat
+   128941 gcaagcatga taacttatat gctgttctat atctccatga atctaggaac ttttgcttgc
+   129001 attgtattat ttggtctacg taccggaact gataacattc gagattatgc aggattatac
+   129061 acgaaagatc cttttttggc tctctcttta gccctatgtc tcttatccct aggaggcctt
+   129121 cctccactag caggtttctt cggaaaactc tatctattct ggtgtggatg gcaagcaggc
+   129181 ctatatttct tggtttcaat aggactcctt acgagcgttc tttctatcta ctattatcta
+   129241 aaaataataa agttattaat gactggacga aaccaagaaa taacccctta tgtgagaaat
+   129301 tatagaagat cccctttaag atcaaacaat tccatcgaat tgagtatgac tgtatgtgtg
+   129361 atagcatcta ctataccagg aatatcaatg aatcccattc ttgcaattgc tcaggatacc
+   129421 ctcttttagc tgctaggtct atttcttagt tcaagatccc tcttactaac tggaataaaa
+   129481 gaattagtag atctgttccg ccaaaaatgg gaatgggcgc tagggttatg aacttataat
+   129541 catggaatcg actcgatcat cagattataa gttcattcca taccggacta gaccgtgcac
+   129601 attcttatta tgagaagggg tcattcgagc ctatggaaat aggatactct gtttacatag
+   129661 aaatccctac gtccttacat tctatttagg attaggaata ggtgtaagca gacctgcttt
+   129721 tgacatatct atcctatttt tatttgggta ccatatgcac ctctttgggc ttctattgaa
+   129781 tcgagaaatt ggattgtaca tctttcatct ttttgatttt gatatcgatt ttgatacata
+   129841 taaggtgtcc tacggataat gcaaatcgaa gctatttgat gtctgactca ggcctatatg
+   129901 accgatcgat cgaaatactc caagactcca cctttgtcat atattccata tatcgcatta
+   129961 gatagatatc atattcatgg aatacgattc actttcaaga tgccttgatg gtgaaatggt
+   130021 agacacgcga gactcaaaat ctcgtgctga agagcgtgga ggttcgagtc ctcttcaagg
+   130081 cataatatgg agaatgctca ttcaatgagc attccccgta gaagtattcc ggaaatctgc
+   130141 gcctggcgct ctcctctatc ttctgaggtc cttaaccatc tctctgaaaa aagtagacag
+   130201 taaaagccaa aatagactaa atatagcctg aacgatccta aaaatccctc gaaggagata
+   130261 ataaagaacc caaagcggat ggtatcctac tgcaagggtg gtcttaagaa tccaaaagag
+   130321 gttgctcaga agagatagat gtatcccaac ctctattgct ctcgcgtaaa gacttttttt
+   130381 tacgcgacag gaaaaagtga ctacgaattc ccctttttgt ttgcgaatcc ctgtttgtat
+   130441 cctttgagcg cacgcccata agtagcgatc aaatcaagga aatcgagcaa acgatcccaa
+   130501 taccgtgaaa gagaaacttc ccagatccag ggaagcttat ctaagggctt cgacaggggt
+   130561 tttattcgtt ctttgagcaa aaagataaag atcggataga ttcgaaccgc aattgcaaag
+   130621 gtaataacta ctatgccagc ccaaatcatg atcttcacca acttggattt ggttctctcg
+   130681 ctaaaatcgc gagttgcaga gatgagaatc atgaaaagca agatcccgaa taagaaaaca
+   130741 gaaaccgagg aaaccacaag agtgaagact agtagagtct cgtcttttgt cattctttgc
+   130801 tcctttttca ctcaatgatt ctttctaatt tccagaccaa aaattctata tgtctattct
+   130861 atgatatttc tatatatata gaatatgata tctaatatga cacccgattt gtcaaagggg
+   130921 ttggattggt gacttaccca ttcagtgact ttggcactgg acgttccaaa aacgggtact
+   130981 atcggctcgg gtgaattaga gaatagacag aggtccgttg gcatttcagc ctttcttctc
+   131041 ctttcagggc ctatccgaaa gagaatccag tacctcttgg tcctgaatat cagaatagga
+   131101 cgaacgaact ggcctccgcg gatatctttg cttcggaaca aaaccctgca atcaaatgga
+   131161 ttgtcccaag ggcgccatat tctaggagcc caagttatgc tattgaaaat tcgttcctct
+   131221 agcagttccg gtttgaccat tccgttccct ttttcaaact ccacttcttt tcatatagca
+   131281 atccctgatc aaagagagaa caatatccat ttcaaaacat ttctaacgga ttccttggtt
+   131341 cggaccgacg aagtaatggc actcgattat tatcaacctg actgcaatct ttttctgtcg
+   131401 gtaaggattg caccagagca ccttctactt ctaataggcc atgaactata gatagagaag
+   131461 aatcattctg agcgagtcca taagaagcga tccacttttt ttcatcggtt ccaggggaag
+   131521 accaaagatc ttgcgcggca ggtccgccat aaaaacgcaa aagagaaaga agtctcgtta
+   131581 atctcttcat gctcgttcca agttcgaagt accttttggc caaagaaaaa cccgcttcct
+   131641 gacacgatcg cctctttata tagatagatt gattctatgg ggttattact tataagtcta
+   131701 ttttgtacaa gagcccctcc tatctgatag aaaaaggtcc catgatcccg agccgatctt
+   131761 accttggctc gcaaaccaca agtttgtcta tgaagagtta atctaattgt atttttttct
+   131821 ataatggatt tcttatgtgg aatactaatg gatagggcct cgttgctaag tgctacaaga
+   131881 tctagtgcac tggaactcgt ggttatgcac ccgaatcttt tagtatggaa cattgtcttt
+   131941 tctaagtaaa aacccctagt atatgaaaga atgaaaaggt gctttcgttc ttgtggaata
+   132001 agaagccctc gtaccttaat gaaaggaaaa tcgtaatttt tcgttaggta tttgaccaaa
+   132061 taggatcgtc cagttcttat agaacctatc actaaaatac ccgatagggc taagcggaac
+   132121 gaaaagggtt ttccatgaga tggtaaatga aaacgattag ccccacacga ggtttgggaa
+   132181 taagtgattg tctgataatg agcaaggaat atacgtcttt ctgctaaaga ggatctatta
+   132241 aactcataat tcattagatc cttgttatca atgccaacta ggtatcataa gtaaatggat
+   132301 cccggttgtt caatcctttg ataaccaagg tcattctttg ctaaagagaa atgatcacta
+   132361 tgagtcagac tcaatagaat tggatccatt ccaaatagag agaattagga ttcttgatcc
+   132421 ctctcaatct ctctttcaat tcgaggatcc agagaggtgt tttcatagtc atctccgaat
+   132481 atttgccatc tccgaatatt ttcgatttca tttttctatg atatgtcttt ctatatgaaa
+   132541 attggttatt tacgatgtag gatgatccct gttaagcatc catggctgaa tggttaaagc
+   132601 gcccaactca taattggtaa atttgcgggt tcaattcctg ctggatgcac gcgaacggga
+   132661 acgttccata agtctattgg aactggctct ctatccatgg aatctcatcc atcatccata
+   132721 cataacgaat tggtatggta tattcatacc ataacataag aacaataaga actcgaattc
+   132781 ttatcgatac tggaactcag agcataggag ggaaagtcga tttatggatg gaatcaaata
+   132841 cgcagtattt acagaaaaaa gtcttcgttt attgggaaag aatcaatata cttttaatgt
+   132901 cgaatcagga ttcactaaga cagaaataaa gcattgggtc gaactcttct ttggtgttaa
+   132961 ggtagtagct gtgaatagcc atcgactacc cggaaagggt agaagaatag gacctattct
+   133021 gggacataca atgcattaca gacgtatgat cattaccctt caaccgggtt attctattcc
+   133081 acttctagat agagaaaaaa actaaaggag aatacttaat aatacggcga aacatttata
+   133141 caaaacacct atctcgagta cacgcaaggg aaccgtagac aggcaagtga aatccaatcc
+   133201 acgaaataat ttgatccatg gacggcaccg ttgtggtaaa ggtcgtaatt ccagaggaat
+   133261 cattaccgca aggcatagag ggggaggtca taaacgccta taccgtaaaa tcgattttcg
+   133321 acggaatcaa aaagacatat ctggtagaat cgtaaccata gaatacgacc ctaatcgaaa
+   133381 tgcatacatt tgtctcatac actatgggga tggtgagaag agatatattt tacatcccag
+   133441 aggggctata attggagata ctattgtttc tggtacaaaa gttcctatat caatgggaaa
+   133501 tgccctacct ttgagtgcgg tttgaactat tgatttacgt aattggaagt aaccaattag
+   133561 gtttacgacg aaacctagaa atcgatcact gatccaattt gactacctct acgggataga
+   133621 ccttaacaga aaactgttga gtaacggcag caagtgattg agttcagtag ttcctcatag
+   133681 aaaattattg actctagaga tatggtaata tggagaagac aaaattgttt gaagcacgca
+   133741 cagaaccgga agcgcccctt gtttcaaaga gagtaggacg ggttattcac atttaatttg
+   133801 atggtcagag gcgaattgaa agctaagcag tggtaattaa gacccccggg gaaaaaaggg
+   133861 atgtctccta cgttacccat aatatgtgga agtatcaacg taatttcata gagtcattcg
+   133921 atctgaatgc tacatgaaga acataagcca gatgacggaa cgcggagacc taggatgtag
+   133981 aagatcctaa catgagcgat tcggcagatt tggattcctt tcctatatat ccactcatgt
+   134041 ggtacttcat catatgattt atataagatc catctgtcta gagatcgtca tatacatcta
+   134101 gaaagccgta tgcttgaaga agcttgtaca gtttgggaag gggttttttg agagaaaaga
+   134161 agaatctact tcaaccgata tgcccttagg cacggccatg cataacatag aaatcacacg
+   134221 tggaaggggt ggccaattag ctagagcagc aggtgctgta gcgaaactta ttgcaaaaga
+   134281 gggtaaatca gccactttaa gattaccatc tggggaggtc cgtttagtat cccaaaactg
+   134341 cttagcaaca gtcggacaag tgggtaatgt tggggtgaac caaaaaagtt tgggtagagc
+   134401 cggatctaag tgttggctag gtaaacgccc catagtaaga ggggtagtta tgaaccctgt
+   134461 ggaccacccc catgggggcg gtgaagggaa agcccccatt ggtagaaaaa aacccacaac
+   134521 cccttggggt tatcctgcgc ttggaagaag aactaggaaa aggaaaaaat atagcgatag
+   134581 ttttattctt cgtcgccgta agtaaatacg taactaggaa tatggaaaat tgcatttttt
+   134641 gcatttgcaa taatgcgatg ggcgaacgac gggaattgaa cccgcgcatg gtggattcac
+   134701 aatccactgc cttgatccac ttggctacat ccgcccctta tccagctaca ggatttttct
+   134761 cttttttcca ttcatcatta ttctatttat tctgacctcc atacttcgat cgagatattg
+   134821 gacatagatt gccgctcttt aaaaaggaaa aaaaaggagt aatcagctgt gacacgaaaa
+   134881 aaaacgaatc cttttgtagc tcatcattta ttggcaaaaa tagaaaaggt caatatgaag
+   134941 gaggagaaag aaacaatagt aacgtggtcc cgggcatcta gcattctacc cacaatggtt
+   135001 ggccatacaa tcgcgattca taatggaaag gaacatatac ctatttacat aacaaatcct
+   135061 atggtaggtc gcaaattggg ggaattcgta cctactcggc atttcacgag ttatgaaaat
+   135121 gcaagaaagg atactaaatc tcgtcgttaa ctgaattcag aatagaaaga ttcagaataa
+   135181 aaaaaagatg caaagtaaa
+//
+


### PR DESCRIPTION
The Genbank entries can contain features having keys with no value. For example '/trans_splicing' at https://www.ncbi.nlm.nih.gov/nuccore/NC_011032.1