### PR TITLE
Feature/bcf location

### DIFF
--- a/modules/Bio/EnsEMBL/IO/Parser/BCF.pm
+++ b/modules/Bio/EnsEMBL/IO/Parser/BCF.pm
@@ -34,7 +34,7 @@ use warnings;
 use Carp;
 use Bio::DB::HTS::VCF;
 use Bio::DB::HTS::VCF::Iterator;
-
+use Cwd qw(getcwd);
 use parent qw/Bio::EnsEMBL::IO::Parser/;
 
 sub open {
@@ -48,6 +48,21 @@ sub open {
   $self->{bcf_file} = Bio::DB::HTS::VCF->new( filename => $filename );
   $self->{iterator} = undef;
 
+  return $self;
+}
+
+sub open_with_location {
+  my ($caller, $filename, $location, @other_args) = @_;
+  my $class = ref($caller) || $caller;
+
+  # initialize generic parser
+  my $self = $class->SUPER::new(@other_args);
+  my $currentDir = getcwd();
+  chdir($location);
+  $self->{record} = undef;
+  $self->{bcf_file} = Bio::DB::HTS::VCF->new( filename => $filename );
+  $self->{iterator} = undef;
+  chdir($currentDir);
   return $self;
 }
 

--- a/modules/t/bcf.t
+++ b/modules/t/bcf.t
@@ -17,6 +17,7 @@ use warnings;
 
 use Test::More;
 use Bio::EnsEMBL::IO::Parser::BCF;
+use Cwd qw(getcwd);
 
 use FindBin qw( $Bin );
 
@@ -25,6 +26,14 @@ my $test_file = $Bin . '/input/test.bcf';
 # Test standard functions on a BCF file
 ok (my $parser = Bio::EnsEMBL::IO::Parser::BCF->open($test_file), "BCF file open");
 is ($parser->num_variants(), 9, 'correct number of variants identified in file');
+
+#test open with $location
+my $currentDir = getcwd();
+chdir('/');
+ok ($parser = Bio::EnsEMBL::IO::Parser::BCF->open($test_file, $currentDir), "BCF file open with location");
+is ($parser->num_variants(), 9, 'correct number of variants identified in file');
+chdir($currentDir);
+
 
 ok (my $h = $parser->header(), "Got header");
 my $header_str = <<HEADER;


### PR DESCRIPTION
web team requested following function for ensembl-io:
new function, that loads BCF using not current directory( not enough permissions to write there), but temporary directory passed as an argument

here is an issue: https://www.ebi.ac.uk/panda/jira/browse/ENSCORESW-3645?filter=-1

Unit tests are provided