### PR TITLE
Support multiple contigs in VCF files

### DIFF
--- a/modules/Bio/EnsEMBL/IO/Parser/BaseVCF4.pm
+++ b/modules/Bio/EnsEMBL/IO/Parser/BaseVCF4.pm
@@ -106,7 +106,8 @@ sub _parse_metadata_line {
                     'FORMAT'   => 1,
                     'ALT'      => 1,
                     'SAMPLE'   => 1,
-                    'PEDIGREE' => 1 );
+                    'PEDIGREE' => 1,
+                    'contig'   => 1 );
 
 
   push @{$self->{_metadata_order}}, $m_type;
@@ -655,6 +656,38 @@ sub get_format_description {
 }
 
 
+=head2 get_metadata_field
+    Argument [1]: Metadata type, e.g. 'INFO'
+    Argument [2]: Metadata ID, e.g. 'AA'
+    Argument [3]: Metadata field, e.g. 'Description'
+    Description : Retrieve a field of the given metadata type and metadata ID
+    Returntype  : String
+=cut
+
+sub get_metadata_field {
+  my $self  = shift;
+  my $type  = shift;
+  my $id    = shift;
+  my $field = shift;
+
+  if (!defined($type) || !defined($id)) {
+    carp("You need to provide a meta type (e.g. 'INFO') and a meta entry ID (e.g. 'AA')");
+    return;
+  } elsif (!defined($field)) {
+    carp("You need to provide a field (e.g. 'Description')");
+    return;
+  }
+
+  my $meta = $self->get_metadata_by_pragma($type);
+  foreach my $meta_entry (@$meta) {
+    if ($meta_entry->{'ID'} eq $id and $meta_entry->{$field}) {
+      return $meta_entry->{$field};
+    }
+  }
+  return;
+}
+
+
 =head2 get_metadata_description
     Argument [1]: Metadata type, e.g. 'INFO'
     Argument [2]: Metadata ID, e.g. 'AA'
@@ -667,16 +700,7 @@ sub get_metadata_description {
   my $type = shift;
   my $id   = shift;
 
-  if (!defined($type) || !defined($id)) {
-    carp("You need to provide a meta type (e.g. 'INFO') and a meta entry ID (e.g. 'AA')");
-    return;
-  }
-
-  my $meta = $self->get_metadata_by_pragma($type);
-  foreach my $meta_entry (@$meta) {
-    return $meta_entry->{'Description'} if ($meta_entry->{'ID'} eq $id);
-  }
-  return;
+  return $self->get_metadata_field($type, $id, 'Description');
 }
 
 

--- a/modules/t/input/data.vcf
+++ b/modules/t/input/data.vcf
@@ -3,6 +3,7 @@
 ##source=myImputationProgramV3.1
 ##reference=file:///seq/references/1000GenomesPilot-NCBI36.fasta
 ##contig=<ID=20,length=62435964,assembly=B36,md5=f126cdf8a6e0c7f379d618ff66beb2da,species="Homo sapiens",taxonomy=x>
+##contig=<ID=ctg1,length=81195210,URL=ftp://somewhere.example/assembly.fa,md5=f126cdf8a6e0c7f379d618ff66beb2da>
 ##phasing=partial
 ##INFO=<ID=NS,Number=1,Type=Integer,Description="Number of Samples With Data">
 ##INFO=<ID=DP,Number=1,Type=Integer,Description="Total Depth">
@@ -22,3 +23,4 @@
 20	1110696	rs6040355	A	G,T	67	PASS	NS=2;DP=10;AF=0.333,0.667;AA=T;DB	GT:GQ:DP:HQ	1|2:21:6:23,27	2|1:2:0:18,2	2/2:35:4
 20	1230237	.	T	.	47	PASS	NS=3;DP=13;AA=T	GT:GQ:DP:HQ	0|0:54:7:56,60	0|0:48:4:51,51	0/0:61:2
 20	1234567	microsat1	GTC	G,GTCT	50	PASS	NS=3;DP=9;AA=G	GT:GQ:DP	0/1:35:4	0/2:17:2	1/1:40:3
+20	1234567	INS0	C	<ctg1>	6	PASS	.	.	.	.	.

--- a/modules/t/vcf.t
+++ b/modules/t/vcf.t
@@ -121,6 +121,9 @@ ok($parser->get_metadata_key_list eq 'FILTER, FORMAT, INFO, contig, fileDate, fi
 ok($parser->get_metadata_by_pragma('fileDate') eq '20090805', 'getMetadataByPragma');
 ok($parser->get_vcf_version eq 'VCFv4.2', 'getVCFversion');
 ok($parser->get_metadata_description('INFO', 'AA') eq 'Ancestral Allele', 'getMetaDescription'); 
+ok($parser->get_metadata_field('contig', '20', 'length') eq 62435964, 'getMetaField');
+ok(!defined($parser->get_metadata_field('contig', '20', 'URL')), 'getMetaField - non-existing field');
+ok($parser->get_metadata_field('contig', 'ctg1', 'URL') =~ /ftp/, 'Multiple contigs');
 
 note "> Testing format validation";
 $parser->reset();


### PR DESCRIPTION
The VCF Parser currently is only able to handle a single contig in the file header, even though multiple contigs are supported in [VCF 4.4 standard (refer to section **6.2.2 Dictionary of contigs**)](http://samtools.github.io/hts-specs/VCFv4.4.pdf).

We are considering to add support for multiple contigs in VEP. We can still use the raw metadata to do so, but I thought these changes would make sense in this repo.

## Changelog

* Add support for multiple contigs
* Add function `get_metadata_field()` to retrieve a given field for any metadata item
* Add unit tests