### PR TITLE
Add transcript tags to GTF files

### DIFF
--- a/modules/Bio/EnsEMBL/Utils/IO/GTFSerializer.pm
+++ b/modules/Bio/EnsEMBL/Utils/IO/GTFSerializer.pm
@@ -496,6 +496,15 @@ sub _print_attribs {
         print $fh qq{ tag "${value}";};
       }
     }
+
+    # A transcript can have different types of MANE-related attributes (MANE_Select, MANE_Plus_Clinical)
+    # We depend on the Bio::EnsEMBL::MANE object to get the specific type
+    my $mane = $transcript->mane_transcript();
+    if ($mane) {
+      my $mane_type = $mane->type();
+      print $fh qq{ tag "${mane_type}";} if ($mane_type);
+    }
+
     my $attributes = $transcript->get_all_Attributes("TSL");
     if (@{$attributes}) {
       my $value = $attributes->[0]->value;

--- a/modules/Bio/EnsEMBL/Utils/IO/GTFSerializer.pm
+++ b/modules/Bio/EnsEMBL/Utils/IO/GTFSerializer.pm
@@ -487,11 +487,12 @@ sub _print_attribs {
   }
 
   if($transcript && $transcript->isa('Bio::EnsEMBL::Transcript')) {
-    foreach my $tag (qw/cds_end_NF cds_start_NF mRNA_end_NF mRNA_start_NF gencode_basic/) {
+    foreach my $tag (qw/cds_end_NF cds_start_NF mRNA_end_NF mRNA_start_NF gencode_basic is_canonical/) {
       my $attributes = $transcript->get_all_Attributes($tag);
       if(@{$attributes}) {
         my $value = $tag;
         $value = "basic" if $tag eq "gencode_basic";
+        $value = "Ensembl_canonical" if $tag eq "is_canonical";
         print $fh qq{ tag "${value}";};
       }
     }


### PR DESCRIPTION
## Description

Adding the canonical and MANE flags for transcripts and their underlying features in the GTF files.
JIRA Ticket (canonical): [ENSCORESW-3981](https://www.ebi.ac.uk/panda/jira/browse/ENSCORESW-3981)
JIRA Ticket (MANE): [ENSCORESW-3986](https://www.ebi.ac.uk/panda/jira/browse/ENSCORESW-3986)

Sister PR [#685](https://github.com/Ensembl/ensembl-production/pull/685) in ensembl-production for GFF3 changes.

## Use case

The canonical attribute was added to the transcript attributes and is now handled by the REST API and the perl core. This change is a continuation of that in including this attribute in the GFF3 file dumps.
In addition, the MANE attribute (with its different types: MANE_Select, MANE_Plus_Clinical) was added to transcripts and thus needed to be reflected in the GFF3 file dumps.

## Benefits

Consistency with perl and REST APIs.

## Possible Drawbacks

None

## Testing

_Have you added/modified unit tests to test the changes?_

_If so, do the tests pass/fail?_

_Have you run the entire test suite and no regression was detected?_

