### PR TITLE
Fixed clone deps criteria in Travis Build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,7 +64,7 @@ install:
     - cpanm -n DBD::SQLite JSON URI::Escape
     - mysql -u root -h localhost -e 'GRANT ALL PRIVILEGES ON *.* TO "travis"@"%"'
     - cp travisci/MultiTestDB.conf.travisci.mysql  modules/t/MultiTestDB.conf.mysql
-#    - cp travisci/MultiTestDB.conf.travisci.SQLite modules/t/MultiTestDB.conf.SQLite
+    - cp travisci/MultiTestDB.conf.travisci.SQLite modules/t/MultiTestDB.conf.SQLite
 
 script: "./travisci/harness.sh"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ env:
   matrix:
   - COVERALLS=true  DB=mysql
   - COVERALLS=false DB=mysql
-  #- COVERALLS=false DB=sqlite
+  - COVERALLS=false DB=sqlite
 
 addons:
   apt:
@@ -72,7 +72,7 @@ script: "./travisci/harness.sh"
 jobs:
   exclude:
     - perl: "5.30"
-      env: COVERALLS=false DB=mysql
+      env: COVERALLS=true DB=mysql
     - perl: "5.26"
       env: COVERALLS=false DB=mysql
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,21 +12,20 @@ cache:
 
 perl:
   - "5.26"
-  - "5.14"
-#  - "5.12"
-#  - "5.10"
+  - "5.30"
 
-# env:
-#  - COVERALLS=true  DB=mysql
-  # - COVERALLS=false DB=mysql
-#  - COVERALLS=false DB=sqlite
+env:
+  matrix:
+  - COVERALLS=true  DB=mysql
+  - COVERALLS=false DB=mysql
+  #- COVERALLS=false DB=sqlite
 
 addons:
   apt:
     packages:
       - unzip
       - apache2
-      - libpng12-dev
+      - libpng-dev
       - libssl-dev
       - openssl
 
@@ -34,9 +33,12 @@ services:
   - mysql
 
 before_install:
-    - git clone --branch main --depth 1 https://github.com/Ensembl/ensembl-test.git
-    - git clone --branch main --depth 1 https://github.com/Ensembl/ensembl.git
-    - git clone --branch main --depth 1 https://github.com/Ensembl/ensembl-variation.git
+    - export ENSEMBL_BRANCH='main'
+    - export ENSEMBL_VER=$(echo $TRAVIS_BRANCH | grep -P -o '(?<=version[\W_]|fix[\W_]|release[\W_])(\d+)')
+    - if [[ $ENSEMBL_VER =~ [0-9]+ ]]; then ENSEMBL_BRANCH="release/$ENSEMBL_VER"; fi
+    - git clone --branch $ENSEMBL_BRANCH --depth 1 https://github.com/Ensembl/ensembl-test.git
+    - git clone --branch $ENSEMBL_BRANCH --depth 1 https://github.com/Ensembl/ensembl.git
+    - git clone --branch $ENSEMBL_BRANCH --depth 1 https://github.com/Ensembl/ensembl-variation.git
     - export CWD=$PWD
     - export DEPS=$HOME/dependencies
     - mkdir -p $DEPS
@@ -59,29 +61,20 @@ install:
     - cpanm -v --installdeps --notest .
     - cpanm Bio::DB::HTS
     - cpanm -n Devel::Cover::Report::Coveralls
-    - cpanm -n DBD::SQLite
-    - cpanm JSON
-    - cpanm URI::Escape
+    - cpanm -n DBD::SQLite JSON URI::Escape
     - mysql -u root -h localhost -e 'GRANT ALL PRIVILEGES ON *.* TO "travis"@"%"'
-    - cp travisci/MultiTestDB.conf.travisci.mysql  modules/t/MultiTestDB.conf
+    - cp travisci/MultiTestDB.conf.travisci.mysql  modules/t/MultiTestDB.conf.mysql
 #    - cp travisci/MultiTestDB.conf.travisci.SQLite modules/t/MultiTestDB.conf.SQLite
 
 script: "./travisci/harness.sh"
 
-# Get the matrix to only build coveralls support when on 5.10
-# matrix:
-#   exclude:
-#     - perl: "5.10"
-#       env: COVERALLS=false DB=mysql
-#     - perl: "5.12"
-#       env: COVERALLS=false DB=sqlite
-#     - perl: "5.12"
-#       env: COVERALLS=true  DB=mysql
-#     - perl: "5.14"
-#       env: COVERALLS=false DB=sqlite
-#     - perl: "5.14"
-#       env: COVERALLS=true  DB=mysql
-#
+# Get the matrix to only build coveralls support when on 5.26
+jobs:
+  exclude:
+    - perl: "5.30"
+      env: COVERALLS=false DB=mysql
+    - perl: "5.26"
+      env: COVERALLS=false DB=mysql
 
 notifications:
   slack:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: trusty
+dist: xenial
 
 language: "perl"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,9 +59,8 @@ install:
     - cd $CWD
     - cpanm -v --installdeps --with-recommends --notest --cpanfile ensembl/cpanfile .
     - cpanm -v --installdeps --notest .
-    - cpanm Bio::DB::HTS
     - cpanm -n Devel::Cover::Report::Coveralls
-    - cpanm -n DBD::SQLite JSON URI::Escape
+    - cpanm -n Bio::DB::HTS DBD::SQLite JSON URI::Escape
     - mysql -u root -h localhost -e 'GRANT ALL PRIVILEGES ON *.* TO "travis"@"%"'
     - cp travisci/MultiTestDB.conf.travisci.mysql  modules/t/MultiTestDB.conf.mysql
     - cp travisci/MultiTestDB.conf.travisci.SQLite modules/t/MultiTestDB.conf.SQLite

--- a/modules/t/test-genome-DBs/homo_sapiens/core/SQLite/table.sql
+++ b/modules/t/test-genome-DBs/homo_sapiens/core/SQLite/table.sql
@@ -1,985 +1,1139 @@
--- 
+--
 -- Created by SQL::Translator::Producer::SQLite
--- Created on Tue Mar 28 11:00:35 2017
--- 
+-- Created on Fri Jan 26 15:05:34 2024
+--
 
 BEGIN TRANSACTION;
 
 --
--- Table: alt_allele
+-- Table: "assembly"
 --
-CREATE TABLE alt_allele (
-  alt_allele_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-  alt_allele_group_id integer NOT NULL,
-  gene_id integer NOT NULL
+CREATE TABLE "assembly" (
+  "asm_seq_region_id" INT(10) NOT NULL,
+  "cmp_seq_region_id" INT(10) NOT NULL,
+  "asm_start" INT(10) NOT NULL,
+  "asm_end" INT(10) NOT NULL,
+  "cmp_start" INT(10) NOT NULL,
+  "cmp_end" INT(10) NOT NULL,
+  "ori" TINYINT(4) NOT NULL
 );
 
-CREATE UNIQUE INDEX gene_idx ON alt_allele (gene_id);
 
+
+
+--
+-- Table: "assembly_exception"
+--
+CREATE TABLE "assembly_exception" (
+  "assembly_exception_id" INTEGER PRIMARY KEY NOT NULL,
+  "seq_region_id" INT(10) NOT NULL,
+  "seq_region_start" INT(10) NOT NULL,
+  "seq_region_end" INT(10) NOT NULL,
+  "exc_type" ENUM(11) NOT NULL,
+  "exc_seq_region_id" INT(10) NOT NULL,
+  "exc_seq_region_start" INT(10) NOT NULL,
+  "exc_seq_region_end" INT(10) NOT NULL,
+  "ori" int(11) NOT NULL
+);
+
+
+
+--
+-- Table: "coord_system"
 --
--- Table: alt_allele_attrib
+CREATE TABLE "coord_system" (
+  "coord_system_id" INTEGER PRIMARY KEY NOT NULL,
+  "species_id" INT(10) NOT NULL DEFAULT 1,
+  "name" VARCHAR(40) NOT NULL,
+  "version" VARCHAR(255) DEFAULT NULL,
+  "rank" int(11) NOT NULL,
+  "attrib" varchar
+);
+
+
+
+
+--
+-- Table: "data_file"
 --
-CREATE TABLE alt_allele_attrib (
-  alt_allele_id integer,
-  attrib enum
+CREATE TABLE "data_file" (
+  "data_file_id" INTEGER PRIMARY KEY NOT NULL,
+  "coord_system_id" INT(10) NOT NULL,
+  "analysis_id" SMALLINT(5) NOT NULL,
+  "name" VARCHAR(100) NOT NULL,
+  "version_lock" TINYINT(1) NOT NULL DEFAULT 0,
+  "absolute" TINYINT(1) NOT NULL DEFAULT 0,
+  "url" TEXT(65535),
+  "file_type" ENUM(6)
 );
+
+
+
 
 --
--- Table: alt_allele_group
+-- Table: "dna"
 --
-CREATE TABLE alt_allele_group (
-  alt_allele_group_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL
+CREATE TABLE "dna" (
+  "seq_region_id" INTEGER PRIMARY KEY NOT NULL,
+  "sequence" LONGTEXT(4294967295) NOT NULL
 );
 
 --
--- Table: analysis
+-- Table: "genome_statistics"
 --
-CREATE TABLE analysis (
-  analysis_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-  created datetime,
-  logic_name varchar(40) NOT NULL DEFAULT '',
-  db varchar(120),
-  db_version varchar(40),
-  db_file varchar(120),
-  program varchar(80),
-  program_version varchar(40),
-  program_file varchar(80),
-  parameters text,
-  module varchar(80),
-  module_version varchar(40),
-  gff_source varchar(40),
-  gff_feature varchar(40)
+CREATE TABLE "genome_statistics" (
+  "genome_statistics_id" INTEGER PRIMARY KEY NOT NULL,
+  "statistic" VARCHAR(128) NOT NULL,
+  "value" BIGINT(11) NOT NULL DEFAULT 0,
+  "species_id" int(10) DEFAULT 1,
+  "attrib_type_id" INT(10) DEFAULT NULL,
+  "timestamp" DATETIME DEFAULT NULL
 );
 
-CREATE UNIQUE INDEX logic_name_idx ON analysis (logic_name);
 
 --
--- Table: analysis_description
+-- Table: "karyotype"
 --
-CREATE TABLE analysis_description (
-  analysis_id integer NOT NULL DEFAULT 0,
-  description text,
-  display_label varchar(255),
-  displayable tinyint NOT NULL DEFAULT 1,
-  web_data text
+CREATE TABLE "karyotype" (
+  "karyotype_id" INTEGER PRIMARY KEY NOT NULL,
+  "seq_region_id" INT(10) NOT NULL,
+  "seq_region_start" INT(10) NOT NULL,
+  "seq_region_end" INT(10) NOT NULL,
+  "band" VARCHAR(40) DEFAULT NULL,
+  "stain" VARCHAR(40) DEFAULT NULL
 );
 
-CREATE UNIQUE INDEX analysis_idx ON analysis_description (analysis_id);
 
 --
--- Table: assembly
+-- Table: "meta"
 --
-CREATE TABLE assembly (
-  asm_seq_region_id integer NOT NULL DEFAULT 0,
-  cmp_seq_region_id integer NOT NULL DEFAULT 0,
-  asm_start integer NOT NULL DEFAULT 0,
-  asm_end integer NOT NULL DEFAULT 0,
-  cmp_start integer NOT NULL DEFAULT 0,
-  cmp_end integer NOT NULL DEFAULT 0,
-  ori tinyint NOT NULL DEFAULT 0
+CREATE TABLE "meta" (
+  "meta_id" INTEGER PRIMARY KEY NOT NULL,
+  "species_id" int(10) DEFAULT 1,
+  "meta_key" VARCHAR(40) NOT NULL,
+  "meta_value" VARCHAR(255) DEFAULT NULL
 );
 
-CREATE UNIQUE INDEX all_idx ON assembly (asm_seq_region_id, cmp_seq_region_id, asm_start, asm_end, cmp_start, cmp_end, ori);
 
+
 --
--- Table: assembly_exception
+-- Table: "meta_coord"
 --
-CREATE TABLE assembly_exception (
-  assembly_exception_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-  seq_region_id integer NOT NULL DEFAULT 0,
-  seq_region_start integer NOT NULL DEFAULT 0,
-  seq_region_end integer NOT NULL DEFAULT 0,
-  exc_type enum NOT NULL DEFAULT 'HAP',
-  exc_seq_region_id integer NOT NULL DEFAULT 0,
-  exc_seq_region_start integer NOT NULL DEFAULT 0,
-  exc_seq_region_end integer NOT NULL DEFAULT 0,
-  ori integer NOT NULL DEFAULT 0
+CREATE TABLE "meta_coord" (
+  "table_name" VARCHAR(40) NOT NULL,
+  "coord_system_id" INT(10) NOT NULL,
+  "max_length" int(11)
 );
+
 
 --
--- Table: associated_group
+-- Table: "seq_region"
 --
-CREATE TABLE associated_group (
-  associated_group_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-  description varchar(128)
+CREATE TABLE "seq_region" (
+  "seq_region_id" INTEGER PRIMARY KEY NOT NULL,
+  "name" VARCHAR(255) NOT NULL,
+  "coord_system_id" INT(10) NOT NULL,
+  "length" INT(10) NOT NULL
 );
+
+
 
 --
--- Table: associated_xref
+-- Table: "seq_region_synonym"
 --
-CREATE TABLE associated_xref (
-  associated_xref_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-  object_xref_id integer NOT NULL DEFAULT 0,
-  xref_id integer NOT NULL DEFAULT 0,
-  source_xref_id integer,
-  condition_type varchar(128),
-  associated_group_id integer,
-  rank integer DEFAULT 0
+CREATE TABLE "seq_region_synonym" (
+  "seq_region_synonym_id" INTEGER PRIMARY KEY NOT NULL,
+  "seq_region_id" INT(10) NOT NULL,
+  "synonym" VARCHAR(250) NOT NULL,
+  "external_db_id" int(10)
 );
 
-CREATE UNIQUE INDEX object_associated_source_type_idx ON associated_xref (object_xref_id, xref_id, source_xref_id, condition_type, associated_group_id);
 
+
 --
--- Table: attrib_type
+-- Table: "seq_region_attrib"
 --
-CREATE TABLE attrib_type (
-  attrib_type_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-  code varchar(20) NOT NULL DEFAULT '',
-  name varchar(255) NOT NULL DEFAULT '',
-  description text
+CREATE TABLE "seq_region_attrib" (
+  "seq_region_id" INT(10) NOT NULL DEFAULT 0,
+  "attrib_type_id" SMALLINT(5) NOT NULL DEFAULT 0,
+  "value" TEXT(65535) NOT NULL
 );
+
 
-CREATE UNIQUE INDEX code_idx ON attrib_type (code);
 
+
+
 --
--- Table: coord_system
+-- Table: "alt_allele"
 --
-CREATE TABLE coord_system (
-  coord_system_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-  species_id integer NOT NULL DEFAULT 1,
-  name varchar(40) NOT NULL,
-  version varchar(255),
-  rank integer NOT NULL,
-  attrib varchar
+CREATE TABLE "alt_allele" (
+  "alt_allele_id" INTEGER PRIMARY KEY NOT NULL,
+  "alt_allele_group_id" int(10) NOT NULL,
+  "gene_id" int(10) NOT NULL
 );
 
-CREATE UNIQUE INDEX name_idx ON coord_system (name, version, species_id);
 
-CREATE UNIQUE INDEX rank_idx ON coord_system (rank, species_id);
 
 --
--- Table: data_file
+-- Table: "alt_allele_attrib"
 --
-CREATE TABLE data_file (
-  data_file_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-  coord_system_id integer NOT NULL,
-  analysis_id smallint NOT NULL,
-  name varchar(100) NOT NULL,
-  version_lock tinyint NOT NULL DEFAULT 0,
-  absolute tinyint NOT NULL DEFAULT 0,
-  url text,
-  file_type enum
+CREATE TABLE "alt_allele_attrib" (
+  "alt_allele_id" int(10),
+  "attrib" ENUM(35)
 );
 
-CREATE UNIQUE INDEX df_unq_idx ON data_file (coord_system_id, analysis_id, name, file_type);
 
 --
--- Table: density_feature
+-- Table: "alt_allele_group"
 --
-CREATE TABLE density_feature (
-  density_feature_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-  density_type_id integer NOT NULL DEFAULT 0,
-  seq_region_id integer NOT NULL DEFAULT 0,
-  seq_region_start integer NOT NULL DEFAULT 0,
-  seq_region_end integer NOT NULL DEFAULT 0,
-  density_value float NOT NULL DEFAULT 0
+CREATE TABLE "alt_allele_group" (
+  "alt_allele_group_id" INTEGER PRIMARY KEY NOT NULL
 );
 
 --
--- Table: density_type
+-- Table: "analysis"
 --
-CREATE TABLE density_type (
-  density_type_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-  analysis_id integer NOT NULL DEFAULT 0,
-  block_size integer NOT NULL DEFAULT 0,
-  region_features integer NOT NULL DEFAULT 0,
-  value_type enum NOT NULL DEFAULT 'sum'
+CREATE TABLE "analysis" (
+  "analysis_id" INTEGER PRIMARY KEY NOT NULL,
+  "created" datetime DEFAULT NULL,
+  "logic_name" VARCHAR(128) NOT NULL,
+  "db" VARCHAR(120),
+  "db_version" VARCHAR(40),
+  "db_file" VARCHAR(120),
+  "program" VARCHAR(80),
+  "program_version" VARCHAR(40),
+  "program_file" VARCHAR(80),
+  "parameters" TEXT(65535),
+  "module" VARCHAR(80),
+  "module_version" VARCHAR(40),
+  "gff_source" VARCHAR(40),
+  "gff_feature" VARCHAR(40)
 );
 
-CREATE UNIQUE INDEX analysis_id ON density_type (analysis_id, block_size, region_features);
 
 --
--- Table: dependent_xref
+-- Table: "analysis_description"
 --
-CREATE TABLE dependent_xref (
-  object_xref_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-  master_xref_id integer NOT NULL,
-  dependent_xref_id integer NOT NULL
+CREATE TABLE "analysis_description" (
+  "analysis_id" SMALLINT(5) NOT NULL,
+  "description" TEXT(65535),
+  "display_label" VARCHAR(255) NOT NULL,
+  "displayable" TINYINT(1) NOT NULL DEFAULT 1,
+  "web_data" TEXT(65535)
 );
+
 
 --
--- Table: ditag
+-- Table: "attrib_type"
 --
-CREATE TABLE ditag (
-  ditag_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-  name varchar(30),
-  type varchar(30),
-  tag_count smallint DEFAULT 1,
-  sequence text
+CREATE TABLE "attrib_type" (
+  "attrib_type_id" INTEGER PRIMARY KEY NOT NULL,
+  "code" VARCHAR(20) NOT NULL DEFAULT '',
+  "name" VARCHAR(255) NOT NULL DEFAULT '',
+  "description" TEXT(65535)
 );
 
+
 --
--- Table: ditag_feature
+-- Table: "dna_align_feature"
 --
-CREATE TABLE ditag_feature (
-  ditag_feature_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-  ditag_id integer NOT NULL DEFAULT 0,
-  ditag_pair_id integer NOT NULL DEFAULT 0,
-  seq_region_id integer NOT NULL DEFAULT 0,
-  seq_region_start integer NOT NULL DEFAULT 0,
-  seq_region_end integer NOT NULL DEFAULT 0,
-  seq_region_strand tinyint NOT NULL DEFAULT 0,
-  analysis_id integer NOT NULL DEFAULT 0,
-  hit_start integer NOT NULL DEFAULT 0,
-  hit_end integer NOT NULL DEFAULT 0,
-  hit_strand tinyint NOT NULL DEFAULT 0,
-  cigar_line text,
-  ditag_side char(1) DEFAULT ''
+CREATE TABLE "dna_align_feature" (
+  "dna_align_feature_id" INTEGER PRIMARY KEY NOT NULL,
+  "seq_region_id" INT(10) NOT NULL,
+  "seq_region_start" INT(10) NOT NULL,
+  "seq_region_end" INT(10) NOT NULL,
+  "seq_region_strand" TINYINT(1) NOT NULL,
+  "hit_start" int(11) NOT NULL,
+  "hit_end" int(11) NOT NULL,
+  "hit_strand" TINYINT(1) NOT NULL,
+  "hit_name" VARCHAR(40) NOT NULL,
+  "analysis_id" SMALLINT(5) NOT NULL,
+  "score" DOUBLE,
+  "evalue" DOUBLE,
+  "perc_ident" FLOAT,
+  "cigar_line" TEXT(65535),
+  "external_db_id" int(10),
+  "hcoverage" DOUBLE,
+  "align_type" ENUM(7) DEFAULT 'ensembl'
 );
+
+
+
+
 
+
 --
--- Table: dna
+-- Table: "dna_align_feature_attrib"
 --
-CREATE TABLE dna (
-  seq_region_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL DEFAULT 0,
-  sequence mediumtext NOT NULL
+CREATE TABLE "dna_align_feature_attrib" (
+  "dna_align_feature_id" INT(10) NOT NULL,
+  "attrib_type_id" SMALLINT(5) NOT NULL,
+  "value" TEXT(65535) NOT NULL
 );
+
+
+
+
 
 --
--- Table: dna_align_feature
+-- Table: "exon"
 --
-CREATE TABLE dna_align_feature (
-  dna_align_feature_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-  seq_region_id integer NOT NULL DEFAULT 0,
-  seq_region_start integer NOT NULL DEFAULT 0,
-  seq_region_end integer NOT NULL DEFAULT 0,
-  seq_region_strand tinyint NOT NULL DEFAULT 0,
-  hit_start integer NOT NULL DEFAULT 0,
-  hit_end integer NOT NULL DEFAULT 0,
-  hit_strand tinyint NOT NULL DEFAULT 0,
-  hit_name varchar(40) NOT NULL DEFAULT '',
-  analysis_id integer NOT NULL DEFAULT 0,
-  score double precision,
-  evalue double precision,
-  perc_ident float,
-  cigar_line text,
-  external_db_id smallint,
-  hcoverage double precision,
-  external_data text
+CREATE TABLE "exon" (
+  "exon_id" INTEGER PRIMARY KEY NOT NULL,
+  "seq_region_id" INT(10) NOT NULL,
+  "seq_region_start" INT(10) NOT NULL,
+  "seq_region_end" INT(10) NOT NULL,
+  "seq_region_strand" TINYINT(2) NOT NULL,
+  "phase" TINYINT(2) NOT NULL,
+  "end_phase" TINYINT(2) NOT NULL,
+  "is_current" TINYINT(1) NOT NULL DEFAULT 1,
+  "is_constitutive" TINYINT(1) NOT NULL DEFAULT 0,
+  "stable_id" VARCHAR(128) DEFAULT NULL,
+  "version" SMALLINT(5) DEFAULT NULL,
+  "created_date" DATETIME DEFAULT NULL,
+  "modified_date" DATETIME DEFAULT NULL
 );
 
+
+
 --
--- Table: dna_align_feature_attrib
+-- Table: "exon_transcript"
 --
-CREATE TABLE dna_align_feature_attrib (
-  dna_align_feature_id integer NOT NULL,
-  attrib_type_id smallint NOT NULL,
-  value text NOT NULL
+CREATE TABLE "exon_transcript" (
+  "exon_id" INT(10) NOT NULL,
+  "transcript_id" INT(10) NOT NULL,
+  "rank" INT(10) NOT NULL,
+  PRIMARY KEY ("exon_id", "transcript_id", "rank")
 );
 
-CREATE UNIQUE INDEX dna_align_feature_attribx ON dna_align_feature_attrib (dna_align_feature_id, attrib_type_id, value);
 
+
 --
--- Table: exon
+-- Table: "gene"
 --
-CREATE TABLE exon (
-  exon_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-  seq_region_id integer NOT NULL,
-  seq_region_start integer NOT NULL,
-  seq_region_end integer NOT NULL,
-  seq_region_strand tinyint NOT NULL,
-  phase tinyint NOT NULL,
-  end_phase tinyint NOT NULL,
-  is_current tinyint NOT NULL DEFAULT 1,
-  is_constitutive tinyint NOT NULL DEFAULT 0,
-  stable_id varchar(128),
-  version smallint,
-  created_date datetime,
-  modified_date datetime
+CREATE TABLE "gene" (
+  "gene_id" INTEGER PRIMARY KEY NOT NULL,
+  "biotype" VARCHAR(40) NOT NULL,
+  "analysis_id" SMALLINT(5) NOT NULL,
+  "seq_region_id" INT(10) NOT NULL,
+  "seq_region_start" INT(10) NOT NULL,
+  "seq_region_end" INT(10) NOT NULL,
+  "seq_region_strand" TINYINT(2) NOT NULL,
+  "display_xref_id" INT(10),
+  "source" VARCHAR(40) NOT NULL,
+  "description" TEXT(65535),
+  "is_current" TINYINT(1) NOT NULL DEFAULT 1,
+  "canonical_transcript_id" INT(10) NOT NULL,
+  "stable_id" VARCHAR(128) DEFAULT NULL,
+  "version" SMALLINT(5) DEFAULT NULL,
+  "created_date" DATETIME DEFAULT NULL,
+  "modified_date" DATETIME DEFAULT NULL
 );
+
 
+
+
+
+
 --
--- Table: exon_transcript
+-- Table: "gene_attrib"
 --
-CREATE TABLE exon_transcript (
-  exon_id integer NOT NULL DEFAULT 0,
-  transcript_id integer NOT NULL DEFAULT 0,
-  rank integer NOT NULL DEFAULT 0,
-  PRIMARY KEY (exon_id, transcript_id, rank)
+CREATE TABLE "gene_attrib" (
+  "gene_id" INT(10) NOT NULL DEFAULT 0,
+  "attrib_type_id" SMALLINT(5) NOT NULL DEFAULT 0,
+  "value" TEXT(65535) NOT NULL
 );
+
 
+
+
+
 --
--- Table: external_db
+-- Table: "protein_align_feature"
 --
-CREATE TABLE external_db (
-  external_db_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL DEFAULT 0,
-  db_name varchar(27) NOT NULL DEFAULT '',
-  db_release varchar(40) NOT NULL DEFAULT '',
-  status enum NOT NULL DEFAULT 'KNOWNXREF',
-  priority integer NOT NULL DEFAULT 0,
-  db_display_name varchar(255),
-  type enum,
-  secondary_db_name varchar(255),
-  secondary_db_table varchar(255),
-  description text
+CREATE TABLE "protein_align_feature" (
+  "protein_align_feature_id" INTEGER PRIMARY KEY NOT NULL,
+  "seq_region_id" INT(10) NOT NULL,
+  "seq_region_start" INT(10) NOT NULL,
+  "seq_region_end" INT(10) NOT NULL,
+  "seq_region_strand" TINYINT(1) NOT NULL DEFAULT 1,
+  "hit_start" INT(10) NOT NULL,
+  "hit_end" INT(10) NOT NULL,
+  "hit_name" VARCHAR(40) NOT NULL,
+  "analysis_id" SMALLINT(5) NOT NULL,
+  "score" DOUBLE,
+  "evalue" DOUBLE,
+  "perc_ident" FLOAT,
+  "cigar_line" TEXT(65535),
+  "external_db_id" int(10),
+  "hcoverage" DOUBLE,
+  "align_type" ENUM(7) DEFAULT 'ensembl'
 );
+
 
-CREATE UNIQUE INDEX db_name_db_release_idx ON external_db (db_name, db_release);
 
+
+
+
 --
--- Table: external_synonym
+-- Table: "protein_feature"
 --
-CREATE TABLE external_synonym (
-  xref_id integer NOT NULL DEFAULT 0,
-  synonym varchar(40) NOT NULL DEFAULT '',
-  PRIMARY KEY (xref_id, synonym)
+CREATE TABLE "protein_feature" (
+  "protein_feature_id" INTEGER PRIMARY KEY NOT NULL,
+  "translation_id" INT(10) NOT NULL,
+  "seq_start" INT(10) NOT NULL,
+  "seq_end" INT(10) NOT NULL,
+  "hit_start" INT(10) NOT NULL,
+  "hit_end" INT(10) NOT NULL,
+  "hit_name" VARCHAR(40) NOT NULL,
+  "analysis_id" SMALLINT(5) NOT NULL,
+  "score" DOUBLE,
+  "evalue" DOUBLE,
+  "perc_ident" FLOAT,
+  "external_data" TEXT(65535),
+  "hit_description" TEXT(65535),
+  "cigar_line" TEXT(65535),
+  "align_type" ENUM(9) DEFAULT NULL
 );
+
+
 
+
+
 --
--- Table: gene
+-- Table: "supporting_feature"
 --
-CREATE TABLE gene (
-  gene_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-  biotype varchar(40) NOT NULL,
-  analysis_id smallint NOT NULL,
-  seq_region_id integer NOT NULL,
-  seq_region_start integer NOT NULL,
-  seq_region_end integer NOT NULL,
-  seq_region_strand tinyint NOT NULL,
-  display_xref_id integer,
-  source varchar(40) NOT NULL,
-  status enum,
-  description text,
-  is_current tinyint NOT NULL DEFAULT 1,
-  canonical_transcript_id integer NOT NULL,
-  stable_id varchar(128),
-  version smallint,
-  created_date datetime,
-  modified_date datetime
+CREATE TABLE "supporting_feature" (
+  "exon_id" INT(10) NOT NULL DEFAULT 0,
+  "feature_type" ENUM(21),
+  "feature_id" INT(10) NOT NULL DEFAULT 0
 );
+
+
 
 --
--- Table: gene_archive
+-- Table: "transcript"
 --
-CREATE TABLE gene_archive (
-  gene_stable_id varchar(128) NOT NULL DEFAULT '',
-  gene_version smallint NOT NULL DEFAULT 0,
-  transcript_stable_id varchar(128) NOT NULL DEFAULT '',
-  transcript_version smallint NOT NULL DEFAULT 0,
-  translation_stable_id varchar(128) NOT NULL DEFAULT '',
-  translation_version smallint NOT NULL DEFAULT 0,
-  peptide_archive_id integer NOT NULL DEFAULT 0,
-  mapping_session_id integer NOT NULL DEFAULT 0
+CREATE TABLE "transcript" (
+  "transcript_id" INTEGER PRIMARY KEY NOT NULL,
+  "gene_id" INT(10),
+  "analysis_id" SMALLINT(5) NOT NULL,
+  "seq_region_id" INT(10) NOT NULL,
+  "seq_region_start" INT(10) NOT NULL,
+  "seq_region_end" INT(10) NOT NULL,
+  "seq_region_strand" TINYINT(2) NOT NULL,
+  "display_xref_id" INT(10),
+  "source" VARCHAR(40) NOT NULL DEFAULT 'ensembl',
+  "biotype" VARCHAR(40) NOT NULL,
+  "description" TEXT(65535),
+  "is_current" TINYINT(1) NOT NULL DEFAULT 1,
+  "canonical_translation_id" INT(10),
+  "stable_id" VARCHAR(128) DEFAULT NULL,
+  "version" SMALLINT(5) DEFAULT NULL,
+  "created_date" DATETIME DEFAULT NULL,
+  "modified_date" DATETIME DEFAULT NULL
 );
+
+
+
+
+
 
+
 --
--- Table: gene_attrib
+-- Table: "transcript_attrib"
 --
-CREATE TABLE gene_attrib (
-  gene_id integer NOT NULL DEFAULT 0,
-  attrib_type_id smallint NOT NULL DEFAULT 0,
-  value text NOT NULL
+CREATE TABLE "transcript_attrib" (
+  "transcript_id" INT(10) NOT NULL DEFAULT 0,
+  "attrib_type_id" SMALLINT(5) NOT NULL DEFAULT 0,
+  "value" TEXT(65535) NOT NULL
 );
+
 
-CREATE UNIQUE INDEX gene_attribx ON gene_attrib (gene_id, attrib_type_id, value);
 
+
+
 --
--- Table: genome_statistics
+-- Table: "transcript_supporting_feature"
 --
-CREATE TABLE genome_statistics (
-  genome_statistics_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-  statistic varchar(128) NOT NULL,
-  value bigint NOT NULL DEFAULT 0,
-  species_id integer DEFAULT 1,
-  attrib_type_id integer,
-  timestamp datetime
+CREATE TABLE "transcript_supporting_feature" (
+  "transcript_id" INT(10) NOT NULL DEFAULT 0,
+  "feature_type" ENUM(21),
+  "feature_id" INT(10) NOT NULL DEFAULT 0
 );
+
 
-CREATE UNIQUE INDEX stats_uniq ON genome_statistics (statistic, attrib_type_id, species_id);
 
 --
--- Table: identity_xref
+-- Table: "translation"
 --
-CREATE TABLE identity_xref (
-  object_xref_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL DEFAULT 0,
-  xref_identity integer,
-  ensembl_identity integer,
-  xref_start integer,
-  xref_end integer,
-  ensembl_start integer,
-  ensembl_end integer,
-  cigar_line text,
-  score double precision,
-  evalue double precision
+CREATE TABLE "translation" (
+  "translation_id" INTEGER PRIMARY KEY NOT NULL,
+  "transcript_id" INT(10) NOT NULL,
+  "seq_start" INT(10) NOT NULL,
+  -- relative to exon start
+  "start_exon_id" INT(10) NOT NULL,
+  "seq_end" INT(10) NOT NULL,
+  -- relative to exon start
+  "end_exon_id" INT(10) NOT NULL,
+  "stable_id" VARCHAR(128) DEFAULT NULL,
+  "version" SMALLINT(5) DEFAULT NULL,
+  "created_date" DATETIME DEFAULT NULL,
+  "modified_date" DATETIME DEFAULT NULL
 );
 
+
+
 --
--- Table: interpro
+-- Table: "translation_attrib"
 --
-CREATE TABLE interpro (
-  interpro_ac varchar(40) NOT NULL DEFAULT '',
-  id varchar(40) NOT NULL DEFAULT ''
+CREATE TABLE "translation_attrib" (
+  "translation_id" INT(10) NOT NULL DEFAULT 0,
+  "attrib_type_id" SMALLINT(5) NOT NULL DEFAULT 0,
+  "value" TEXT(65535) NOT NULL
 );
+
+
+
 
-CREATE UNIQUE INDEX accession_idx ON interpro (interpro_ac, id);
 
 --
--- Table: intron_supporting_evidence
+-- Table: "density_feature"
 --
-CREATE TABLE intron_supporting_evidence (
-  intron_supporting_evidence_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-  analysis_id smallint NOT NULL,
-  seq_region_id integer NOT NULL,
-  seq_region_start integer NOT NULL,
-  seq_region_end integer NOT NULL,
-  seq_region_strand tinyint NOT NULL,
-  hit_name varchar(100) NOT NULL,
-  score decimal(10,3),
-  score_type enum DEFAULT 'NONE',
-  is_splice_canonical tinyint NOT NULL DEFAULT 0
+CREATE TABLE "density_feature" (
+  "density_feature_id" INTEGER PRIMARY KEY NOT NULL,
+  "density_type_id" INT(10) NOT NULL,
+  "seq_region_id" INT(10) NOT NULL,
+  "seq_region_start" INT(10) NOT NULL,
+  "seq_region_end" INT(10) NOT NULL,
+  "density_value" FLOAT NOT NULL
 );
 
-CREATE UNIQUE INDEX analysis_id02 ON intron_supporting_evidence (analysis_id, seq_region_id, seq_region_start, seq_region_end, seq_region_strand, hit_name);
 
+
 --
--- Table: karyotype
+-- Table: "density_type"
 --
-CREATE TABLE karyotype (
-  karyotype_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-  seq_region_id integer NOT NULL DEFAULT 0,
-  seq_region_start integer NOT NULL DEFAULT 0,
-  seq_region_end integer NOT NULL DEFAULT 0,
-  band varchar(40),
-  stain varchar(40)
+CREATE TABLE "density_type" (
+  "density_type_id" INTEGER PRIMARY KEY NOT NULL,
+  "analysis_id" SMALLINT(5) NOT NULL,
+  "block_size" int(11) NOT NULL,
+  "region_features" int(11) NOT NULL,
+  "value_type" ENUM(5) NOT NULL
 );
+
 
 --
--- Table: map
+-- Table: "ditag"
 --
-CREATE TABLE map (
-  map_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-  map_name varchar(30) NOT NULL DEFAULT ''
+CREATE TABLE "ditag" (
+  "ditag_id" INTEGER PRIMARY KEY NOT NULL,
+  "name" VARCHAR(30) NOT NULL,
+  "type" VARCHAR(30) NOT NULL,
+  "tag_count" smallint(6) NOT NULL DEFAULT 1,
+  "sequence" TINYTEXT(255) NOT NULL
 );
 
 --
--- Table: mapping_session
+-- Table: "ditag_feature"
 --
-CREATE TABLE mapping_session (
-  mapping_session_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-  old_db_name varchar(80) NOT NULL DEFAULT '',
-  new_db_name varchar(80) NOT NULL DEFAULT '',
-  old_release varchar(5) NOT NULL DEFAULT '',
-  new_release varchar(5) NOT NULL DEFAULT '',
-  old_assembly varchar(20) NOT NULL DEFAULT '',
-  new_assembly varchar(20) NOT NULL DEFAULT '',
-  created datetime
+CREATE TABLE "ditag_feature" (
+  "ditag_feature_id" INTEGER PRIMARY KEY NOT NULL,
+  "ditag_id" INT(10) NOT NULL DEFAULT 0,
+  "ditag_pair_id" INT(10) NOT NULL DEFAULT 0,
+  "seq_region_id" INT(10) NOT NULL DEFAULT 0,
+  "seq_region_start" INT(10) NOT NULL DEFAULT 0,
+  "seq_region_end" INT(10) NOT NULL DEFAULT 0,
+  "seq_region_strand" TINYINT(1) NOT NULL DEFAULT 0,
+  "analysis_id" SMALLINT(5) NOT NULL DEFAULT 0,
+  "hit_start" INT(10) NOT NULL DEFAULT 0,
+  "hit_end" INT(10) NOT NULL DEFAULT 0,
+  "hit_strand" TINYINT(1) NOT NULL DEFAULT 0,
+  "cigar_line" TINYTEXT(255) NOT NULL,
+  "ditag_side" ENUM(1) NOT NULL
 );
+
+
 
+
 --
--- Table: mapping_set
+-- Table: "intron_supporting_evidence"
 --
-CREATE TABLE mapping_set (
-  mapping_set_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-  internal_schema_build varchar(20) NOT NULL,
-  external_schema_build varchar(20) NOT NULL
+CREATE TABLE "intron_supporting_evidence" (
+  "intron_supporting_evidence_id" INTEGER PRIMARY KEY NOT NULL,
+  "analysis_id" SMALLINT(5) NOT NULL,
+  "seq_region_id" INT(10) NOT NULL,
+  "seq_region_start" INT(10) NOT NULL,
+  "seq_region_end" INT(10) NOT NULL,
+  "seq_region_strand" TINYINT(2) NOT NULL,
+  "hit_name" VARCHAR(100) NOT NULL,
+  "score" DECIMAL(10,3),
+  "score_type" ENUM(5) DEFAULT 'NONE',
+  "is_splice_canonical" TINYINT(1) NOT NULL DEFAULT 0
 );
+
 
-CREATE UNIQUE INDEX mapping_idx ON mapping_set (internal_schema_build, external_schema_build);
+
+--
+-- Table: "map"
+--
+CREATE TABLE "map" (
+  "map_id" INTEGER PRIMARY KEY NOT NULL,
+  "map_name" VARCHAR(30) NOT NULL
+);
 
 --
--- Table: marker
+-- Table: "marker"
 --
-CREATE TABLE marker (
-  marker_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-  display_marker_synonym_id integer,
-  left_primer varchar(100) NOT NULL DEFAULT '',
-  right_primer varchar(100) NOT NULL DEFAULT '',
-  min_primer_dist integer NOT NULL DEFAULT 0,
-  max_primer_dist integer NOT NULL DEFAULT 0,
-  priority integer,
-  type enum
+CREATE TABLE "marker" (
+  "marker_id" INTEGER PRIMARY KEY NOT NULL,
+  "display_marker_synonym_id" INT(10),
+  "left_primer" VARCHAR(100) NOT NULL,
+  "right_primer" VARCHAR(100) NOT NULL,
+  "min_primer_dist" INT(10) NOT NULL,
+  "max_primer_dist" INT(10) NOT NULL,
+  "priority" int(11),
+  "type" ENUM(14)
 );
+
 
+
 --
--- Table: marker_feature
+-- Table: "marker_feature"
 --
-CREATE TABLE marker_feature (
-  marker_feature_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-  marker_id integer NOT NULL DEFAULT 0,
-  seq_region_id integer NOT NULL DEFAULT 0,
-  seq_region_start integer NOT NULL DEFAULT 0,
-  seq_region_end integer NOT NULL DEFAULT 0,
-  analysis_id integer NOT NULL DEFAULT 0,
-  map_weight integer
+CREATE TABLE "marker_feature" (
+  "marker_feature_id" INTEGER PRIMARY KEY NOT NULL,
+  "marker_id" INT(10) NOT NULL,
+  "seq_region_id" INT(10) NOT NULL,
+  "seq_region_start" INT(10) NOT NULL,
+  "seq_region_end" INT(10) NOT NULL,
+  "analysis_id" SMALLINT(5) NOT NULL,
+  "map_weight" INT(10)
 );
+
 
+
 --
--- Table: marker_map_location
+-- Table: "marker_map_location"
 --
-CREATE TABLE marker_map_location (
-  marker_id integer NOT NULL DEFAULT 0,
-  map_id integer NOT NULL DEFAULT 0,
-  chromosome_name varchar(15) NOT NULL DEFAULT '',
-  marker_synonym_id integer NOT NULL DEFAULT 0,
-  position varchar(15) NOT NULL DEFAULT '',
-  lod_score double precision,
-  PRIMARY KEY (marker_id, map_id)
+CREATE TABLE "marker_map_location" (
+  "marker_id" INT(10) NOT NULL,
+  "map_id" INT(10) NOT NULL,
+  "chromosome_name" VARCHAR(15) NOT NULL,
+  "marker_synonym_id" INT(10) NOT NULL,
+  "position" VARCHAR(15) NOT NULL,
+  "lod_score" DOUBLE,
+  PRIMARY KEY ("marker_id", "map_id")
 );
+
 
 --
--- Table: marker_synonym
+-- Table: "marker_synonym"
 --
-CREATE TABLE marker_synonym (
-  marker_synonym_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-  marker_id integer NOT NULL DEFAULT 0,
-  source varchar(20),
-  name varchar(30)
+CREATE TABLE "marker_synonym" (
+  "marker_synonym_id" INTEGER PRIMARY KEY NOT NULL,
+  "marker_id" INT(10) NOT NULL,
+  "source" VARCHAR(20),
+  "name" VARCHAR(50)
 );
 
+
+
 --
--- Table: meta
+-- Table: "misc_attrib"
 --
-CREATE TABLE meta (
-  meta_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-  species_id integer DEFAULT 1,
-  meta_key varchar(40) NOT NULL,
-  meta_value varchar(255) NOT NULL
+CREATE TABLE "misc_attrib" (
+  "misc_feature_id" INT(10) NOT NULL DEFAULT 0,
+  "attrib_type_id" SMALLINT(5) NOT NULL DEFAULT 0,
+  "value" TEXT(65535) NOT NULL
 );
+
 
-CREATE UNIQUE INDEX species_key_value_idx ON meta (species_id, meta_key, meta_value);
 
+
+
 --
--- Table: meta_coord
+-- Table: "misc_feature"
 --
-CREATE TABLE meta_coord (
-  table_name varchar(40) NOT NULL DEFAULT '',
-  coord_system_id integer NOT NULL DEFAULT 0,
-  max_length integer
+CREATE TABLE "misc_feature" (
+  "misc_feature_id" INTEGER PRIMARY KEY NOT NULL,
+  "seq_region_id" INT(10) NOT NULL DEFAULT 0,
+  "seq_region_start" INT(10) NOT NULL DEFAULT 0,
+  "seq_region_end" INT(10) NOT NULL DEFAULT 0,
+  "seq_region_strand" TINYINT(4) NOT NULL DEFAULT 0
 );
 
-CREATE UNIQUE INDEX cs_table_name_idx ON meta_coord (coord_system_id, table_name);
 
 --
--- Table: misc_attrib
+-- Table: "misc_feature_misc_set"
 --
-CREATE TABLE misc_attrib (
-  misc_feature_id integer NOT NULL DEFAULT 0,
-  attrib_type_id smallint NOT NULL DEFAULT 0,
-  value text NOT NULL
+CREATE TABLE "misc_feature_misc_set" (
+  "misc_feature_id" INT(10) NOT NULL DEFAULT 0,
+  "misc_set_id" SMALLINT(5) NOT NULL DEFAULT 0,
+  PRIMARY KEY ("misc_feature_id", "misc_set_id")
 );
 
-CREATE UNIQUE INDEX misc_attribx ON misc_attrib (misc_feature_id, attrib_type_id, value);
 
 --
--- Table: misc_feature
+-- Table: "misc_set"
 --
-CREATE TABLE misc_feature (
-  misc_feature_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-  seq_region_id integer NOT NULL DEFAULT 0,
-  seq_region_start integer NOT NULL DEFAULT 0,
-  seq_region_end integer NOT NULL DEFAULT 0,
-  seq_region_strand tinyint NOT NULL DEFAULT 0
+CREATE TABLE "misc_set" (
+  "misc_set_id" INTEGER PRIMARY KEY NOT NULL,
+  "code" VARCHAR(25) NOT NULL DEFAULT '',
+  "name" VARCHAR(255) NOT NULL DEFAULT '',
+  "description" TEXT(65535) NOT NULL,
+  "max_length" int(10) NOT NULL
 );
 
+
 --
--- Table: misc_feature_misc_set
+-- Table: "prediction_exon"
 --
-CREATE TABLE misc_feature_misc_set (
-  misc_feature_id integer NOT NULL DEFAULT 0,
-  misc_set_id smallint NOT NULL DEFAULT 0,
-  PRIMARY KEY (misc_feature_id, misc_set_id)
+CREATE TABLE "prediction_exon" (
+  "prediction_exon_id" INTEGER PRIMARY KEY NOT NULL,
+  "prediction_transcript_id" INT(10) NOT NULL,
+  "exon_rank" SMALLINT(5) NOT NULL,
+  "seq_region_id" INT(10) NOT NULL,
+  "seq_region_start" INT(10) NOT NULL,
+  "seq_region_end" INT(10) NOT NULL,
+  "seq_region_strand" TINYINT(4) NOT NULL,
+  "start_phase" TINYINT(4) NOT NULL,
+  "score" DOUBLE,
+  "p_value" DOUBLE
 );
+
 
+
 --
--- Table: misc_set
+-- Table: "prediction_transcript"
 --
-CREATE TABLE misc_set (
-  misc_set_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-  code varchar(25) NOT NULL DEFAULT '',
-  name varchar(255) NOT NULL DEFAULT '',
-  description text NOT NULL,
-  max_length integer NOT NULL DEFAULT 0
+CREATE TABLE "prediction_transcript" (
+  "prediction_transcript_id" INTEGER PRIMARY KEY NOT NULL,
+  "seq_region_id" INT(10) NOT NULL,
+  "seq_region_start" INT(10) NOT NULL,
+  "seq_region_end" INT(10) NOT NULL,
+  "seq_region_strand" TINYINT(4) NOT NULL,
+  "analysis_id" SMALLINT(5) NOT NULL,
+  "display_label" VARCHAR(255)
 );
+
 
-CREATE UNIQUE INDEX code_idx02 ON misc_set (code);
 
 --
--- Table: object_xref
+-- Table: "repeat_consensus"
 --
-CREATE TABLE object_xref (
-  object_xref_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-  ensembl_id integer NOT NULL DEFAULT 0,
-  ensembl_object_type enum NOT NULL DEFAULT 'RawContig',
-  xref_id integer NOT NULL,
-  linkage_annotation varchar(255),
-  analysis_id smallint NOT NULL
+CREATE TABLE "repeat_consensus" (
+  "repeat_consensus_id" INTEGER PRIMARY KEY NOT NULL,
+  "repeat_name" VARCHAR(255) NOT NULL,
+  "repeat_class" VARCHAR(100) NOT NULL,
+  "repeat_type" VARCHAR(40) NOT NULL,
+  "repeat_consensus" TEXT(65535)
 );
+
+
+
 
-CREATE UNIQUE INDEX xref_idx ON object_xref (xref_id, ensembl_object_type, ensembl_id, analysis_id);
 
 --
--- Table: ontology_xref
+-- Table: "repeat_feature"
 --
-CREATE TABLE ontology_xref (
-  object_xref_id integer NOT NULL DEFAULT 0,
-  linkage_type varchar(3),
-  source_xref_id integer
+CREATE TABLE "repeat_feature" (
+  "repeat_feature_id" INTEGER PRIMARY KEY NOT NULL,
+  "seq_region_id" INT(10) NOT NULL,
+  "seq_region_start" INT(10) NOT NULL,
+  "seq_region_end" INT(10) NOT NULL,
+  "seq_region_strand" TINYINT(1) NOT NULL DEFAULT 1,
+  "repeat_start" INT(10) NOT NULL,
+  "repeat_end" INT(10) NOT NULL,
+  "repeat_consensus_id" INT(10) NOT NULL,
+  "analysis_id" SMALLINT(5) NOT NULL,
+  "score" DOUBLE
 );
 
-CREATE UNIQUE INDEX object_source_type_idx ON ontology_xref (object_xref_id, source_xref_id, linkage_type);
 
+
+
 --
--- Table: operon
+-- Table: "simple_feature"
 --
-CREATE TABLE operon (
-  operon_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-  seq_region_id integer NOT NULL,
-  seq_region_start integer NOT NULL,
-  seq_region_end integer NOT NULL,
-  seq_region_strand tinyint NOT NULL,
-  display_label varchar(255),
-  analysis_id smallint NOT NULL,
-  stable_id varchar(128),
-  version smallint,
-  created_date datetime,
-  modified_date datetime
+CREATE TABLE "simple_feature" (
+  "simple_feature_id" INTEGER PRIMARY KEY NOT NULL,
+  "seq_region_id" INT(10) NOT NULL,
+  "seq_region_start" INT(10) NOT NULL,
+  "seq_region_end" INT(10) NOT NULL,
+  "seq_region_strand" TINYINT(1) NOT NULL,
+  "display_label" VARCHAR(255) NOT NULL,
+  "analysis_id" SMALLINT(5) NOT NULL,
+  "score" DOUBLE
 );
+
+
+
 
 --
--- Table: operon_transcript
+-- Table: "transcript_intron_supporting_evidence"
 --
-CREATE TABLE operon_transcript (
-  operon_transcript_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-  seq_region_id integer NOT NULL,
-  seq_region_start integer NOT NULL,
-  seq_region_end integer NOT NULL,
-  seq_region_strand tinyint NOT NULL,
-  operon_id integer NOT NULL,
-  display_label varchar(255),
-  analysis_id smallint NOT NULL,
-  stable_id varchar(128),
-  version smallint,
-  created_date datetime,
-  modified_date datetime
+CREATE TABLE "transcript_intron_supporting_evidence" (
+  "transcript_id" INT(10) NOT NULL,
+  "intron_supporting_evidence_id" INT(10) NOT NULL,
+  "previous_exon_id" INT(10) NOT NULL,
+  "next_exon_id" INT(10) NOT NULL,
+  PRIMARY KEY ("intron_supporting_evidence_id", "transcript_id")
 );
 
+
 --
--- Table: operon_transcript_gene
+-- Table: "gene_archive"
 --
-CREATE TABLE operon_transcript_gene (
-  operon_transcript_id integer,
-  gene_id integer
+CREATE TABLE "gene_archive" (
+  "gene_stable_id" VARCHAR(128) NOT NULL,
+  "gene_version" SMALLINT(6) NOT NULL DEFAULT 1,
+  "transcript_stable_id" VARCHAR(128) NOT NULL,
+  "transcript_version" SMALLINT(6) NOT NULL DEFAULT 1,
+  "translation_stable_id" VARCHAR(128),
+  "translation_version" SMALLINT(6) NOT NULL DEFAULT 1,
+  "peptide_archive_id" INT(10),
+  "mapping_session_id" INT(10) NOT NULL
 );
+
+
+
+
 
 --
--- Table: peptide_archive
+-- Table: "mapping_session"
 --
-CREATE TABLE peptide_archive (
-  peptide_archive_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-  md5_checksum varchar(32),
-  peptide_seq mediumtext NOT NULL
+CREATE TABLE "mapping_session" (
+  "mapping_session_id" INTEGER PRIMARY KEY NOT NULL,
+  "old_db_name" VARCHAR(80) NOT NULL DEFAULT '',
+  "new_db_name" VARCHAR(80) NOT NULL DEFAULT '',
+  "old_release" VARCHAR(5) NOT NULL DEFAULT '',
+  "new_release" VARCHAR(5) NOT NULL DEFAULT '',
+  "old_assembly" VARCHAR(80) NOT NULL DEFAULT '',
+  "new_assembly" VARCHAR(80) NOT NULL DEFAULT '',
+  "created" DATETIME NOT NULL
 );
 
 --
--- Table: prediction_exon
+-- Table: "peptide_archive"
 --
-CREATE TABLE prediction_exon (
-  prediction_exon_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-  prediction_transcript_id integer NOT NULL DEFAULT 0,
-  exon_rank smallint NOT NULL DEFAULT 0,
-  seq_region_id integer NOT NULL DEFAULT 0,
-  seq_region_start integer NOT NULL DEFAULT 0,
-  seq_region_end integer NOT NULL DEFAULT 0,
-  seq_region_strand tinyint NOT NULL DEFAULT 0,
-  start_phase tinyint NOT NULL DEFAULT 0,
-  score double precision,
-  p_value double precision
+CREATE TABLE "peptide_archive" (
+  "peptide_archive_id" INTEGER PRIMARY KEY NOT NULL,
+  "md5_checksum" VARCHAR(32),
+  "peptide_seq" MEDIUMTEXT(16777215) NOT NULL
 );
 
+
 --
--- Table: prediction_transcript
+-- Table: "mapping_set"
 --
-CREATE TABLE prediction_transcript (
-  prediction_transcript_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-  seq_region_id integer NOT NULL DEFAULT 0,
-  seq_region_start integer NOT NULL DEFAULT 0,
-  seq_region_end integer NOT NULL DEFAULT 0,
-  seq_region_strand tinyint NOT NULL DEFAULT 0,
-  analysis_id integer,
-  display_label varchar(255)
+CREATE TABLE "mapping_set" (
+  "mapping_set_id" INTEGER PRIMARY KEY NOT NULL,
+  "internal_schema_build" VARCHAR(20) NOT NULL,
+  "external_schema_build" VARCHAR(20) NOT NULL
 );
+
 
 --
--- Table: protein_align_feature
+-- Table: "stable_id_event"
 --
-CREATE TABLE protein_align_feature (
-  protein_align_feature_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-  seq_region_id integer NOT NULL DEFAULT 0,
-  seq_region_start integer NOT NULL DEFAULT 0,
-  seq_region_end integer NOT NULL DEFAULT 0,
-  seq_region_strand tinyint NOT NULL DEFAULT 1,
-  hit_start integer NOT NULL DEFAULT 0,
-  hit_end integer NOT NULL DEFAULT 0,
-  hit_name varchar(40) NOT NULL DEFAULT '',
-  analysis_id integer NOT NULL DEFAULT 0,
-  score double precision,
-  evalue double precision,
-  perc_ident float,
-  cigar_line text,
-  external_db_id smallint,
-  hcoverage double precision
+CREATE TABLE "stable_id_event" (
+  "old_stable_id" VARCHAR(128),
+  "old_version" SMALLINT(6),
+  "new_stable_id" VARCHAR(128),
+  "new_version" SMALLINT(6),
+  "mapping_session_id" INT(10) NOT NULL DEFAULT 0,
+  "type" ENUM(11) NOT NULL,
+  "score" FLOAT NOT NULL DEFAULT 0
 );
+
+
 
+
 --
--- Table: protein_feature
+-- Table: "seq_region_mapping"
 --
-CREATE TABLE protein_feature (
-  protein_feature_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-  translation_id integer NOT NULL DEFAULT 0,
-  seq_start integer NOT NULL DEFAULT 0,
-  seq_end integer NOT NULL DEFAULT 0,
-  hit_start integer NOT NULL DEFAULT 0,
-  hit_end integer NOT NULL DEFAULT 0,
-  hit_name varchar(40) NOT NULL DEFAULT '',
-  analysis_id integer NOT NULL DEFAULT 0,
-  score double precision NOT NULL DEFAULT 0,
-  evalue double precision,
-  perc_ident float,
-  external_data text,
-  hit_description text
+CREATE TABLE "seq_region_mapping" (
+  "external_seq_region_id" INT(10) NOT NULL,
+  "internal_seq_region_id" INT(10) NOT NULL,
+  "mapping_set_id" INT(10) NOT NULL
 );
+
 
-CREATE UNIQUE INDEX aln_idx ON protein_feature (translation_id, hit_name, seq_start, seq_end, hit_start, hit_end, analysis_id);
 
 --
--- Table: repeat_consensus
+-- Table: "associated_group"
 --
-CREATE TABLE repeat_consensus (
-  repeat_consensus_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-  repeat_name varchar(255) NOT NULL DEFAULT '',
-  repeat_class varchar(100) NOT NULL DEFAULT '',
-  repeat_type varchar(40) NOT NULL DEFAULT '',
-  repeat_consensus text
+CREATE TABLE "associated_group" (
+  "associated_group_id" INTEGER PRIMARY KEY NOT NULL,
+  "description" VARCHAR(128) DEFAULT NULL
 );
 
 --
--- Table: repeat_feature
+-- Table: "associated_xref"
 --
-CREATE TABLE repeat_feature (
-  repeat_feature_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-  seq_region_id integer NOT NULL DEFAULT 0,
-  seq_region_start integer NOT NULL DEFAULT 0,
-  seq_region_end integer NOT NULL DEFAULT 0,
-  seq_region_strand tinyint NOT NULL DEFAULT 1,
-  repeat_start integer NOT NULL DEFAULT 0,
-  repeat_end integer NOT NULL DEFAULT 0,
-  repeat_consensus_id integer NOT NULL DEFAULT 0,
-  analysis_id integer NOT NULL DEFAULT 0,
-  score double precision
+CREATE TABLE "associated_xref" (
+  "associated_xref_id" INTEGER PRIMARY KEY NOT NULL,
+  "object_xref_id" INT(10) NOT NULL DEFAULT 0,
+  "xref_id" INT(10) NOT NULL DEFAULT 0,
+  "source_xref_id" INT(10) DEFAULT NULL,
+  "condition_type" VARCHAR(128) DEFAULT NULL,
+  "associated_group_id" INT(10) DEFAULT NULL,
+  "rank" INT(10) DEFAULT 0
 );
+
+
+
 
+
+
 --
--- Table: seq_region
+-- Table: "dependent_xref"
 --
-CREATE TABLE seq_region (
-  seq_region_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-  name varchar(255) NOT NULL,
-  coord_system_id integer NOT NULL DEFAULT 0,
-  length integer NOT NULL DEFAULT 0
+CREATE TABLE "dependent_xref" (
+  "object_xref_id" INTEGER PRIMARY KEY NOT NULL,
+  "master_xref_id" INT(10) NOT NULL,
+  "dependent_xref_id" INT(10) NOT NULL
 );
 
-CREATE UNIQUE INDEX name_cs_idx ON seq_region (name, coord_system_id);
 
+
 --
--- Table: seq_region_attrib
+-- Table: "external_db"
 --
-CREATE TABLE seq_region_attrib (
-  seq_region_id integer NOT NULL DEFAULT 0,
-  attrib_type_id smallint NOT NULL DEFAULT 0,
-  value text NOT NULL
+CREATE TABLE "external_db" (
+  "external_db_id" INTEGER PRIMARY KEY NOT NULL,
+  "db_name" VARCHAR(100) NOT NULL,
+  "db_release" VARCHAR(255),
+  "status" ENUM(9) NOT NULL,
+  "priority" int(11) NOT NULL,
+  "db_display_name" VARCHAR(255),
+  "type" ENUM(18) NOT NULL,
+  "secondary_db_name" VARCHAR(255) DEFAULT NULL,
+  "secondary_db_table" VARCHAR(255) DEFAULT NULL,
+  "description" TEXT(65535)
 );
 
-CREATE UNIQUE INDEX region_attribx ON seq_region_attrib (seq_region_id, attrib_type_id, value);
 
 --
--- Table: seq_region_mapping
+-- Table: "biotype"
 --
-CREATE TABLE seq_region_mapping (
-  external_seq_region_id integer NOT NULL,
-  internal_seq_region_id integer NOT NULL,
-  mapping_set_id integer NOT NULL
+CREATE TABLE "biotype" (
+  "biotype_id" INTEGER PRIMARY KEY NOT NULL,
+  "name" VARCHAR(64) NOT NULL,
+  "object_type" ENUM(10) NOT NULL DEFAULT 'gene',
+  "db_type" varchar(19) NOT NULL DEFAULT 'core',
+  "attrib_type_id" int(11) DEFAULT NULL,
+  "description" TEXT(65535),
+  "biotype_group" ENUM(10) DEFAULT NULL,
+  "so_acc" VARCHAR(64),
+  "so_term" VARCHAR(1023)
 );
 
+
 --
--- Table: seq_region_synonym
+-- Table: "external_synonym"
 --
-CREATE TABLE seq_region_synonym (
-  seq_region_synonym_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-  seq_region_id integer NOT NULL,
-  synonym varchar(250) NOT NULL,
-  external_db_id smallint
+CREATE TABLE "external_synonym" (
+  "xref_id" INT(10) NOT NULL,
+  "synonym" VARCHAR(100) NOT NULL,
+  PRIMARY KEY ("xref_id", "synonym")
 );
 
-CREATE UNIQUE INDEX syn_idx ON seq_region_synonym (synonym, seq_region_id);
 
 --
--- Table: simple_feature
+-- Table: "identity_xref"
 --
-CREATE TABLE simple_feature (
-  simple_feature_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-  seq_region_id integer NOT NULL DEFAULT 0,
-  seq_region_start integer NOT NULL DEFAULT 0,
-  seq_region_end integer NOT NULL DEFAULT 0,
-  seq_region_strand tinyint NOT NULL DEFAULT 0,
-  display_label varchar(40) NOT NULL DEFAULT '',
-  analysis_id integer NOT NULL DEFAULT 0,
-  score double precision
+CREATE TABLE "identity_xref" (
+  "object_xref_id" INTEGER PRIMARY KEY NOT NULL,
+  "xref_identity" INT(5),
+  "ensembl_identity" INT(5),
+  "xref_start" int(11),
+  "xref_end" int(11),
+  "ensembl_start" int(11),
+  "ensembl_end" int(11),
+  "cigar_line" TEXT(65535),
+  "score" DOUBLE,
+  "evalue" DOUBLE
 );
 
 --
--- Table: stable_id_event
+-- Table: "interpro"
 --
-CREATE TABLE stable_id_event (
-  old_stable_id varchar(128),
-  old_version smallint,
-  new_stable_id varchar(128),
-  new_version smallint,
-  mapping_session_id integer NOT NULL DEFAULT 0,
-  type enum NOT NULL DEFAULT 'gene',
-  score float NOT NULL DEFAULT 0
+CREATE TABLE "interpro" (
+  "interpro_ac" VARCHAR(40) NOT NULL,
+  "id" VARCHAR(40) NOT NULL
 );
+
 
-CREATE UNIQUE INDEX uni_idx ON stable_id_event (mapping_session_id, old_stable_id, old_version, new_stable_id, new_version, type);
 
 --
--- Table: supporting_feature
+-- Table: "object_xref"
 --
-CREATE TABLE supporting_feature (
-  exon_id integer NOT NULL DEFAULT 0,
-  feature_type enum,
-  feature_id integer NOT NULL DEFAULT 0
+CREATE TABLE "object_xref" (
+  "object_xref_id" INTEGER PRIMARY KEY NOT NULL,
+  "ensembl_id" INT(10) NOT NULL,
+  "ensembl_object_type" ENUM(16) NOT NULL,
+  "xref_id" INT(10) NOT NULL,
+  "linkage_annotation" VARCHAR(255) DEFAULT NULL,
+  "analysis_id" SMALLINT(5)
 );
 
-CREATE UNIQUE INDEX all_idx02 ON supporting_feature (exon_id, feature_type, feature_id);
 
+
+
 --
--- Table: transcript
+-- Table: "ontology_xref"
 --
-CREATE TABLE transcript (
-  transcript_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-  gene_id integer,
-  analysis_id smallint NOT NULL,
-  seq_region_id integer NOT NULL,
-  seq_region_start integer NOT NULL,
-  seq_region_end integer NOT NULL,
-  seq_region_strand tinyint NOT NULL,
-  display_xref_id integer,
-  source varchar(40) NOT NULL DEFAULT 'ensembl',
-  biotype varchar(40) NOT NULL,
-  status enum,
-  description text,
-  is_current tinyint NOT NULL DEFAULT 1,
-  canonical_translation_id integer,
-  stable_id varchar(128),
-  version smallint,
-  created_date datetime,
-  modified_date datetime
+CREATE TABLE "ontology_xref" (
+  "object_xref_id" INT(10) NOT NULL DEFAULT 0,
+  "source_xref_id" INT(10) DEFAULT NULL,
+  "linkage_type" VARCHAR(3) DEFAULT NULL
 );
 
-CREATE UNIQUE INDEX canonical_translation_idx ON transcript (canonical_translation_id);
 
+
+
 --
--- Table: transcript_attrib
+-- Table: "unmapped_object"
 --
-CREATE TABLE transcript_attrib (
-  transcript_id integer NOT NULL DEFAULT 0,
-  attrib_type_id smallint NOT NULL DEFAULT 0,
-  value text NOT NULL
+CREATE TABLE "unmapped_object" (
+  "unmapped_object_id" INTEGER PRIMARY KEY NOT NULL,
+  "type" ENUM(6) NOT NULL,
+  "analysis_id" SMALLINT(5) NOT NULL,
+  "external_db_id" int(10),
+  "identifier" VARCHAR(255) NOT NULL,
+  "unmapped_reason_id" INT(10) NOT NULL,
+  "query_score" DOUBLE,
+  "target_score" DOUBLE,
+  "ensembl_id" INT(10) DEFAULT 0,
+  "ensembl_object_type" ENUM(11) DEFAULT 'RawContig',
+  "parent" VARCHAR(255) DEFAULT NULL
 );
+
 
-CREATE UNIQUE INDEX transcript_attribx ON transcript_attrib (transcript_id, attrib_type_id, value);
 
+
+
+--
+-- Table: "unmapped_reason"
+--
+CREATE TABLE "unmapped_reason" (
+  "unmapped_reason_id" INTEGER PRIMARY KEY NOT NULL,
+  "summary_description" VARCHAR(255),
+  "full_description" VARCHAR(255)
+);
+
 --
--- Table: transcript_intron_supporting_evidence
+-- Table: "xref"
 --
-CREATE TABLE transcript_intron_supporting_evidence (
-  transcript_id integer NOT NULL,
-  intron_supporting_evidence_id integer NOT NULL,
-  previous_exon_id integer NOT NULL,
-  next_exon_id integer NOT NULL,
-  PRIMARY KEY (intron_supporting_evidence_id, transcript_id)
+CREATE TABLE "xref" (
+  "xref_id" INTEGER PRIMARY KEY NOT NULL,
+  "external_db_id" int(10) NOT NULL,
+  "dbprimary_acc" VARCHAR(512) NOT NULL,
+  "display_label" VARCHAR(512) NOT NULL,
+  "version" VARCHAR(10) DEFAULT NULL,
+  "description" TEXT(65535),
+  "info_type" ENUM(18) NOT NULL DEFAULT 'NONE',
+  "info_text" VARCHAR(255) NOT NULL DEFAULT ''
 );
+
+
+
 
 --
--- Table: transcript_supporting_feature
+-- Table: "operon"
 --
-CREATE TABLE transcript_supporting_feature (
-  transcript_id integer NOT NULL DEFAULT 0,
-  feature_type enum,
-  feature_id integer NOT NULL DEFAULT 0
+CREATE TABLE "operon" (
+  "operon_id" INTEGER PRIMARY KEY NOT NULL,
+  "seq_region_id" INT(10) NOT NULL,
+  "seq_region_start" INT(10) NOT NULL,
+  "seq_region_end" INT(10) NOT NULL,
+  "seq_region_strand" TINYINT(2) NOT NULL,
+  "display_label" VARCHAR(255) DEFAULT NULL,
+  "analysis_id" SMALLINT(5) NOT NULL,
+  "stable_id" VARCHAR(128) DEFAULT NULL,
+  "version" SMALLINT(5) DEFAULT NULL,
+  "created_date" DATETIME DEFAULT NULL,
+  "modified_date" DATETIME DEFAULT NULL
 );
 
-CREATE UNIQUE INDEX all_idx03 ON transcript_supporting_feature (transcript_id, feature_type, feature_id);
 
+
+
 --
--- Table: translation
+-- Table: "operon_transcript"
 --
-CREATE TABLE translation (
-  translation_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-  transcript_id integer NOT NULL,
-  seq_start integer NOT NULL,
-  start_exon_id integer NOT NULL,
-  seq_end integer NOT NULL,
-  end_exon_id integer NOT NULL,
-  stable_id varchar(128),
-  version smallint,
-  created_date datetime,
-  modified_date datetime
+CREATE TABLE "operon_transcript" (
+  "operon_transcript_id" INTEGER PRIMARY KEY NOT NULL,
+  "seq_region_id" INT(10) NOT NULL,
+  "seq_region_start" INT(10) NOT NULL,
+  "seq_region_end" INT(10) NOT NULL,
+  "seq_region_strand" TINYINT(2) NOT NULL,
+  "operon_id" INT(10) NOT NULL,
+  "display_label" VARCHAR(255) DEFAULT NULL,
+  "analysis_id" SMALLINT(5) NOT NULL,
+  "stable_id" VARCHAR(128) DEFAULT NULL,
+  "version" SMALLINT(5) DEFAULT NULL,
+  "created_date" DATETIME DEFAULT NULL,
+  "modified_date" DATETIME DEFAULT NULL
 );
+
+
+
 
 --
--- Table: translation_attrib
+-- Table: "operon_transcript_gene"
 --
-CREATE TABLE translation_attrib (
-  translation_id integer NOT NULL DEFAULT 0,
-  attrib_type_id smallint NOT NULL DEFAULT 0,
-  value text NOT NULL
+CREATE TABLE "operon_transcript_gene" (
+  "operon_transcript_id" INT(10),
+  "gene_id" INT(10)
 );
 
-CREATE UNIQUE INDEX translation_attribx ON translation_attrib (translation_id, attrib_type_id, value);
 
 --
--- Table: unmapped_object
+-- Table: "rnaproduct"
 --
-CREATE TABLE unmapped_object (
-  unmapped_object_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-  type enum NOT NULL,
-  analysis_id integer NOT NULL,
-  external_db_id integer,
-  identifier varchar(255) NOT NULL,
-  unmapped_reason_id integer NOT NULL,
-  query_score double precision,
-  target_score double precision,
-  ensembl_id integer DEFAULT 0,
-  ensembl_object_type enum DEFAULT 'RawContig',
-  parent varchar(255)
+CREATE TABLE "rnaproduct" (
+  "rnaproduct_id" INTEGER PRIMARY KEY NOT NULL,
+  "rnaproduct_type_id" SMALLINT(5) NOT NULL,
+  "transcript_id" INT(10) NOT NULL,
+  "seq_start" INT(10) NOT NULL,
+  -- relative to transcript start
+  "start_exon_id" INT(10),
+  "seq_end" INT(10) NOT NULL,
+  -- relative to transcript start
+  "end_exon_id" INT(10),
+  "stable_id" VARCHAR(128) DEFAULT NULL,
+  "version" SMALLINT(5) DEFAULT NULL,
+  "created_date" DATETIME DEFAULT NULL,
+  "modified_date" DATETIME DEFAULT NULL
 );
 
-CREATE UNIQUE INDEX unique_unmapped_obj_idx ON unmapped_object (ensembl_id, ensembl_object_type, identifier, unmapped_reason_id, parent, external_db_id);
 
+
 --
--- Table: unmapped_reason
+-- Table: "rnaproduct_attrib"
 --
-CREATE TABLE unmapped_reason (
-  unmapped_reason_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-  summary_description varchar(255),
-  full_description varchar(255)
+CREATE TABLE "rnaproduct_attrib" (
+  "rnaproduct_id" INT(10) NOT NULL DEFAULT 0,
+  "attrib_type_id" SMALLINT(5) NOT NULL DEFAULT 0,
+  "value" TEXT(65535) NOT NULL
 );
+
+
+
+
 
 --
--- Table: xref
+-- Table: "rnaproduct_type"
 --
-CREATE TABLE xref (
-  xref_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-  external_db_id integer NOT NULL,
-  dbprimary_acc varchar(512) NOT NULL,
-  display_label varchar(512) NOT NULL,
-  version varchar(10),
-  description text,
-  info_type enum NOT NULL DEFAULT 'NONE',
-  info_text varchar(255) NOT NULL DEFAULT ''
+CREATE TABLE "rnaproduct_type" (
+  "rnaproduct_type_id" INTEGER PRIMARY KEY NOT NULL,
+  "code" VARCHAR(20) NOT NULL DEFAULT '',
+  "name" VARCHAR(255) NOT NULL DEFAULT '',
+  "description" TEXT(65535)
 );
 
-CREATE UNIQUE INDEX id_index ON xref (dbprimary_acc, external_db_id, info_type, info_text, version);
 
 COMMIT;

--- a/modules/t/test-genome-DBs/homo_sapiens/empty/SQLite/table.sql
+++ b/modules/t/test-genome-DBs/homo_sapiens/empty/SQLite/table.sql
@@ -1,985 +1,1139 @@
--- 
+--
 -- Created by SQL::Translator::Producer::SQLite
--- Created on Tue Mar 28 11:00:39 2017
--- 
+-- Created on Fri Jan 26 15:05:34 2024
+--
 
 BEGIN TRANSACTION;
 
 --
--- Table: alt_allele
+-- Table: "assembly"
 --
-CREATE TABLE alt_allele (
-  alt_allele_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-  alt_allele_group_id integer NOT NULL,
-  gene_id integer NOT NULL
+CREATE TABLE "assembly" (
+  "asm_seq_region_id" INT(10) NOT NULL,
+  "cmp_seq_region_id" INT(10) NOT NULL,
+  "asm_start" INT(10) NOT NULL,
+  "asm_end" INT(10) NOT NULL,
+  "cmp_start" INT(10) NOT NULL,
+  "cmp_end" INT(10) NOT NULL,
+  "ori" TINYINT(4) NOT NULL
 );
 
-CREATE UNIQUE INDEX gene_idx ON alt_allele (gene_id);
 
+
+
+--
+-- Table: "assembly_exception"
+--
+CREATE TABLE "assembly_exception" (
+  "assembly_exception_id" INTEGER PRIMARY KEY NOT NULL,
+  "seq_region_id" INT(10) NOT NULL,
+  "seq_region_start" INT(10) NOT NULL,
+  "seq_region_end" INT(10) NOT NULL,
+  "exc_type" ENUM(11) NOT NULL,
+  "exc_seq_region_id" INT(10) NOT NULL,
+  "exc_seq_region_start" INT(10) NOT NULL,
+  "exc_seq_region_end" INT(10) NOT NULL,
+  "ori" int(11) NOT NULL
+);
+
+
+
+--
+-- Table: "coord_system"
 --
--- Table: alt_allele_attrib
+CREATE TABLE "coord_system" (
+  "coord_system_id" INTEGER PRIMARY KEY NOT NULL,
+  "species_id" INT(10) NOT NULL DEFAULT 1,
+  "name" VARCHAR(40) NOT NULL,
+  "version" VARCHAR(255) DEFAULT NULL,
+  "rank" int(11) NOT NULL,
+  "attrib" varchar
+);
+
+
+
+
+--
+-- Table: "data_file"
 --
-CREATE TABLE alt_allele_attrib (
-  alt_allele_id integer,
-  attrib enum
+CREATE TABLE "data_file" (
+  "data_file_id" INTEGER PRIMARY KEY NOT NULL,
+  "coord_system_id" INT(10) NOT NULL,
+  "analysis_id" SMALLINT(5) NOT NULL,
+  "name" VARCHAR(100) NOT NULL,
+  "version_lock" TINYINT(1) NOT NULL DEFAULT 0,
+  "absolute" TINYINT(1) NOT NULL DEFAULT 0,
+  "url" TEXT(65535),
+  "file_type" ENUM(6)
 );
+
+
+
 
 --
--- Table: alt_allele_group
+-- Table: "dna"
 --
-CREATE TABLE alt_allele_group (
-  alt_allele_group_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL
+CREATE TABLE "dna" (
+  "seq_region_id" INTEGER PRIMARY KEY NOT NULL,
+  "sequence" LONGTEXT(4294967295) NOT NULL
 );
 
 --
--- Table: analysis
+-- Table: "genome_statistics"
 --
-CREATE TABLE analysis (
-  analysis_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-  created datetime,
-  logic_name varchar(40) NOT NULL DEFAULT '',
-  db varchar(120),
-  db_version varchar(40),
-  db_file varchar(120),
-  program varchar(80),
-  program_version varchar(40),
-  program_file varchar(80),
-  parameters text,
-  module varchar(80),
-  module_version varchar(40),
-  gff_source varchar(40),
-  gff_feature varchar(40)
+CREATE TABLE "genome_statistics" (
+  "genome_statistics_id" INTEGER PRIMARY KEY NOT NULL,
+  "statistic" VARCHAR(128) NOT NULL,
+  "value" BIGINT(11) NOT NULL DEFAULT 0,
+  "species_id" int(10) DEFAULT 1,
+  "attrib_type_id" INT(10) DEFAULT NULL,
+  "timestamp" DATETIME DEFAULT NULL
 );
 
-CREATE UNIQUE INDEX logic_name_idx ON analysis (logic_name);
 
 --
--- Table: analysis_description
+-- Table: "karyotype"
 --
-CREATE TABLE analysis_description (
-  analysis_id integer NOT NULL DEFAULT 0,
-  description text,
-  display_label varchar(255),
-  displayable tinyint NOT NULL DEFAULT 1,
-  web_data text
+CREATE TABLE "karyotype" (
+  "karyotype_id" INTEGER PRIMARY KEY NOT NULL,
+  "seq_region_id" INT(10) NOT NULL,
+  "seq_region_start" INT(10) NOT NULL,
+  "seq_region_end" INT(10) NOT NULL,
+  "band" VARCHAR(40) DEFAULT NULL,
+  "stain" VARCHAR(40) DEFAULT NULL
 );
 
-CREATE UNIQUE INDEX analysis_idx ON analysis_description (analysis_id);
 
 --
--- Table: assembly
+-- Table: "meta"
 --
-CREATE TABLE assembly (
-  asm_seq_region_id integer NOT NULL DEFAULT 0,
-  cmp_seq_region_id integer NOT NULL DEFAULT 0,
-  asm_start integer NOT NULL DEFAULT 0,
-  asm_end integer NOT NULL DEFAULT 0,
-  cmp_start integer NOT NULL DEFAULT 0,
-  cmp_end integer NOT NULL DEFAULT 0,
-  ori tinyint NOT NULL DEFAULT 0
+CREATE TABLE "meta" (
+  "meta_id" INTEGER PRIMARY KEY NOT NULL,
+  "species_id" int(10) DEFAULT 1,
+  "meta_key" VARCHAR(40) NOT NULL,
+  "meta_value" VARCHAR(255) DEFAULT NULL
 );
 
-CREATE UNIQUE INDEX all_idx ON assembly (asm_seq_region_id, cmp_seq_region_id, asm_start, asm_end, cmp_start, cmp_end, ori);
 
+
 --
--- Table: assembly_exception
+-- Table: "meta_coord"
 --
-CREATE TABLE assembly_exception (
-  assembly_exception_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-  seq_region_id integer NOT NULL DEFAULT 0,
-  seq_region_start integer NOT NULL DEFAULT 0,
-  seq_region_end integer NOT NULL DEFAULT 0,
-  exc_type enum NOT NULL DEFAULT 'HAP',
-  exc_seq_region_id integer NOT NULL DEFAULT 0,
-  exc_seq_region_start integer NOT NULL DEFAULT 0,
-  exc_seq_region_end integer NOT NULL DEFAULT 0,
-  ori integer NOT NULL DEFAULT 0
+CREATE TABLE "meta_coord" (
+  "table_name" VARCHAR(40) NOT NULL,
+  "coord_system_id" INT(10) NOT NULL,
+  "max_length" int(11)
 );
+
 
 --
--- Table: associated_group
+-- Table: "seq_region"
 --
-CREATE TABLE associated_group (
-  associated_group_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-  description varchar(128)
+CREATE TABLE "seq_region" (
+  "seq_region_id" INTEGER PRIMARY KEY NOT NULL,
+  "name" VARCHAR(255) NOT NULL,
+  "coord_system_id" INT(10) NOT NULL,
+  "length" INT(10) NOT NULL
 );
+
+
 
 --
--- Table: associated_xref
+-- Table: "seq_region_synonym"
 --
-CREATE TABLE associated_xref (
-  associated_xref_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-  object_xref_id integer NOT NULL DEFAULT 0,
-  xref_id integer NOT NULL DEFAULT 0,
-  source_xref_id integer,
-  condition_type varchar(128),
-  associated_group_id integer,
-  rank integer DEFAULT 0
+CREATE TABLE "seq_region_synonym" (
+  "seq_region_synonym_id" INTEGER PRIMARY KEY NOT NULL,
+  "seq_region_id" INT(10) NOT NULL,
+  "synonym" VARCHAR(250) NOT NULL,
+  "external_db_id" int(10)
 );
 
-CREATE UNIQUE INDEX object_associated_source_type_idx ON associated_xref (object_xref_id, xref_id, source_xref_id, condition_type, associated_group_id);
 
+
 --
--- Table: attrib_type
+-- Table: "seq_region_attrib"
 --
-CREATE TABLE attrib_type (
-  attrib_type_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-  code varchar(20) NOT NULL DEFAULT '',
-  name varchar(255) NOT NULL DEFAULT '',
-  description text
+CREATE TABLE "seq_region_attrib" (
+  "seq_region_id" INT(10) NOT NULL DEFAULT 0,
+  "attrib_type_id" SMALLINT(5) NOT NULL DEFAULT 0,
+  "value" TEXT(65535) NOT NULL
 );
+
 
-CREATE UNIQUE INDEX code_idx ON attrib_type (code);
 
+
+
 --
--- Table: coord_system
+-- Table: "alt_allele"
 --
-CREATE TABLE coord_system (
-  coord_system_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-  species_id integer NOT NULL DEFAULT 1,
-  name varchar(40) NOT NULL,
-  version varchar(255),
-  rank integer NOT NULL,
-  attrib varchar
+CREATE TABLE "alt_allele" (
+  "alt_allele_id" INTEGER PRIMARY KEY NOT NULL,
+  "alt_allele_group_id" int(10) NOT NULL,
+  "gene_id" int(10) NOT NULL
 );
 
-CREATE UNIQUE INDEX name_idx ON coord_system (name, version, species_id);
 
-CREATE UNIQUE INDEX rank_idx ON coord_system (rank, species_id);
 
 --
--- Table: data_file
+-- Table: "alt_allele_attrib"
 --
-CREATE TABLE data_file (
-  data_file_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-  coord_system_id integer NOT NULL,
-  analysis_id smallint NOT NULL,
-  name varchar(100) NOT NULL,
-  version_lock tinyint NOT NULL DEFAULT 0,
-  absolute tinyint NOT NULL DEFAULT 0,
-  url text,
-  file_type enum
+CREATE TABLE "alt_allele_attrib" (
+  "alt_allele_id" int(10),
+  "attrib" ENUM(35)
 );
 
-CREATE UNIQUE INDEX df_unq_idx ON data_file (coord_system_id, analysis_id, name, file_type);
 
 --
--- Table: density_feature
+-- Table: "alt_allele_group"
 --
-CREATE TABLE density_feature (
-  density_feature_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-  density_type_id integer NOT NULL DEFAULT 0,
-  seq_region_id integer NOT NULL DEFAULT 0,
-  seq_region_start integer NOT NULL DEFAULT 0,
-  seq_region_end integer NOT NULL DEFAULT 0,
-  density_value float NOT NULL DEFAULT 0
+CREATE TABLE "alt_allele_group" (
+  "alt_allele_group_id" INTEGER PRIMARY KEY NOT NULL
 );
 
 --
--- Table: density_type
+-- Table: "analysis"
 --
-CREATE TABLE density_type (
-  density_type_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-  analysis_id integer NOT NULL DEFAULT 0,
-  block_size integer NOT NULL DEFAULT 0,
-  region_features integer NOT NULL DEFAULT 0,
-  value_type enum NOT NULL DEFAULT 'sum'
+CREATE TABLE "analysis" (
+  "analysis_id" INTEGER PRIMARY KEY NOT NULL,
+  "created" datetime DEFAULT NULL,
+  "logic_name" VARCHAR(128) NOT NULL,
+  "db" VARCHAR(120),
+  "db_version" VARCHAR(40),
+  "db_file" VARCHAR(120),
+  "program" VARCHAR(80),
+  "program_version" VARCHAR(40),
+  "program_file" VARCHAR(80),
+  "parameters" TEXT(65535),
+  "module" VARCHAR(80),
+  "module_version" VARCHAR(40),
+  "gff_source" VARCHAR(40),
+  "gff_feature" VARCHAR(40)
 );
 
-CREATE UNIQUE INDEX analysis_id ON density_type (analysis_id, block_size, region_features);
 
 --
--- Table: dependent_xref
+-- Table: "analysis_description"
 --
-CREATE TABLE dependent_xref (
-  object_xref_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-  master_xref_id integer NOT NULL,
-  dependent_xref_id integer NOT NULL
+CREATE TABLE "analysis_description" (
+  "analysis_id" SMALLINT(5) NOT NULL,
+  "description" TEXT(65535),
+  "display_label" VARCHAR(255) NOT NULL,
+  "displayable" TINYINT(1) NOT NULL DEFAULT 1,
+  "web_data" TEXT(65535)
 );
+
 
 --
--- Table: ditag
+-- Table: "attrib_type"
 --
-CREATE TABLE ditag (
-  ditag_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-  name varchar(30),
-  type varchar(30),
-  tag_count smallint DEFAULT 1,
-  sequence text
+CREATE TABLE "attrib_type" (
+  "attrib_type_id" INTEGER PRIMARY KEY NOT NULL,
+  "code" VARCHAR(20) NOT NULL DEFAULT '',
+  "name" VARCHAR(255) NOT NULL DEFAULT '',
+  "description" TEXT(65535)
 );
 
+
 --
--- Table: ditag_feature
+-- Table: "dna_align_feature"
 --
-CREATE TABLE ditag_feature (
-  ditag_feature_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-  ditag_id integer NOT NULL DEFAULT 0,
-  ditag_pair_id integer NOT NULL DEFAULT 0,
-  seq_region_id integer NOT NULL DEFAULT 0,
-  seq_region_start integer NOT NULL DEFAULT 0,
-  seq_region_end integer NOT NULL DEFAULT 0,
-  seq_region_strand tinyint NOT NULL DEFAULT 0,
-  analysis_id integer NOT NULL DEFAULT 0,
-  hit_start integer NOT NULL DEFAULT 0,
-  hit_end integer NOT NULL DEFAULT 0,
-  hit_strand tinyint NOT NULL DEFAULT 0,
-  cigar_line text,
-  ditag_side char(1) DEFAULT ''
+CREATE TABLE "dna_align_feature" (
+  "dna_align_feature_id" INTEGER PRIMARY KEY NOT NULL,
+  "seq_region_id" INT(10) NOT NULL,
+  "seq_region_start" INT(10) NOT NULL,
+  "seq_region_end" INT(10) NOT NULL,
+  "seq_region_strand" TINYINT(1) NOT NULL,
+  "hit_start" int(11) NOT NULL,
+  "hit_end" int(11) NOT NULL,
+  "hit_strand" TINYINT(1) NOT NULL,
+  "hit_name" VARCHAR(40) NOT NULL,
+  "analysis_id" SMALLINT(5) NOT NULL,
+  "score" DOUBLE,
+  "evalue" DOUBLE,
+  "perc_ident" FLOAT,
+  "cigar_line" TEXT(65535),
+  "external_db_id" int(10),
+  "hcoverage" DOUBLE,
+  "align_type" ENUM(7) DEFAULT 'ensembl'
 );
+
+
+
+
 
+
 --
--- Table: dna
+-- Table: "dna_align_feature_attrib"
 --
-CREATE TABLE dna (
-  seq_region_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL DEFAULT 0,
-  sequence mediumtext NOT NULL
+CREATE TABLE "dna_align_feature_attrib" (
+  "dna_align_feature_id" INT(10) NOT NULL,
+  "attrib_type_id" SMALLINT(5) NOT NULL,
+  "value" TEXT(65535) NOT NULL
 );
+
+
+
+
 
 --
--- Table: dna_align_feature
+-- Table: "exon"
 --
-CREATE TABLE dna_align_feature (
-  dna_align_feature_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-  seq_region_id integer NOT NULL DEFAULT 0,
-  seq_region_start integer NOT NULL DEFAULT 0,
-  seq_region_end integer NOT NULL DEFAULT 0,
-  seq_region_strand tinyint NOT NULL DEFAULT 0,
-  hit_start integer NOT NULL DEFAULT 0,
-  hit_end integer NOT NULL DEFAULT 0,
-  hit_strand tinyint NOT NULL DEFAULT 0,
-  hit_name varchar(40) NOT NULL DEFAULT '',
-  analysis_id integer NOT NULL DEFAULT 0,
-  score double precision,
-  evalue double precision,
-  perc_ident float,
-  cigar_line text,
-  external_db_id smallint,
-  hcoverage double precision,
-  external_data text
+CREATE TABLE "exon" (
+  "exon_id" INTEGER PRIMARY KEY NOT NULL,
+  "seq_region_id" INT(10) NOT NULL,
+  "seq_region_start" INT(10) NOT NULL,
+  "seq_region_end" INT(10) NOT NULL,
+  "seq_region_strand" TINYINT(2) NOT NULL,
+  "phase" TINYINT(2) NOT NULL,
+  "end_phase" TINYINT(2) NOT NULL,
+  "is_current" TINYINT(1) NOT NULL DEFAULT 1,
+  "is_constitutive" TINYINT(1) NOT NULL DEFAULT 0,
+  "stable_id" VARCHAR(128) DEFAULT NULL,
+  "version" SMALLINT(5) DEFAULT NULL,
+  "created_date" DATETIME DEFAULT NULL,
+  "modified_date" DATETIME DEFAULT NULL
 );
 
+
+
 --
--- Table: dna_align_feature_attrib
+-- Table: "exon_transcript"
 --
-CREATE TABLE dna_align_feature_attrib (
-  dna_align_feature_id integer NOT NULL,
-  attrib_type_id smallint NOT NULL,
-  value text NOT NULL
+CREATE TABLE "exon_transcript" (
+  "exon_id" INT(10) NOT NULL,
+  "transcript_id" INT(10) NOT NULL,
+  "rank" INT(10) NOT NULL,
+  PRIMARY KEY ("exon_id", "transcript_id", "rank")
 );
 
-CREATE UNIQUE INDEX dna_align_feature_attribx ON dna_align_feature_attrib (dna_align_feature_id, attrib_type_id, value);
 
+
 --
--- Table: exon
+-- Table: "gene"
 --
-CREATE TABLE exon (
-  exon_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-  seq_region_id integer NOT NULL,
-  seq_region_start integer NOT NULL,
-  seq_region_end integer NOT NULL,
-  seq_region_strand tinyint NOT NULL,
-  phase tinyint NOT NULL,
-  end_phase tinyint NOT NULL,
-  is_current tinyint NOT NULL DEFAULT 1,
-  is_constitutive tinyint NOT NULL DEFAULT 0,
-  stable_id varchar(128),
-  version smallint,
-  created_date datetime,
-  modified_date datetime
+CREATE TABLE "gene" (
+  "gene_id" INTEGER PRIMARY KEY NOT NULL,
+  "biotype" VARCHAR(40) NOT NULL,
+  "analysis_id" SMALLINT(5) NOT NULL,
+  "seq_region_id" INT(10) NOT NULL,
+  "seq_region_start" INT(10) NOT NULL,
+  "seq_region_end" INT(10) NOT NULL,
+  "seq_region_strand" TINYINT(2) NOT NULL,
+  "display_xref_id" INT(10),
+  "source" VARCHAR(40) NOT NULL,
+  "description" TEXT(65535),
+  "is_current" TINYINT(1) NOT NULL DEFAULT 1,
+  "canonical_transcript_id" INT(10) NOT NULL,
+  "stable_id" VARCHAR(128) DEFAULT NULL,
+  "version" SMALLINT(5) DEFAULT NULL,
+  "created_date" DATETIME DEFAULT NULL,
+  "modified_date" DATETIME DEFAULT NULL
 );
+
 
+
+
+
+
 --
--- Table: exon_transcript
+-- Table: "gene_attrib"
 --
-CREATE TABLE exon_transcript (
-  exon_id integer NOT NULL DEFAULT 0,
-  transcript_id integer NOT NULL DEFAULT 0,
-  rank integer NOT NULL DEFAULT 0,
-  PRIMARY KEY (exon_id, transcript_id, rank)
+CREATE TABLE "gene_attrib" (
+  "gene_id" INT(10) NOT NULL DEFAULT 0,
+  "attrib_type_id" SMALLINT(5) NOT NULL DEFAULT 0,
+  "value" TEXT(65535) NOT NULL
 );
+
 
+
+
+
 --
--- Table: external_db
+-- Table: "protein_align_feature"
 --
-CREATE TABLE external_db (
-  external_db_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL DEFAULT 0,
-  db_name varchar(27) NOT NULL DEFAULT '',
-  db_release varchar(40) NOT NULL DEFAULT '',
-  status enum NOT NULL DEFAULT 'KNOWNXREF',
-  priority integer NOT NULL DEFAULT 0,
-  db_display_name varchar(255),
-  type enum,
-  secondary_db_name varchar(255),
-  secondary_db_table varchar(255),
-  description text
+CREATE TABLE "protein_align_feature" (
+  "protein_align_feature_id" INTEGER PRIMARY KEY NOT NULL,
+  "seq_region_id" INT(10) NOT NULL,
+  "seq_region_start" INT(10) NOT NULL,
+  "seq_region_end" INT(10) NOT NULL,
+  "seq_region_strand" TINYINT(1) NOT NULL DEFAULT 1,
+  "hit_start" INT(10) NOT NULL,
+  "hit_end" INT(10) NOT NULL,
+  "hit_name" VARCHAR(40) NOT NULL,
+  "analysis_id" SMALLINT(5) NOT NULL,
+  "score" DOUBLE,
+  "evalue" DOUBLE,
+  "perc_ident" FLOAT,
+  "cigar_line" TEXT(65535),
+  "external_db_id" int(10),
+  "hcoverage" DOUBLE,
+  "align_type" ENUM(7) DEFAULT 'ensembl'
 );
+
 
-CREATE UNIQUE INDEX db_name_db_release_idx ON external_db (db_name, db_release);
 
+
+
+
 --
--- Table: external_synonym
+-- Table: "protein_feature"
 --
-CREATE TABLE external_synonym (
-  xref_id integer NOT NULL DEFAULT 0,
-  synonym varchar(40) NOT NULL DEFAULT '',
-  PRIMARY KEY (xref_id, synonym)
+CREATE TABLE "protein_feature" (
+  "protein_feature_id" INTEGER PRIMARY KEY NOT NULL,
+  "translation_id" INT(10) NOT NULL,
+  "seq_start" INT(10) NOT NULL,
+  "seq_end" INT(10) NOT NULL,
+  "hit_start" INT(10) NOT NULL,
+  "hit_end" INT(10) NOT NULL,
+  "hit_name" VARCHAR(40) NOT NULL,
+  "analysis_id" SMALLINT(5) NOT NULL,
+  "score" DOUBLE,
+  "evalue" DOUBLE,
+  "perc_ident" FLOAT,
+  "external_data" TEXT(65535),
+  "hit_description" TEXT(65535),
+  "cigar_line" TEXT(65535),
+  "align_type" ENUM(9) DEFAULT NULL
 );
+
+
 
+
+
 --
--- Table: gene
+-- Table: "supporting_feature"
 --
-CREATE TABLE gene (
-  gene_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-  biotype varchar(40) NOT NULL,
-  analysis_id smallint NOT NULL,
-  seq_region_id integer NOT NULL,
-  seq_region_start integer NOT NULL,
-  seq_region_end integer NOT NULL,
-  seq_region_strand tinyint NOT NULL,
-  display_xref_id integer,
-  source varchar(40) NOT NULL,
-  status enum,
-  description text,
-  is_current tinyint NOT NULL DEFAULT 1,
-  canonical_transcript_id integer NOT NULL,
-  stable_id varchar(128),
-  version smallint,
-  created_date datetime,
-  modified_date datetime
+CREATE TABLE "supporting_feature" (
+  "exon_id" INT(10) NOT NULL DEFAULT 0,
+  "feature_type" ENUM(21),
+  "feature_id" INT(10) NOT NULL DEFAULT 0
 );
+
+
 
 --
--- Table: gene_archive
+-- Table: "transcript"
 --
-CREATE TABLE gene_archive (
-  gene_stable_id varchar(128) NOT NULL DEFAULT '',
-  gene_version smallint NOT NULL DEFAULT 0,
-  transcript_stable_id varchar(128) NOT NULL DEFAULT '',
-  transcript_version smallint NOT NULL DEFAULT 0,
-  translation_stable_id varchar(128) NOT NULL DEFAULT '',
-  translation_version smallint NOT NULL DEFAULT 0,
-  peptide_archive_id integer NOT NULL DEFAULT 0,
-  mapping_session_id integer NOT NULL DEFAULT 0
+CREATE TABLE "transcript" (
+  "transcript_id" INTEGER PRIMARY KEY NOT NULL,
+  "gene_id" INT(10),
+  "analysis_id" SMALLINT(5) NOT NULL,
+  "seq_region_id" INT(10) NOT NULL,
+  "seq_region_start" INT(10) NOT NULL,
+  "seq_region_end" INT(10) NOT NULL,
+  "seq_region_strand" TINYINT(2) NOT NULL,
+  "display_xref_id" INT(10),
+  "source" VARCHAR(40) NOT NULL DEFAULT 'ensembl',
+  "biotype" VARCHAR(40) NOT NULL,
+  "description" TEXT(65535),
+  "is_current" TINYINT(1) NOT NULL DEFAULT 1,
+  "canonical_translation_id" INT(10),
+  "stable_id" VARCHAR(128) DEFAULT NULL,
+  "version" SMALLINT(5) DEFAULT NULL,
+  "created_date" DATETIME DEFAULT NULL,
+  "modified_date" DATETIME DEFAULT NULL
 );
+
+
+
+
+
 
+
 --
--- Table: gene_attrib
+-- Table: "transcript_attrib"
 --
-CREATE TABLE gene_attrib (
-  gene_id integer NOT NULL DEFAULT 0,
-  attrib_type_id smallint NOT NULL DEFAULT 0,
-  value text NOT NULL
+CREATE TABLE "transcript_attrib" (
+  "transcript_id" INT(10) NOT NULL DEFAULT 0,
+  "attrib_type_id" SMALLINT(5) NOT NULL DEFAULT 0,
+  "value" TEXT(65535) NOT NULL
 );
+
 
-CREATE UNIQUE INDEX gene_attribx ON gene_attrib (gene_id, attrib_type_id, value);
 
+
+
 --
--- Table: genome_statistics
+-- Table: "transcript_supporting_feature"
 --
-CREATE TABLE genome_statistics (
-  genome_statistics_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-  statistic varchar(128) NOT NULL,
-  value bigint NOT NULL DEFAULT 0,
-  species_id integer DEFAULT 1,
-  attrib_type_id integer,
-  timestamp datetime
+CREATE TABLE "transcript_supporting_feature" (
+  "transcript_id" INT(10) NOT NULL DEFAULT 0,
+  "feature_type" ENUM(21),
+  "feature_id" INT(10) NOT NULL DEFAULT 0
 );
+
 
-CREATE UNIQUE INDEX stats_uniq ON genome_statistics (statistic, attrib_type_id, species_id);
 
 --
--- Table: identity_xref
+-- Table: "translation"
 --
-CREATE TABLE identity_xref (
-  object_xref_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL DEFAULT 0,
-  xref_identity integer,
-  ensembl_identity integer,
-  xref_start integer,
-  xref_end integer,
-  ensembl_start integer,
-  ensembl_end integer,
-  cigar_line text,
-  score double precision,
-  evalue double precision
+CREATE TABLE "translation" (
+  "translation_id" INTEGER PRIMARY KEY NOT NULL,
+  "transcript_id" INT(10) NOT NULL,
+  "seq_start" INT(10) NOT NULL,
+  -- relative to exon start
+  "start_exon_id" INT(10) NOT NULL,
+  "seq_end" INT(10) NOT NULL,
+  -- relative to exon start
+  "end_exon_id" INT(10) NOT NULL,
+  "stable_id" VARCHAR(128) DEFAULT NULL,
+  "version" SMALLINT(5) DEFAULT NULL,
+  "created_date" DATETIME DEFAULT NULL,
+  "modified_date" DATETIME DEFAULT NULL
 );
 
+
+
 --
--- Table: interpro
+-- Table: "translation_attrib"
 --
-CREATE TABLE interpro (
-  interpro_ac varchar(40) NOT NULL DEFAULT '',
-  id varchar(40) NOT NULL DEFAULT ''
+CREATE TABLE "translation_attrib" (
+  "translation_id" INT(10) NOT NULL DEFAULT 0,
+  "attrib_type_id" SMALLINT(5) NOT NULL DEFAULT 0,
+  "value" TEXT(65535) NOT NULL
 );
+
+
+
 
-CREATE UNIQUE INDEX accession_idx ON interpro (interpro_ac, id);
 
 --
--- Table: intron_supporting_evidence
+-- Table: "density_feature"
 --
-CREATE TABLE intron_supporting_evidence (
-  intron_supporting_evidence_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-  analysis_id smallint NOT NULL,
-  seq_region_id integer NOT NULL,
-  seq_region_start integer NOT NULL,
-  seq_region_end integer NOT NULL,
-  seq_region_strand tinyint NOT NULL,
-  hit_name varchar(100) NOT NULL,
-  score decimal(10,3),
-  score_type enum DEFAULT 'NONE',
-  is_splice_canonical tinyint NOT NULL DEFAULT 0
+CREATE TABLE "density_feature" (
+  "density_feature_id" INTEGER PRIMARY KEY NOT NULL,
+  "density_type_id" INT(10) NOT NULL,
+  "seq_region_id" INT(10) NOT NULL,
+  "seq_region_start" INT(10) NOT NULL,
+  "seq_region_end" INT(10) NOT NULL,
+  "density_value" FLOAT NOT NULL
 );
 
-CREATE UNIQUE INDEX analysis_id02 ON intron_supporting_evidence (analysis_id, seq_region_id, seq_region_start, seq_region_end, seq_region_strand, hit_name);
 
+
 --
--- Table: karyotype
+-- Table: "density_type"
 --
-CREATE TABLE karyotype (
-  karyotype_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-  seq_region_id integer NOT NULL DEFAULT 0,
-  seq_region_start integer NOT NULL DEFAULT 0,
-  seq_region_end integer NOT NULL DEFAULT 0,
-  band varchar(40),
-  stain varchar(40)
+CREATE TABLE "density_type" (
+  "density_type_id" INTEGER PRIMARY KEY NOT NULL,
+  "analysis_id" SMALLINT(5) NOT NULL,
+  "block_size" int(11) NOT NULL,
+  "region_features" int(11) NOT NULL,
+  "value_type" ENUM(5) NOT NULL
 );
+
 
 --
--- Table: map
+-- Table: "ditag"
 --
-CREATE TABLE map (
-  map_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-  map_name varchar(30) NOT NULL DEFAULT ''
+CREATE TABLE "ditag" (
+  "ditag_id" INTEGER PRIMARY KEY NOT NULL,
+  "name" VARCHAR(30) NOT NULL,
+  "type" VARCHAR(30) NOT NULL,
+  "tag_count" smallint(6) NOT NULL DEFAULT 1,
+  "sequence" TINYTEXT(255) NOT NULL
 );
 
 --
--- Table: mapping_session
+-- Table: "ditag_feature"
 --
-CREATE TABLE mapping_session (
-  mapping_session_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-  old_db_name varchar(80) NOT NULL DEFAULT '',
-  new_db_name varchar(80) NOT NULL DEFAULT '',
-  old_release varchar(5) NOT NULL DEFAULT '',
-  new_release varchar(5) NOT NULL DEFAULT '',
-  old_assembly varchar(20) NOT NULL DEFAULT '',
-  new_assembly varchar(20) NOT NULL DEFAULT '',
-  created datetime
+CREATE TABLE "ditag_feature" (
+  "ditag_feature_id" INTEGER PRIMARY KEY NOT NULL,
+  "ditag_id" INT(10) NOT NULL DEFAULT 0,
+  "ditag_pair_id" INT(10) NOT NULL DEFAULT 0,
+  "seq_region_id" INT(10) NOT NULL DEFAULT 0,
+  "seq_region_start" INT(10) NOT NULL DEFAULT 0,
+  "seq_region_end" INT(10) NOT NULL DEFAULT 0,
+  "seq_region_strand" TINYINT(1) NOT NULL DEFAULT 0,
+  "analysis_id" SMALLINT(5) NOT NULL DEFAULT 0,
+  "hit_start" INT(10) NOT NULL DEFAULT 0,
+  "hit_end" INT(10) NOT NULL DEFAULT 0,
+  "hit_strand" TINYINT(1) NOT NULL DEFAULT 0,
+  "cigar_line" TINYTEXT(255) NOT NULL,
+  "ditag_side" ENUM(1) NOT NULL
 );
+
+
 
+
 --
--- Table: mapping_set
+-- Table: "intron_supporting_evidence"
 --
-CREATE TABLE mapping_set (
-  mapping_set_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-  internal_schema_build varchar(20) NOT NULL,
-  external_schema_build varchar(20) NOT NULL
+CREATE TABLE "intron_supporting_evidence" (
+  "intron_supporting_evidence_id" INTEGER PRIMARY KEY NOT NULL,
+  "analysis_id" SMALLINT(5) NOT NULL,
+  "seq_region_id" INT(10) NOT NULL,
+  "seq_region_start" INT(10) NOT NULL,
+  "seq_region_end" INT(10) NOT NULL,
+  "seq_region_strand" TINYINT(2) NOT NULL,
+  "hit_name" VARCHAR(100) NOT NULL,
+  "score" DECIMAL(10,3),
+  "score_type" ENUM(5) DEFAULT 'NONE',
+  "is_splice_canonical" TINYINT(1) NOT NULL DEFAULT 0
 );
+
 
-CREATE UNIQUE INDEX mapping_idx ON mapping_set (internal_schema_build, external_schema_build);
+
+--
+-- Table: "map"
+--
+CREATE TABLE "map" (
+  "map_id" INTEGER PRIMARY KEY NOT NULL,
+  "map_name" VARCHAR(30) NOT NULL
+);
 
 --
--- Table: marker
+-- Table: "marker"
 --
-CREATE TABLE marker (
-  marker_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-  display_marker_synonym_id integer,
-  left_primer varchar(100) NOT NULL DEFAULT '',
-  right_primer varchar(100) NOT NULL DEFAULT '',
-  min_primer_dist integer NOT NULL DEFAULT 0,
-  max_primer_dist integer NOT NULL DEFAULT 0,
-  priority integer,
-  type enum
+CREATE TABLE "marker" (
+  "marker_id" INTEGER PRIMARY KEY NOT NULL,
+  "display_marker_synonym_id" INT(10),
+  "left_primer" VARCHAR(100) NOT NULL,
+  "right_primer" VARCHAR(100) NOT NULL,
+  "min_primer_dist" INT(10) NOT NULL,
+  "max_primer_dist" INT(10) NOT NULL,
+  "priority" int(11),
+  "type" ENUM(14)
 );
+
 
+
 --
--- Table: marker_feature
+-- Table: "marker_feature"
 --
-CREATE TABLE marker_feature (
-  marker_feature_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-  marker_id integer NOT NULL DEFAULT 0,
-  seq_region_id integer NOT NULL DEFAULT 0,
-  seq_region_start integer NOT NULL DEFAULT 0,
-  seq_region_end integer NOT NULL DEFAULT 0,
-  analysis_id integer NOT NULL DEFAULT 0,
-  map_weight integer
+CREATE TABLE "marker_feature" (
+  "marker_feature_id" INTEGER PRIMARY KEY NOT NULL,
+  "marker_id" INT(10) NOT NULL,
+  "seq_region_id" INT(10) NOT NULL,
+  "seq_region_start" INT(10) NOT NULL,
+  "seq_region_end" INT(10) NOT NULL,
+  "analysis_id" SMALLINT(5) NOT NULL,
+  "map_weight" INT(10)
 );
+
 
+
 --
--- Table: marker_map_location
+-- Table: "marker_map_location"
 --
-CREATE TABLE marker_map_location (
-  marker_id integer NOT NULL DEFAULT 0,
-  map_id integer NOT NULL DEFAULT 0,
-  chromosome_name varchar(15) NOT NULL DEFAULT '',
-  marker_synonym_id integer NOT NULL DEFAULT 0,
-  position varchar(15) NOT NULL DEFAULT '',
-  lod_score double precision,
-  PRIMARY KEY (marker_id, map_id)
+CREATE TABLE "marker_map_location" (
+  "marker_id" INT(10) NOT NULL,
+  "map_id" INT(10) NOT NULL,
+  "chromosome_name" VARCHAR(15) NOT NULL,
+  "marker_synonym_id" INT(10) NOT NULL,
+  "position" VARCHAR(15) NOT NULL,
+  "lod_score" DOUBLE,
+  PRIMARY KEY ("marker_id", "map_id")
 );
+
 
 --
--- Table: marker_synonym
+-- Table: "marker_synonym"
 --
-CREATE TABLE marker_synonym (
-  marker_synonym_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-  marker_id integer NOT NULL DEFAULT 0,
-  source varchar(20),
-  name varchar(30)
+CREATE TABLE "marker_synonym" (
+  "marker_synonym_id" INTEGER PRIMARY KEY NOT NULL,
+  "marker_id" INT(10) NOT NULL,
+  "source" VARCHAR(20),
+  "name" VARCHAR(50)
 );
 
+
+
 --
--- Table: meta
+-- Table: "misc_attrib"
 --
-CREATE TABLE meta (
-  meta_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-  species_id integer DEFAULT 1,
-  meta_key varchar(40) NOT NULL,
-  meta_value varchar(255) NOT NULL
+CREATE TABLE "misc_attrib" (
+  "misc_feature_id" INT(10) NOT NULL DEFAULT 0,
+  "attrib_type_id" SMALLINT(5) NOT NULL DEFAULT 0,
+  "value" TEXT(65535) NOT NULL
 );
+
 
-CREATE UNIQUE INDEX species_key_value_idx ON meta (species_id, meta_key, meta_value);
 
+
+
 --
--- Table: meta_coord
+-- Table: "misc_feature"
 --
-CREATE TABLE meta_coord (
-  table_name varchar(40) NOT NULL DEFAULT '',
-  coord_system_id integer NOT NULL DEFAULT 0,
-  max_length integer
+CREATE TABLE "misc_feature" (
+  "misc_feature_id" INTEGER PRIMARY KEY NOT NULL,
+  "seq_region_id" INT(10) NOT NULL DEFAULT 0,
+  "seq_region_start" INT(10) NOT NULL DEFAULT 0,
+  "seq_region_end" INT(10) NOT NULL DEFAULT 0,
+  "seq_region_strand" TINYINT(4) NOT NULL DEFAULT 0
 );
 
-CREATE UNIQUE INDEX cs_table_name_idx ON meta_coord (coord_system_id, table_name);
 
 --
--- Table: misc_attrib
+-- Table: "misc_feature_misc_set"
 --
-CREATE TABLE misc_attrib (
-  misc_feature_id integer NOT NULL DEFAULT 0,
-  attrib_type_id smallint NOT NULL DEFAULT 0,
-  value text NOT NULL
+CREATE TABLE "misc_feature_misc_set" (
+  "misc_feature_id" INT(10) NOT NULL DEFAULT 0,
+  "misc_set_id" SMALLINT(5) NOT NULL DEFAULT 0,
+  PRIMARY KEY ("misc_feature_id", "misc_set_id")
 );
 
-CREATE UNIQUE INDEX misc_attribx ON misc_attrib (misc_feature_id, attrib_type_id, value);
 
 --
--- Table: misc_feature
+-- Table: "misc_set"
 --
-CREATE TABLE misc_feature (
-  misc_feature_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-  seq_region_id integer NOT NULL DEFAULT 0,
-  seq_region_start integer NOT NULL DEFAULT 0,
-  seq_region_end integer NOT NULL DEFAULT 0,
-  seq_region_strand tinyint NOT NULL DEFAULT 0
+CREATE TABLE "misc_set" (
+  "misc_set_id" INTEGER PRIMARY KEY NOT NULL,
+  "code" VARCHAR(25) NOT NULL DEFAULT '',
+  "name" VARCHAR(255) NOT NULL DEFAULT '',
+  "description" TEXT(65535) NOT NULL,
+  "max_length" int(10) NOT NULL
 );
 
+
 --
--- Table: misc_feature_misc_set
+-- Table: "prediction_exon"
 --
-CREATE TABLE misc_feature_misc_set (
-  misc_feature_id integer NOT NULL DEFAULT 0,
-  misc_set_id smallint NOT NULL DEFAULT 0,
-  PRIMARY KEY (misc_feature_id, misc_set_id)
+CREATE TABLE "prediction_exon" (
+  "prediction_exon_id" INTEGER PRIMARY KEY NOT NULL,
+  "prediction_transcript_id" INT(10) NOT NULL,
+  "exon_rank" SMALLINT(5) NOT NULL,
+  "seq_region_id" INT(10) NOT NULL,
+  "seq_region_start" INT(10) NOT NULL,
+  "seq_region_end" INT(10) NOT NULL,
+  "seq_region_strand" TINYINT(4) NOT NULL,
+  "start_phase" TINYINT(4) NOT NULL,
+  "score" DOUBLE,
+  "p_value" DOUBLE
 );
+
 
+
 --
--- Table: misc_set
+-- Table: "prediction_transcript"
 --
-CREATE TABLE misc_set (
-  misc_set_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-  code varchar(25) NOT NULL DEFAULT '',
-  name varchar(255) NOT NULL DEFAULT '',
-  description text NOT NULL,
-  max_length integer NOT NULL DEFAULT 0
+CREATE TABLE "prediction_transcript" (
+  "prediction_transcript_id" INTEGER PRIMARY KEY NOT NULL,
+  "seq_region_id" INT(10) NOT NULL,
+  "seq_region_start" INT(10) NOT NULL,
+  "seq_region_end" INT(10) NOT NULL,
+  "seq_region_strand" TINYINT(4) NOT NULL,
+  "analysis_id" SMALLINT(5) NOT NULL,
+  "display_label" VARCHAR(255)
 );
+
 
-CREATE UNIQUE INDEX code_idx02 ON misc_set (code);
 
 --
--- Table: object_xref
+-- Table: "repeat_consensus"
 --
-CREATE TABLE object_xref (
-  object_xref_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-  ensembl_id integer NOT NULL DEFAULT 0,
-  ensembl_object_type enum NOT NULL DEFAULT 'RawContig',
-  xref_id integer NOT NULL,
-  linkage_annotation varchar(255),
-  analysis_id smallint NOT NULL
+CREATE TABLE "repeat_consensus" (
+  "repeat_consensus_id" INTEGER PRIMARY KEY NOT NULL,
+  "repeat_name" VARCHAR(255) NOT NULL,
+  "repeat_class" VARCHAR(100) NOT NULL,
+  "repeat_type" VARCHAR(40) NOT NULL,
+  "repeat_consensus" TEXT(65535)
 );
+
+
+
 
-CREATE UNIQUE INDEX xref_idx ON object_xref (xref_id, ensembl_object_type, ensembl_id, analysis_id);
 
 --
--- Table: ontology_xref
+-- Table: "repeat_feature"
 --
-CREATE TABLE ontology_xref (
-  object_xref_id integer NOT NULL DEFAULT 0,
-  linkage_type varchar(3),
-  source_xref_id integer
+CREATE TABLE "repeat_feature" (
+  "repeat_feature_id" INTEGER PRIMARY KEY NOT NULL,
+  "seq_region_id" INT(10) NOT NULL,
+  "seq_region_start" INT(10) NOT NULL,
+  "seq_region_end" INT(10) NOT NULL,
+  "seq_region_strand" TINYINT(1) NOT NULL DEFAULT 1,
+  "repeat_start" INT(10) NOT NULL,
+  "repeat_end" INT(10) NOT NULL,
+  "repeat_consensus_id" INT(10) NOT NULL,
+  "analysis_id" SMALLINT(5) NOT NULL,
+  "score" DOUBLE
 );
 
-CREATE UNIQUE INDEX object_source_type_idx ON ontology_xref (object_xref_id, source_xref_id, linkage_type);
 
+
+
 --
--- Table: operon
+-- Table: "simple_feature"
 --
-CREATE TABLE operon (
-  operon_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-  seq_region_id integer NOT NULL,
-  seq_region_start integer NOT NULL,
-  seq_region_end integer NOT NULL,
-  seq_region_strand tinyint NOT NULL,
-  display_label varchar(255),
-  analysis_id smallint NOT NULL,
-  stable_id varchar(128),
-  version smallint,
-  created_date datetime,
-  modified_date datetime
+CREATE TABLE "simple_feature" (
+  "simple_feature_id" INTEGER PRIMARY KEY NOT NULL,
+  "seq_region_id" INT(10) NOT NULL,
+  "seq_region_start" INT(10) NOT NULL,
+  "seq_region_end" INT(10) NOT NULL,
+  "seq_region_strand" TINYINT(1) NOT NULL,
+  "display_label" VARCHAR(255) NOT NULL,
+  "analysis_id" SMALLINT(5) NOT NULL,
+  "score" DOUBLE
 );
+
+
+
 
 --
--- Table: operon_transcript
+-- Table: "transcript_intron_supporting_evidence"
 --
-CREATE TABLE operon_transcript (
-  operon_transcript_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-  seq_region_id integer NOT NULL,
-  seq_region_start integer NOT NULL,
-  seq_region_end integer NOT NULL,
-  seq_region_strand tinyint NOT NULL,
-  operon_id integer NOT NULL,
-  display_label varchar(255),
-  analysis_id smallint NOT NULL,
-  stable_id varchar(128),
-  version smallint,
-  created_date datetime,
-  modified_date datetime
+CREATE TABLE "transcript_intron_supporting_evidence" (
+  "transcript_id" INT(10) NOT NULL,
+  "intron_supporting_evidence_id" INT(10) NOT NULL,
+  "previous_exon_id" INT(10) NOT NULL,
+  "next_exon_id" INT(10) NOT NULL,
+  PRIMARY KEY ("intron_supporting_evidence_id", "transcript_id")
 );
 
+
 --
--- Table: operon_transcript_gene
+-- Table: "gene_archive"
 --
-CREATE TABLE operon_transcript_gene (
-  operon_transcript_id integer,
-  gene_id integer
+CREATE TABLE "gene_archive" (
+  "gene_stable_id" VARCHAR(128) NOT NULL,
+  "gene_version" SMALLINT(6) NOT NULL DEFAULT 1,
+  "transcript_stable_id" VARCHAR(128) NOT NULL,
+  "transcript_version" SMALLINT(6) NOT NULL DEFAULT 1,
+  "translation_stable_id" VARCHAR(128),
+  "translation_version" SMALLINT(6) NOT NULL DEFAULT 1,
+  "peptide_archive_id" INT(10),
+  "mapping_session_id" INT(10) NOT NULL
 );
+
+
+
+
 
 --
--- Table: peptide_archive
+-- Table: "mapping_session"
 --
-CREATE TABLE peptide_archive (
-  peptide_archive_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-  md5_checksum varchar(32),
-  peptide_seq mediumtext NOT NULL
+CREATE TABLE "mapping_session" (
+  "mapping_session_id" INTEGER PRIMARY KEY NOT NULL,
+  "old_db_name" VARCHAR(80) NOT NULL DEFAULT '',
+  "new_db_name" VARCHAR(80) NOT NULL DEFAULT '',
+  "old_release" VARCHAR(5) NOT NULL DEFAULT '',
+  "new_release" VARCHAR(5) NOT NULL DEFAULT '',
+  "old_assembly" VARCHAR(80) NOT NULL DEFAULT '',
+  "new_assembly" VARCHAR(80) NOT NULL DEFAULT '',
+  "created" DATETIME NOT NULL
 );
 
 --
--- Table: prediction_exon
+-- Table: "peptide_archive"
 --
-CREATE TABLE prediction_exon (
-  prediction_exon_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-  prediction_transcript_id integer NOT NULL DEFAULT 0,
-  exon_rank smallint NOT NULL DEFAULT 0,
-  seq_region_id integer NOT NULL DEFAULT 0,
-  seq_region_start integer NOT NULL DEFAULT 0,
-  seq_region_end integer NOT NULL DEFAULT 0,
-  seq_region_strand tinyint NOT NULL DEFAULT 0,
-  start_phase tinyint NOT NULL DEFAULT 0,
-  score double precision,
-  p_value double precision
+CREATE TABLE "peptide_archive" (
+  "peptide_archive_id" INTEGER PRIMARY KEY NOT NULL,
+  "md5_checksum" VARCHAR(32),
+  "peptide_seq" MEDIUMTEXT(16777215) NOT NULL
 );
 
+
 --
--- Table: prediction_transcript
+-- Table: "mapping_set"
 --
-CREATE TABLE prediction_transcript (
-  prediction_transcript_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-  seq_region_id integer NOT NULL DEFAULT 0,
-  seq_region_start integer NOT NULL DEFAULT 0,
-  seq_region_end integer NOT NULL DEFAULT 0,
-  seq_region_strand tinyint NOT NULL DEFAULT 0,
-  analysis_id integer,
-  display_label varchar(255)
+CREATE TABLE "mapping_set" (
+  "mapping_set_id" INTEGER PRIMARY KEY NOT NULL,
+  "internal_schema_build" VARCHAR(20) NOT NULL,
+  "external_schema_build" VARCHAR(20) NOT NULL
 );
+
 
 --
--- Table: protein_align_feature
+-- Table: "stable_id_event"
 --
-CREATE TABLE protein_align_feature (
-  protein_align_feature_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-  seq_region_id integer NOT NULL DEFAULT 0,
-  seq_region_start integer NOT NULL DEFAULT 0,
-  seq_region_end integer NOT NULL DEFAULT 0,
-  seq_region_strand tinyint NOT NULL DEFAULT 1,
-  hit_start integer NOT NULL DEFAULT 0,
-  hit_end integer NOT NULL DEFAULT 0,
-  hit_name varchar(40) NOT NULL DEFAULT '',
-  analysis_id integer NOT NULL DEFAULT 0,
-  score double precision,
-  evalue double precision,
-  perc_ident float,
-  cigar_line text,
-  external_db_id smallint,
-  hcoverage double precision
+CREATE TABLE "stable_id_event" (
+  "old_stable_id" VARCHAR(128),
+  "old_version" SMALLINT(6),
+  "new_stable_id" VARCHAR(128),
+  "new_version" SMALLINT(6),
+  "mapping_session_id" INT(10) NOT NULL DEFAULT 0,
+  "type" ENUM(11) NOT NULL,
+  "score" FLOAT NOT NULL DEFAULT 0
 );
+
+
 
+
 --
--- Table: protein_feature
+-- Table: "seq_region_mapping"
 --
-CREATE TABLE protein_feature (
-  protein_feature_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-  translation_id integer NOT NULL DEFAULT 0,
-  seq_start integer NOT NULL DEFAULT 0,
-  seq_end integer NOT NULL DEFAULT 0,
-  hit_start integer NOT NULL DEFAULT 0,
-  hit_end integer NOT NULL DEFAULT 0,
-  hit_name varchar(40) NOT NULL DEFAULT '',
-  analysis_id integer NOT NULL DEFAULT 0,
-  score double precision NOT NULL DEFAULT 0,
-  evalue double precision,
-  perc_ident float,
-  external_data text,
-  hit_description text
+CREATE TABLE "seq_region_mapping" (
+  "external_seq_region_id" INT(10) NOT NULL,
+  "internal_seq_region_id" INT(10) NOT NULL,
+  "mapping_set_id" INT(10) NOT NULL
 );
+
 
-CREATE UNIQUE INDEX aln_idx ON protein_feature (translation_id, hit_name, seq_start, seq_end, hit_start, hit_end, analysis_id);
 
 --
--- Table: repeat_consensus
+-- Table: "associated_group"
 --
-CREATE TABLE repeat_consensus (
-  repeat_consensus_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-  repeat_name varchar(255) NOT NULL DEFAULT '',
-  repeat_class varchar(100) NOT NULL DEFAULT '',
-  repeat_type varchar(40) NOT NULL DEFAULT '',
-  repeat_consensus text
+CREATE TABLE "associated_group" (
+  "associated_group_id" INTEGER PRIMARY KEY NOT NULL,
+  "description" VARCHAR(128) DEFAULT NULL
 );
 
 --
--- Table: repeat_feature
+-- Table: "associated_xref"
 --
-CREATE TABLE repeat_feature (
-  repeat_feature_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-  seq_region_id integer NOT NULL DEFAULT 0,
-  seq_region_start integer NOT NULL DEFAULT 0,
-  seq_region_end integer NOT NULL DEFAULT 0,
-  seq_region_strand tinyint NOT NULL DEFAULT 1,
-  repeat_start integer NOT NULL DEFAULT 0,
-  repeat_end integer NOT NULL DEFAULT 0,
-  repeat_consensus_id integer NOT NULL DEFAULT 0,
-  analysis_id integer NOT NULL DEFAULT 0,
-  score double precision
+CREATE TABLE "associated_xref" (
+  "associated_xref_id" INTEGER PRIMARY KEY NOT NULL,
+  "object_xref_id" INT(10) NOT NULL DEFAULT 0,
+  "xref_id" INT(10) NOT NULL DEFAULT 0,
+  "source_xref_id" INT(10) DEFAULT NULL,
+  "condition_type" VARCHAR(128) DEFAULT NULL,
+  "associated_group_id" INT(10) DEFAULT NULL,
+  "rank" INT(10) DEFAULT 0
 );
+
+
+
 
+
+
 --
--- Table: seq_region
+-- Table: "dependent_xref"
 --
-CREATE TABLE seq_region (
-  seq_region_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-  name varchar(255) NOT NULL,
-  coord_system_id integer NOT NULL DEFAULT 0,
-  length integer NOT NULL DEFAULT 0
+CREATE TABLE "dependent_xref" (
+  "object_xref_id" INTEGER PRIMARY KEY NOT NULL,
+  "master_xref_id" INT(10) NOT NULL,
+  "dependent_xref_id" INT(10) NOT NULL
 );
 
-CREATE UNIQUE INDEX name_cs_idx ON seq_region (name, coord_system_id);
 
+
 --
--- Table: seq_region_attrib
+-- Table: "external_db"
 --
-CREATE TABLE seq_region_attrib (
-  seq_region_id integer NOT NULL DEFAULT 0,
-  attrib_type_id smallint NOT NULL DEFAULT 0,
-  value text NOT NULL
+CREATE TABLE "external_db" (
+  "external_db_id" INTEGER PRIMARY KEY NOT NULL,
+  "db_name" VARCHAR(100) NOT NULL,
+  "db_release" VARCHAR(255),
+  "status" ENUM(9) NOT NULL,
+  "priority" int(11) NOT NULL,
+  "db_display_name" VARCHAR(255),
+  "type" ENUM(18) NOT NULL,
+  "secondary_db_name" VARCHAR(255) DEFAULT NULL,
+  "secondary_db_table" VARCHAR(255) DEFAULT NULL,
+  "description" TEXT(65535)
 );
 
-CREATE UNIQUE INDEX region_attribx ON seq_region_attrib (seq_region_id, attrib_type_id, value);
 
 --
--- Table: seq_region_mapping
+-- Table: "biotype"
 --
-CREATE TABLE seq_region_mapping (
-  external_seq_region_id integer NOT NULL,
-  internal_seq_region_id integer NOT NULL,
-  mapping_set_id integer NOT NULL
+CREATE TABLE "biotype" (
+  "biotype_id" INTEGER PRIMARY KEY NOT NULL,
+  "name" VARCHAR(64) NOT NULL,
+  "object_type" ENUM(10) NOT NULL DEFAULT 'gene',
+  "db_type" varchar(19) NOT NULL DEFAULT 'core',
+  "attrib_type_id" int(11) DEFAULT NULL,
+  "description" TEXT(65535),
+  "biotype_group" ENUM(10) DEFAULT NULL,
+  "so_acc" VARCHAR(64),
+  "so_term" VARCHAR(1023)
 );
 
+
 --
--- Table: seq_region_synonym
+-- Table: "external_synonym"
 --
-CREATE TABLE seq_region_synonym (
-  seq_region_synonym_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-  seq_region_id integer NOT NULL,
-  synonym varchar(250) NOT NULL,
-  external_db_id smallint
+CREATE TABLE "external_synonym" (
+  "xref_id" INT(10) NOT NULL,
+  "synonym" VARCHAR(100) NOT NULL,
+  PRIMARY KEY ("xref_id", "synonym")
 );
 
-CREATE UNIQUE INDEX syn_idx ON seq_region_synonym (synonym, seq_region_id);
 
 --
--- Table: simple_feature
+-- Table: "identity_xref"
 --
-CREATE TABLE simple_feature (
-  simple_feature_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-  seq_region_id integer NOT NULL DEFAULT 0,
-  seq_region_start integer NOT NULL DEFAULT 0,
-  seq_region_end integer NOT NULL DEFAULT 0,
-  seq_region_strand tinyint NOT NULL DEFAULT 0,
-  display_label varchar(40) NOT NULL DEFAULT '',
-  analysis_id integer NOT NULL DEFAULT 0,
-  score double precision
+CREATE TABLE "identity_xref" (
+  "object_xref_id" INTEGER PRIMARY KEY NOT NULL,
+  "xref_identity" INT(5),
+  "ensembl_identity" INT(5),
+  "xref_start" int(11),
+  "xref_end" int(11),
+  "ensembl_start" int(11),
+  "ensembl_end" int(11),
+  "cigar_line" TEXT(65535),
+  "score" DOUBLE,
+  "evalue" DOUBLE
 );
 
 --
--- Table: stable_id_event
+-- Table: "interpro"
 --
-CREATE TABLE stable_id_event (
-  old_stable_id varchar(128),
-  old_version smallint,
-  new_stable_id varchar(128),
-  new_version smallint,
-  mapping_session_id integer NOT NULL DEFAULT 0,
-  type enum NOT NULL DEFAULT 'gene',
-  score float NOT NULL DEFAULT 0
+CREATE TABLE "interpro" (
+  "interpro_ac" VARCHAR(40) NOT NULL,
+  "id" VARCHAR(40) NOT NULL
 );
+
 
-CREATE UNIQUE INDEX uni_idx ON stable_id_event (mapping_session_id, old_stable_id, old_version, new_stable_id, new_version, type);
 
 --
--- Table: supporting_feature
+-- Table: "object_xref"
 --
-CREATE TABLE supporting_feature (
-  exon_id integer NOT NULL DEFAULT 0,
-  feature_type enum,
-  feature_id integer NOT NULL DEFAULT 0
+CREATE TABLE "object_xref" (
+  "object_xref_id" INTEGER PRIMARY KEY NOT NULL,
+  "ensembl_id" INT(10) NOT NULL,
+  "ensembl_object_type" ENUM(16) NOT NULL,
+  "xref_id" INT(10) NOT NULL,
+  "linkage_annotation" VARCHAR(255) DEFAULT NULL,
+  "analysis_id" SMALLINT(5)
 );
 
-CREATE UNIQUE INDEX all_idx02 ON supporting_feature (exon_id, feature_type, feature_id);
 
+
+
 --
--- Table: transcript
+-- Table: "ontology_xref"
 --
-CREATE TABLE transcript (
-  transcript_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-  gene_id integer,
-  analysis_id smallint NOT NULL,
-  seq_region_id integer NOT NULL,
-  seq_region_start integer NOT NULL,
-  seq_region_end integer NOT NULL,
-  seq_region_strand tinyint NOT NULL,
-  display_xref_id integer,
-  source varchar(40) NOT NULL DEFAULT 'ensembl',
-  biotype varchar(40) NOT NULL,
-  status enum,
-  description text,
-  is_current tinyint NOT NULL DEFAULT 1,
-  canonical_translation_id integer,
-  stable_id varchar(128),
-  version smallint,
-  created_date datetime,
-  modified_date datetime
+CREATE TABLE "ontology_xref" (
+  "object_xref_id" INT(10) NOT NULL DEFAULT 0,
+  "source_xref_id" INT(10) DEFAULT NULL,
+  "linkage_type" VARCHAR(3) DEFAULT NULL
 );
 
-CREATE UNIQUE INDEX canonical_translation_idx ON transcript (canonical_translation_id);
 
+
+
 --
--- Table: transcript_attrib
+-- Table: "unmapped_object"
 --
-CREATE TABLE transcript_attrib (
-  transcript_id integer NOT NULL DEFAULT 0,
-  attrib_type_id smallint NOT NULL DEFAULT 0,
-  value text NOT NULL
+CREATE TABLE "unmapped_object" (
+  "unmapped_object_id" INTEGER PRIMARY KEY NOT NULL,
+  "type" ENUM(6) NOT NULL,
+  "analysis_id" SMALLINT(5) NOT NULL,
+  "external_db_id" int(10),
+  "identifier" VARCHAR(255) NOT NULL,
+  "unmapped_reason_id" INT(10) NOT NULL,
+  "query_score" DOUBLE,
+  "target_score" DOUBLE,
+  "ensembl_id" INT(10) DEFAULT 0,
+  "ensembl_object_type" ENUM(11) DEFAULT 'RawContig',
+  "parent" VARCHAR(255) DEFAULT NULL
 );
+
 
-CREATE UNIQUE INDEX transcript_attribx ON transcript_attrib (transcript_id, attrib_type_id, value);
 
+
+
+--
+-- Table: "unmapped_reason"
+--
+CREATE TABLE "unmapped_reason" (
+  "unmapped_reason_id" INTEGER PRIMARY KEY NOT NULL,
+  "summary_description" VARCHAR(255),
+  "full_description" VARCHAR(255)
+);
+
 --
--- Table: transcript_intron_supporting_evidence
+-- Table: "xref"
 --
-CREATE TABLE transcript_intron_supporting_evidence (
-  transcript_id integer NOT NULL,
-  intron_supporting_evidence_id integer NOT NULL,
-  previous_exon_id integer NOT NULL,
-  next_exon_id integer NOT NULL,
-  PRIMARY KEY (intron_supporting_evidence_id, transcript_id)
+CREATE TABLE "xref" (
+  "xref_id" INTEGER PRIMARY KEY NOT NULL,
+  "external_db_id" int(10) NOT NULL,
+  "dbprimary_acc" VARCHAR(512) NOT NULL,
+  "display_label" VARCHAR(512) NOT NULL,
+  "version" VARCHAR(10) DEFAULT NULL,
+  "description" TEXT(65535),
+  "info_type" ENUM(18) NOT NULL DEFAULT 'NONE',
+  "info_text" VARCHAR(255) NOT NULL DEFAULT ''
 );
+
+
+
 
 --
--- Table: transcript_supporting_feature
+-- Table: "operon"
 --
-CREATE TABLE transcript_supporting_feature (
-  transcript_id integer NOT NULL DEFAULT 0,
-  feature_type enum,
-  feature_id integer NOT NULL DEFAULT 0
+CREATE TABLE "operon" (
+  "operon_id" INTEGER PRIMARY KEY NOT NULL,
+  "seq_region_id" INT(10) NOT NULL,
+  "seq_region_start" INT(10) NOT NULL,
+  "seq_region_end" INT(10) NOT NULL,
+  "seq_region_strand" TINYINT(2) NOT NULL,
+  "display_label" VARCHAR(255) DEFAULT NULL,
+  "analysis_id" SMALLINT(5) NOT NULL,
+  "stable_id" VARCHAR(128) DEFAULT NULL,
+  "version" SMALLINT(5) DEFAULT NULL,
+  "created_date" DATETIME DEFAULT NULL,
+  "modified_date" DATETIME DEFAULT NULL
 );
 
-CREATE UNIQUE INDEX all_idx03 ON transcript_supporting_feature (transcript_id, feature_type, feature_id);
 
+
+
 --
--- Table: translation
+-- Table: "operon_transcript"
 --
-CREATE TABLE translation (
-  translation_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-  transcript_id integer NOT NULL,
-  seq_start integer NOT NULL,
-  start_exon_id integer NOT NULL,
-  seq_end integer NOT NULL,
-  end_exon_id integer NOT NULL,
-  stable_id varchar(128),
-  version smallint,
-  created_date datetime,
-  modified_date datetime
+CREATE TABLE "operon_transcript" (
+  "operon_transcript_id" INTEGER PRIMARY KEY NOT NULL,
+  "seq_region_id" INT(10) NOT NULL,
+  "seq_region_start" INT(10) NOT NULL,
+  "seq_region_end" INT(10) NOT NULL,
+  "seq_region_strand" TINYINT(2) NOT NULL,
+  "operon_id" INT(10) NOT NULL,
+  "display_label" VARCHAR(255) DEFAULT NULL,
+  "analysis_id" SMALLINT(5) NOT NULL,
+  "stable_id" VARCHAR(128) DEFAULT NULL,
+  "version" SMALLINT(5) DEFAULT NULL,
+  "created_date" DATETIME DEFAULT NULL,
+  "modified_date" DATETIME DEFAULT NULL
 );
+
+
+
 
 --
--- Table: translation_attrib
+-- Table: "operon_transcript_gene"
 --
-CREATE TABLE translation_attrib (
-  translation_id integer NOT NULL DEFAULT 0,
-  attrib_type_id smallint NOT NULL DEFAULT 0,
-  value text NOT NULL
+CREATE TABLE "operon_transcript_gene" (
+  "operon_transcript_id" INT(10),
+  "gene_id" INT(10)
 );
 
-CREATE UNIQUE INDEX translation_attribx ON translation_attrib (translation_id, attrib_type_id, value);
 
 --
--- Table: unmapped_object
+-- Table: "rnaproduct"
 --
-CREATE TABLE unmapped_object (
-  unmapped_object_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-  type enum NOT NULL,
-  analysis_id integer NOT NULL,
-  external_db_id integer,
-  identifier varchar(255) NOT NULL,
-  unmapped_reason_id integer NOT NULL,
-  query_score double precision,
-  target_score double precision,
-  ensembl_id integer DEFAULT 0,
-  ensembl_object_type enum DEFAULT 'RawContig',
-  parent varchar(255)
+CREATE TABLE "rnaproduct" (
+  "rnaproduct_id" INTEGER PRIMARY KEY NOT NULL,
+  "rnaproduct_type_id" SMALLINT(5) NOT NULL,
+  "transcript_id" INT(10) NOT NULL,
+  "seq_start" INT(10) NOT NULL,
+  -- relative to transcript start
+  "start_exon_id" INT(10),
+  "seq_end" INT(10) NOT NULL,
+  -- relative to transcript start
+  "end_exon_id" INT(10),
+  "stable_id" VARCHAR(128) DEFAULT NULL,
+  "version" SMALLINT(5) DEFAULT NULL,
+  "created_date" DATETIME DEFAULT NULL,
+  "modified_date" DATETIME DEFAULT NULL
 );
 
-CREATE UNIQUE INDEX unique_unmapped_obj_idx ON unmapped_object (ensembl_id, ensembl_object_type, identifier, unmapped_reason_id, parent, external_db_id);
 
+
 --
--- Table: unmapped_reason
+-- Table: "rnaproduct_attrib"
 --
-CREATE TABLE unmapped_reason (
-  unmapped_reason_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-  summary_description varchar(255),
-  full_description varchar(255)
+CREATE TABLE "rnaproduct_attrib" (
+  "rnaproduct_id" INT(10) NOT NULL DEFAULT 0,
+  "attrib_type_id" SMALLINT(5) NOT NULL DEFAULT 0,
+  "value" TEXT(65535) NOT NULL
 );
+
+
+
+
 
 --
--- Table: xref
+-- Table: "rnaproduct_type"
 --
-CREATE TABLE xref (
-  xref_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-  external_db_id integer NOT NULL,
-  dbprimary_acc varchar(512) NOT NULL,
-  display_label varchar(512) NOT NULL,
-  version varchar(10),
-  description text,
-  info_type enum NOT NULL DEFAULT 'NONE',
-  info_text varchar(255) NOT NULL DEFAULT ''
+CREATE TABLE "rnaproduct_type" (
+  "rnaproduct_type_id" INTEGER PRIMARY KEY NOT NULL,
+  "code" VARCHAR(20) NOT NULL DEFAULT '',
+  "name" VARCHAR(255) NOT NULL DEFAULT '',
+  "description" TEXT(65535)
 );
 
-CREATE UNIQUE INDEX id_index ON xref (dbprimary_acc, external_db_id, info_type, info_text, version);
 
 COMMIT;

--- a/modules/t/test-genome-DBs/homo_sapiens/patch/SQLite/table.sql
+++ b/modules/t/test-genome-DBs/homo_sapiens/patch/SQLite/table.sql
@@ -1,985 +1,1139 @@
--- 
+--
 -- Created by SQL::Translator::Producer::SQLite
--- Created on Tue Mar 28 11:00:42 2017
--- 
+-- Created on Fri Jan 26 15:05:34 2024
+--
 
 BEGIN TRANSACTION;
 
 --
--- Table: alt_allele
+-- Table: "assembly"
 --
-CREATE TABLE alt_allele (
-  alt_allele_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-  alt_allele_group_id integer NOT NULL,
-  gene_id integer NOT NULL
+CREATE TABLE "assembly" (
+  "asm_seq_region_id" INT(10) NOT NULL,
+  "cmp_seq_region_id" INT(10) NOT NULL,
+  "asm_start" INT(10) NOT NULL,
+  "asm_end" INT(10) NOT NULL,
+  "cmp_start" INT(10) NOT NULL,
+  "cmp_end" INT(10) NOT NULL,
+  "ori" TINYINT(4) NOT NULL
 );
 
-CREATE UNIQUE INDEX gene_idx ON alt_allele (gene_id);
 
+
+
+--
+-- Table: "assembly_exception"
+--
+CREATE TABLE "assembly_exception" (
+  "assembly_exception_id" INTEGER PRIMARY KEY NOT NULL,
+  "seq_region_id" INT(10) NOT NULL,
+  "seq_region_start" INT(10) NOT NULL,
+  "seq_region_end" INT(10) NOT NULL,
+  "exc_type" ENUM(11) NOT NULL,
+  "exc_seq_region_id" INT(10) NOT NULL,
+  "exc_seq_region_start" INT(10) NOT NULL,
+  "exc_seq_region_end" INT(10) NOT NULL,
+  "ori" int(11) NOT NULL
+);
+
+
+
+--
+-- Table: "coord_system"
 --
--- Table: alt_allele_attrib
+CREATE TABLE "coord_system" (
+  "coord_system_id" INTEGER PRIMARY KEY NOT NULL,
+  "species_id" INT(10) NOT NULL DEFAULT 1,
+  "name" VARCHAR(40) NOT NULL,
+  "version" VARCHAR(255) DEFAULT NULL,
+  "rank" int(11) NOT NULL,
+  "attrib" varchar
+);
+
+
+
+
+--
+-- Table: "data_file"
 --
-CREATE TABLE alt_allele_attrib (
-  alt_allele_id integer,
-  attrib enum
+CREATE TABLE "data_file" (
+  "data_file_id" INTEGER PRIMARY KEY NOT NULL,
+  "coord_system_id" INT(10) NOT NULL,
+  "analysis_id" SMALLINT(5) NOT NULL,
+  "name" VARCHAR(100) NOT NULL,
+  "version_lock" TINYINT(1) NOT NULL DEFAULT 0,
+  "absolute" TINYINT(1) NOT NULL DEFAULT 0,
+  "url" TEXT(65535),
+  "file_type" ENUM(6)
 );
+
+
+
 
 --
--- Table: alt_allele_group
+-- Table: "dna"
 --
-CREATE TABLE alt_allele_group (
-  alt_allele_group_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL
+CREATE TABLE "dna" (
+  "seq_region_id" INTEGER PRIMARY KEY NOT NULL,
+  "sequence" LONGTEXT(4294967295) NOT NULL
 );
 
 --
--- Table: analysis
+-- Table: "genome_statistics"
 --
-CREATE TABLE analysis (
-  analysis_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-  created datetime,
-  logic_name varchar(40) NOT NULL DEFAULT '',
-  db varchar(120),
-  db_version varchar(40),
-  db_file varchar(120),
-  program varchar(80),
-  program_version varchar(40),
-  program_file varchar(80),
-  parameters text,
-  module varchar(80),
-  module_version varchar(40),
-  gff_source varchar(40),
-  gff_feature varchar(40)
+CREATE TABLE "genome_statistics" (
+  "genome_statistics_id" INTEGER PRIMARY KEY NOT NULL,
+  "statistic" VARCHAR(128) NOT NULL,
+  "value" BIGINT(11) NOT NULL DEFAULT 0,
+  "species_id" int(10) DEFAULT 1,
+  "attrib_type_id" INT(10) DEFAULT NULL,
+  "timestamp" DATETIME DEFAULT NULL
 );
 
-CREATE UNIQUE INDEX logic_name_idx ON analysis (logic_name);
 
 --
--- Table: analysis_description
+-- Table: "karyotype"
 --
-CREATE TABLE analysis_description (
-  analysis_id integer NOT NULL DEFAULT 0,
-  description text,
-  display_label varchar(255),
-  displayable tinyint NOT NULL DEFAULT 1,
-  web_data text
+CREATE TABLE "karyotype" (
+  "karyotype_id" INTEGER PRIMARY KEY NOT NULL,
+  "seq_region_id" INT(10) NOT NULL,
+  "seq_region_start" INT(10) NOT NULL,
+  "seq_region_end" INT(10) NOT NULL,
+  "band" VARCHAR(40) DEFAULT NULL,
+  "stain" VARCHAR(40) DEFAULT NULL
 );
 
-CREATE UNIQUE INDEX analysis_idx ON analysis_description (analysis_id);
 
 --
--- Table: assembly
+-- Table: "meta"
 --
-CREATE TABLE assembly (
-  asm_seq_region_id integer NOT NULL DEFAULT 0,
-  cmp_seq_region_id integer NOT NULL DEFAULT 0,
-  asm_start integer NOT NULL DEFAULT 0,
-  asm_end integer NOT NULL DEFAULT 0,
-  cmp_start integer NOT NULL DEFAULT 0,
-  cmp_end integer NOT NULL DEFAULT 0,
-  ori tinyint NOT NULL DEFAULT 0
+CREATE TABLE "meta" (
+  "meta_id" INTEGER PRIMARY KEY NOT NULL,
+  "species_id" int(10) DEFAULT 1,
+  "meta_key" VARCHAR(40) NOT NULL,
+  "meta_value" VARCHAR(255) DEFAULT NULL
 );
 
-CREATE UNIQUE INDEX all_idx ON assembly (asm_seq_region_id, cmp_seq_region_id, asm_start, asm_end, cmp_start, cmp_end, ori);
 
+
 --
--- Table: assembly_exception
+-- Table: "meta_coord"
 --
-CREATE TABLE assembly_exception (
-  assembly_exception_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-  seq_region_id integer NOT NULL DEFAULT 0,
-  seq_region_start integer NOT NULL DEFAULT 0,
-  seq_region_end integer NOT NULL DEFAULT 0,
-  exc_type enum NOT NULL DEFAULT 'HAP',
-  exc_seq_region_id integer NOT NULL DEFAULT 0,
-  exc_seq_region_start integer NOT NULL DEFAULT 0,
-  exc_seq_region_end integer NOT NULL DEFAULT 0,
-  ori integer NOT NULL DEFAULT 0
+CREATE TABLE "meta_coord" (
+  "table_name" VARCHAR(40) NOT NULL,
+  "coord_system_id" INT(10) NOT NULL,
+  "max_length" int(11)
 );
+
 
 --
--- Table: associated_group
+-- Table: "seq_region"
 --
-CREATE TABLE associated_group (
-  associated_group_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-  description varchar(128)
+CREATE TABLE "seq_region" (
+  "seq_region_id" INTEGER PRIMARY KEY NOT NULL,
+  "name" VARCHAR(255) NOT NULL,
+  "coord_system_id" INT(10) NOT NULL,
+  "length" INT(10) NOT NULL
 );
+
+
 
 --
--- Table: associated_xref
+-- Table: "seq_region_synonym"
 --
-CREATE TABLE associated_xref (
-  associated_xref_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-  object_xref_id integer NOT NULL DEFAULT 0,
-  xref_id integer NOT NULL DEFAULT 0,
-  source_xref_id integer,
-  condition_type varchar(128),
-  associated_group_id integer,
-  rank integer DEFAULT 0
+CREATE TABLE "seq_region_synonym" (
+  "seq_region_synonym_id" INTEGER PRIMARY KEY NOT NULL,
+  "seq_region_id" INT(10) NOT NULL,
+  "synonym" VARCHAR(250) NOT NULL,
+  "external_db_id" int(10)
 );
 
-CREATE UNIQUE INDEX object_associated_source_type_idx ON associated_xref (object_xref_id, xref_id, source_xref_id, condition_type, associated_group_id);
 
+
 --
--- Table: attrib_type
+-- Table: "seq_region_attrib"
 --
-CREATE TABLE attrib_type (
-  attrib_type_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-  code varchar(20) NOT NULL DEFAULT '',
-  name varchar(255) NOT NULL DEFAULT '',
-  description text
+CREATE TABLE "seq_region_attrib" (
+  "seq_region_id" INT(10) NOT NULL DEFAULT 0,
+  "attrib_type_id" SMALLINT(5) NOT NULL DEFAULT 0,
+  "value" TEXT(65535) NOT NULL
 );
+
 
-CREATE UNIQUE INDEX code_idx ON attrib_type (code);
 
+
+
 --
--- Table: coord_system
+-- Table: "alt_allele"
 --
-CREATE TABLE coord_system (
-  coord_system_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-  species_id integer NOT NULL DEFAULT 1,
-  name varchar(40) NOT NULL,
-  version varchar(255),
-  rank integer NOT NULL,
-  attrib varchar
+CREATE TABLE "alt_allele" (
+  "alt_allele_id" INTEGER PRIMARY KEY NOT NULL,
+  "alt_allele_group_id" int(10) NOT NULL,
+  "gene_id" int(10) NOT NULL
 );
 
-CREATE UNIQUE INDEX name_idx ON coord_system (name, version, species_id);
 
-CREATE UNIQUE INDEX rank_idx ON coord_system (rank, species_id);
 
 --
--- Table: data_file
+-- Table: "alt_allele_attrib"
 --
-CREATE TABLE data_file (
-  data_file_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-  coord_system_id integer NOT NULL,
-  analysis_id smallint NOT NULL,
-  name varchar(100) NOT NULL,
-  version_lock tinyint NOT NULL DEFAULT 0,
-  absolute tinyint NOT NULL DEFAULT 0,
-  url text,
-  file_type enum
+CREATE TABLE "alt_allele_attrib" (
+  "alt_allele_id" int(10),
+  "attrib" ENUM(35)
 );
 
-CREATE UNIQUE INDEX df_unq_idx ON data_file (coord_system_id, analysis_id, name, file_type);
 
 --
--- Table: density_feature
+-- Table: "alt_allele_group"
 --
-CREATE TABLE density_feature (
-  density_feature_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-  density_type_id integer NOT NULL DEFAULT 0,
-  seq_region_id integer NOT NULL DEFAULT 0,
-  seq_region_start integer NOT NULL DEFAULT 0,
-  seq_region_end integer NOT NULL DEFAULT 0,
-  density_value float NOT NULL DEFAULT 0
+CREATE TABLE "alt_allele_group" (
+  "alt_allele_group_id" INTEGER PRIMARY KEY NOT NULL
 );
 
 --
--- Table: density_type
+-- Table: "analysis"
 --
-CREATE TABLE density_type (
-  density_type_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-  analysis_id integer NOT NULL DEFAULT 0,
-  block_size integer NOT NULL DEFAULT 0,
-  region_features integer NOT NULL DEFAULT 0,
-  value_type enum NOT NULL DEFAULT 'sum'
+CREATE TABLE "analysis" (
+  "analysis_id" INTEGER PRIMARY KEY NOT NULL,
+  "created" datetime DEFAULT NULL,
+  "logic_name" VARCHAR(128) NOT NULL,
+  "db" VARCHAR(120),
+  "db_version" VARCHAR(40),
+  "db_file" VARCHAR(120),
+  "program" VARCHAR(80),
+  "program_version" VARCHAR(40),
+  "program_file" VARCHAR(80),
+  "parameters" TEXT(65535),
+  "module" VARCHAR(80),
+  "module_version" VARCHAR(40),
+  "gff_source" VARCHAR(40),
+  "gff_feature" VARCHAR(40)
 );
 
-CREATE UNIQUE INDEX analysis_id ON density_type (analysis_id, block_size, region_features);
 
 --
--- Table: dependent_xref
+-- Table: "analysis_description"
 --
-CREATE TABLE dependent_xref (
-  object_xref_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-  master_xref_id integer NOT NULL,
-  dependent_xref_id integer NOT NULL
+CREATE TABLE "analysis_description" (
+  "analysis_id" SMALLINT(5) NOT NULL,
+  "description" TEXT(65535),
+  "display_label" VARCHAR(255) NOT NULL,
+  "displayable" TINYINT(1) NOT NULL DEFAULT 1,
+  "web_data" TEXT(65535)
 );
+
 
 --
--- Table: ditag
+-- Table: "attrib_type"
 --
-CREATE TABLE ditag (
-  ditag_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-  name varchar(30),
-  type varchar(30),
-  tag_count smallint DEFAULT 1,
-  sequence text
+CREATE TABLE "attrib_type" (
+  "attrib_type_id" INTEGER PRIMARY KEY NOT NULL,
+  "code" VARCHAR(20) NOT NULL DEFAULT '',
+  "name" VARCHAR(255) NOT NULL DEFAULT '',
+  "description" TEXT(65535)
 );
 
+
 --
--- Table: ditag_feature
+-- Table: "dna_align_feature"
 --
-CREATE TABLE ditag_feature (
-  ditag_feature_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-  ditag_id integer NOT NULL DEFAULT 0,
-  ditag_pair_id integer NOT NULL DEFAULT 0,
-  seq_region_id integer NOT NULL DEFAULT 0,
-  seq_region_start integer NOT NULL DEFAULT 0,
-  seq_region_end integer NOT NULL DEFAULT 0,
-  seq_region_strand tinyint NOT NULL DEFAULT 0,
-  analysis_id integer NOT NULL DEFAULT 0,
-  hit_start integer NOT NULL DEFAULT 0,
-  hit_end integer NOT NULL DEFAULT 0,
-  hit_strand tinyint NOT NULL DEFAULT 0,
-  cigar_line text,
-  ditag_side char(1) DEFAULT ''
+CREATE TABLE "dna_align_feature" (
+  "dna_align_feature_id" INTEGER PRIMARY KEY NOT NULL,
+  "seq_region_id" INT(10) NOT NULL,
+  "seq_region_start" INT(10) NOT NULL,
+  "seq_region_end" INT(10) NOT NULL,
+  "seq_region_strand" TINYINT(1) NOT NULL,
+  "hit_start" int(11) NOT NULL,
+  "hit_end" int(11) NOT NULL,
+  "hit_strand" TINYINT(1) NOT NULL,
+  "hit_name" VARCHAR(40) NOT NULL,
+  "analysis_id" SMALLINT(5) NOT NULL,
+  "score" DOUBLE,
+  "evalue" DOUBLE,
+  "perc_ident" FLOAT,
+  "cigar_line" TEXT(65535),
+  "external_db_id" int(10),
+  "hcoverage" DOUBLE,
+  "align_type" ENUM(7) DEFAULT 'ensembl'
 );
+
+
+
+
 
+
 --
--- Table: dna
+-- Table: "dna_align_feature_attrib"
 --
-CREATE TABLE dna (
-  seq_region_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL DEFAULT 0,
-  sequence mediumtext NOT NULL
+CREATE TABLE "dna_align_feature_attrib" (
+  "dna_align_feature_id" INT(10) NOT NULL,
+  "attrib_type_id" SMALLINT(5) NOT NULL,
+  "value" TEXT(65535) NOT NULL
 );
+
+
+
+
 
 --
--- Table: dna_align_feature
+-- Table: "exon"
 --
-CREATE TABLE dna_align_feature (
-  dna_align_feature_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-  seq_region_id integer NOT NULL DEFAULT 0,
-  seq_region_start integer NOT NULL DEFAULT 0,
-  seq_region_end integer NOT NULL DEFAULT 0,
-  seq_region_strand tinyint NOT NULL DEFAULT 0,
-  hit_start integer NOT NULL DEFAULT 0,
-  hit_end integer NOT NULL DEFAULT 0,
-  hit_strand tinyint NOT NULL DEFAULT 0,
-  hit_name varchar(40) NOT NULL DEFAULT '',
-  analysis_id integer NOT NULL DEFAULT 0,
-  score double precision,
-  evalue double precision,
-  perc_ident float,
-  cigar_line text,
-  external_db_id smallint,
-  hcoverage double precision,
-  external_data text
+CREATE TABLE "exon" (
+  "exon_id" INTEGER PRIMARY KEY NOT NULL,
+  "seq_region_id" INT(10) NOT NULL,
+  "seq_region_start" INT(10) NOT NULL,
+  "seq_region_end" INT(10) NOT NULL,
+  "seq_region_strand" TINYINT(2) NOT NULL,
+  "phase" TINYINT(2) NOT NULL,
+  "end_phase" TINYINT(2) NOT NULL,
+  "is_current" TINYINT(1) NOT NULL DEFAULT 1,
+  "is_constitutive" TINYINT(1) NOT NULL DEFAULT 0,
+  "stable_id" VARCHAR(128) DEFAULT NULL,
+  "version" SMALLINT(5) DEFAULT NULL,
+  "created_date" DATETIME DEFAULT NULL,
+  "modified_date" DATETIME DEFAULT NULL
 );
 
+
+
 --
--- Table: dna_align_feature_attrib
+-- Table: "exon_transcript"
 --
-CREATE TABLE dna_align_feature_attrib (
-  dna_align_feature_id integer NOT NULL,
-  attrib_type_id smallint NOT NULL,
-  value text NOT NULL
+CREATE TABLE "exon_transcript" (
+  "exon_id" INT(10) NOT NULL,
+  "transcript_id" INT(10) NOT NULL,
+  "rank" INT(10) NOT NULL,
+  PRIMARY KEY ("exon_id", "transcript_id", "rank")
 );
 
-CREATE UNIQUE INDEX dna_align_feature_attribx ON dna_align_feature_attrib (dna_align_feature_id, attrib_type_id, value);
 
+
 --
--- Table: exon
+-- Table: "gene"
 --
-CREATE TABLE exon (
-  exon_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-  seq_region_id integer NOT NULL,
-  seq_region_start integer NOT NULL,
-  seq_region_end integer NOT NULL,
-  seq_region_strand tinyint NOT NULL,
-  phase tinyint NOT NULL,
-  end_phase tinyint NOT NULL,
-  is_current tinyint NOT NULL DEFAULT 1,
-  is_constitutive tinyint NOT NULL DEFAULT 0,
-  stable_id varchar(128),
-  version smallint,
-  created_date datetime,
-  modified_date datetime
+CREATE TABLE "gene" (
+  "gene_id" INTEGER PRIMARY KEY NOT NULL,
+  "biotype" VARCHAR(40) NOT NULL,
+  "analysis_id" SMALLINT(5) NOT NULL,
+  "seq_region_id" INT(10) NOT NULL,
+  "seq_region_start" INT(10) NOT NULL,
+  "seq_region_end" INT(10) NOT NULL,
+  "seq_region_strand" TINYINT(2) NOT NULL,
+  "display_xref_id" INT(10),
+  "source" VARCHAR(40) NOT NULL,
+  "description" TEXT(65535),
+  "is_current" TINYINT(1) NOT NULL DEFAULT 1,
+  "canonical_transcript_id" INT(10) NOT NULL,
+  "stable_id" VARCHAR(128) DEFAULT NULL,
+  "version" SMALLINT(5) DEFAULT NULL,
+  "created_date" DATETIME DEFAULT NULL,
+  "modified_date" DATETIME DEFAULT NULL
 );
+
 
+
+
+
+
 --
--- Table: exon_transcript
+-- Table: "gene_attrib"
 --
-CREATE TABLE exon_transcript (
-  exon_id integer NOT NULL DEFAULT 0,
-  transcript_id integer NOT NULL DEFAULT 0,
-  rank integer NOT NULL DEFAULT 0,
-  PRIMARY KEY (exon_id, transcript_id, rank)
+CREATE TABLE "gene_attrib" (
+  "gene_id" INT(10) NOT NULL DEFAULT 0,
+  "attrib_type_id" SMALLINT(5) NOT NULL DEFAULT 0,
+  "value" TEXT(65535) NOT NULL
 );
+
 
+
+
+
 --
--- Table: external_db
+-- Table: "protein_align_feature"
 --
-CREATE TABLE external_db (
-  external_db_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL DEFAULT 0,
-  db_name varchar(27) NOT NULL DEFAULT '',
-  db_release varchar(40) NOT NULL DEFAULT '',
-  status enum NOT NULL DEFAULT 'KNOWNXREF',
-  priority integer NOT NULL DEFAULT 0,
-  db_display_name varchar(255),
-  type enum,
-  secondary_db_name varchar(255),
-  secondary_db_table varchar(255),
-  description text
+CREATE TABLE "protein_align_feature" (
+  "protein_align_feature_id" INTEGER PRIMARY KEY NOT NULL,
+  "seq_region_id" INT(10) NOT NULL,
+  "seq_region_start" INT(10) NOT NULL,
+  "seq_region_end" INT(10) NOT NULL,
+  "seq_region_strand" TINYINT(1) NOT NULL DEFAULT 1,
+  "hit_start" INT(10) NOT NULL,
+  "hit_end" INT(10) NOT NULL,
+  "hit_name" VARCHAR(40) NOT NULL,
+  "analysis_id" SMALLINT(5) NOT NULL,
+  "score" DOUBLE,
+  "evalue" DOUBLE,
+  "perc_ident" FLOAT,
+  "cigar_line" TEXT(65535),
+  "external_db_id" int(10),
+  "hcoverage" DOUBLE,
+  "align_type" ENUM(7) DEFAULT 'ensembl'
 );
+
 
-CREATE UNIQUE INDEX db_name_db_release_idx ON external_db (db_name, db_release);
 
+
+
+
 --
--- Table: external_synonym
+-- Table: "protein_feature"
 --
-CREATE TABLE external_synonym (
-  xref_id integer NOT NULL DEFAULT 0,
-  synonym varchar(40) NOT NULL DEFAULT '',
-  PRIMARY KEY (xref_id, synonym)
+CREATE TABLE "protein_feature" (
+  "protein_feature_id" INTEGER PRIMARY KEY NOT NULL,
+  "translation_id" INT(10) NOT NULL,
+  "seq_start" INT(10) NOT NULL,
+  "seq_end" INT(10) NOT NULL,
+  "hit_start" INT(10) NOT NULL,
+  "hit_end" INT(10) NOT NULL,
+  "hit_name" VARCHAR(40) NOT NULL,
+  "analysis_id" SMALLINT(5) NOT NULL,
+  "score" DOUBLE,
+  "evalue" DOUBLE,
+  "perc_ident" FLOAT,
+  "external_data" TEXT(65535),
+  "hit_description" TEXT(65535),
+  "cigar_line" TEXT(65535),
+  "align_type" ENUM(9) DEFAULT NULL
 );
+
+
 
+
+
 --
--- Table: gene
+-- Table: "supporting_feature"
 --
-CREATE TABLE gene (
-  gene_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-  biotype varchar(40) NOT NULL,
-  analysis_id smallint NOT NULL,
-  seq_region_id integer NOT NULL,
-  seq_region_start integer NOT NULL,
-  seq_region_end integer NOT NULL,
-  seq_region_strand tinyint NOT NULL,
-  display_xref_id integer,
-  source varchar(40) NOT NULL,
-  status enum,
-  description text,
-  is_current tinyint NOT NULL DEFAULT 1,
-  canonical_transcript_id integer NOT NULL,
-  stable_id varchar(128),
-  version smallint,
-  created_date datetime,
-  modified_date datetime
+CREATE TABLE "supporting_feature" (
+  "exon_id" INT(10) NOT NULL DEFAULT 0,
+  "feature_type" ENUM(21),
+  "feature_id" INT(10) NOT NULL DEFAULT 0
 );
+
+
 
 --
--- Table: gene_archive
+-- Table: "transcript"
 --
-CREATE TABLE gene_archive (
-  gene_stable_id varchar(128) NOT NULL DEFAULT '',
-  gene_version smallint NOT NULL DEFAULT 0,
-  transcript_stable_id varchar(128) NOT NULL DEFAULT '',
-  transcript_version smallint NOT NULL DEFAULT 0,
-  translation_stable_id varchar(128) NOT NULL DEFAULT '',
-  translation_version smallint NOT NULL DEFAULT 0,
-  peptide_archive_id integer NOT NULL DEFAULT 0,
-  mapping_session_id integer NOT NULL DEFAULT 0
+CREATE TABLE "transcript" (
+  "transcript_id" INTEGER PRIMARY KEY NOT NULL,
+  "gene_id" INT(10),
+  "analysis_id" SMALLINT(5) NOT NULL,
+  "seq_region_id" INT(10) NOT NULL,
+  "seq_region_start" INT(10) NOT NULL,
+  "seq_region_end" INT(10) NOT NULL,
+  "seq_region_strand" TINYINT(2) NOT NULL,
+  "display_xref_id" INT(10),
+  "source" VARCHAR(40) NOT NULL DEFAULT 'ensembl',
+  "biotype" VARCHAR(40) NOT NULL,
+  "description" TEXT(65535),
+  "is_current" TINYINT(1) NOT NULL DEFAULT 1,
+  "canonical_translation_id" INT(10),
+  "stable_id" VARCHAR(128) DEFAULT NULL,
+  "version" SMALLINT(5) DEFAULT NULL,
+  "created_date" DATETIME DEFAULT NULL,
+  "modified_date" DATETIME DEFAULT NULL
 );
+
+
+
+
+
 
+
 --
--- Table: gene_attrib
+-- Table: "transcript_attrib"
 --
-CREATE TABLE gene_attrib (
-  gene_id integer NOT NULL DEFAULT 0,
-  attrib_type_id smallint NOT NULL DEFAULT 0,
-  value text NOT NULL
+CREATE TABLE "transcript_attrib" (
+  "transcript_id" INT(10) NOT NULL DEFAULT 0,
+  "attrib_type_id" SMALLINT(5) NOT NULL DEFAULT 0,
+  "value" TEXT(65535) NOT NULL
 );
+
 
-CREATE UNIQUE INDEX gene_attribx ON gene_attrib (gene_id, attrib_type_id, value);
 
+
+
 --
--- Table: genome_statistics
+-- Table: "transcript_supporting_feature"
 --
-CREATE TABLE genome_statistics (
-  genome_statistics_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-  statistic varchar(128) NOT NULL,
-  value bigint NOT NULL DEFAULT 0,
-  species_id integer DEFAULT 1,
-  attrib_type_id integer,
-  timestamp datetime
+CREATE TABLE "transcript_supporting_feature" (
+  "transcript_id" INT(10) NOT NULL DEFAULT 0,
+  "feature_type" ENUM(21),
+  "feature_id" INT(10) NOT NULL DEFAULT 0
 );
+
 
-CREATE UNIQUE INDEX stats_uniq ON genome_statistics (statistic, attrib_type_id, species_id);
 
 --
--- Table: identity_xref
+-- Table: "translation"
 --
-CREATE TABLE identity_xref (
-  object_xref_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL DEFAULT 0,
-  xref_identity integer,
-  ensembl_identity integer,
-  xref_start integer,
-  xref_end integer,
-  ensembl_start integer,
-  ensembl_end integer,
-  cigar_line text,
-  score double precision,
-  evalue double precision
+CREATE TABLE "translation" (
+  "translation_id" INTEGER PRIMARY KEY NOT NULL,
+  "transcript_id" INT(10) NOT NULL,
+  "seq_start" INT(10) NOT NULL,
+  -- relative to exon start
+  "start_exon_id" INT(10) NOT NULL,
+  "seq_end" INT(10) NOT NULL,
+  -- relative to exon start
+  "end_exon_id" INT(10) NOT NULL,
+  "stable_id" VARCHAR(128) DEFAULT NULL,
+  "version" SMALLINT(5) DEFAULT NULL,
+  "created_date" DATETIME DEFAULT NULL,
+  "modified_date" DATETIME DEFAULT NULL
 );
 
+
+
 --
--- Table: interpro
+-- Table: "translation_attrib"
 --
-CREATE TABLE interpro (
-  interpro_ac varchar(40) NOT NULL DEFAULT '',
-  id varchar(40) NOT NULL DEFAULT ''
+CREATE TABLE "translation_attrib" (
+  "translation_id" INT(10) NOT NULL DEFAULT 0,
+  "attrib_type_id" SMALLINT(5) NOT NULL DEFAULT 0,
+  "value" TEXT(65535) NOT NULL
 );
+
+
+
 
-CREATE UNIQUE INDEX accession_idx ON interpro (interpro_ac, id);
 
 --
--- Table: intron_supporting_evidence
+-- Table: "density_feature"
 --
-CREATE TABLE intron_supporting_evidence (
-  intron_supporting_evidence_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-  analysis_id smallint NOT NULL,
-  seq_region_id integer NOT NULL,
-  seq_region_start integer NOT NULL,
-  seq_region_end integer NOT NULL,
-  seq_region_strand tinyint NOT NULL,
-  hit_name varchar(100) NOT NULL,
-  score decimal(10,3),
-  score_type enum DEFAULT 'NONE',
-  is_splice_canonical tinyint NOT NULL DEFAULT 0
+CREATE TABLE "density_feature" (
+  "density_feature_id" INTEGER PRIMARY KEY NOT NULL,
+  "density_type_id" INT(10) NOT NULL,
+  "seq_region_id" INT(10) NOT NULL,
+  "seq_region_start" INT(10) NOT NULL,
+  "seq_region_end" INT(10) NOT NULL,
+  "density_value" FLOAT NOT NULL
 );
 
-CREATE UNIQUE INDEX analysis_id02 ON intron_supporting_evidence (analysis_id, seq_region_id, seq_region_start, seq_region_end, seq_region_strand, hit_name);
 
+
 --
--- Table: karyotype
+-- Table: "density_type"
 --
-CREATE TABLE karyotype (
-  karyotype_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-  seq_region_id integer NOT NULL DEFAULT 0,
-  seq_region_start integer NOT NULL DEFAULT 0,
-  seq_region_end integer NOT NULL DEFAULT 0,
-  band varchar(40),
-  stain varchar(40)
+CREATE TABLE "density_type" (
+  "density_type_id" INTEGER PRIMARY KEY NOT NULL,
+  "analysis_id" SMALLINT(5) NOT NULL,
+  "block_size" int(11) NOT NULL,
+  "region_features" int(11) NOT NULL,
+  "value_type" ENUM(5) NOT NULL
 );
+
 
 --
--- Table: map
+-- Table: "ditag"
 --
-CREATE TABLE map (
-  map_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-  map_name varchar(30) NOT NULL DEFAULT ''
+CREATE TABLE "ditag" (
+  "ditag_id" INTEGER PRIMARY KEY NOT NULL,
+  "name" VARCHAR(30) NOT NULL,
+  "type" VARCHAR(30) NOT NULL,
+  "tag_count" smallint(6) NOT NULL DEFAULT 1,
+  "sequence" TINYTEXT(255) NOT NULL
 );
 
 --
--- Table: mapping_session
+-- Table: "ditag_feature"
 --
-CREATE TABLE mapping_session (
-  mapping_session_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-  old_db_name varchar(80) NOT NULL DEFAULT '',
-  new_db_name varchar(80) NOT NULL DEFAULT '',
-  old_release varchar(5) NOT NULL DEFAULT '',
-  new_release varchar(5) NOT NULL DEFAULT '',
-  old_assembly varchar(20) NOT NULL DEFAULT '',
-  new_assembly varchar(20) NOT NULL DEFAULT '',
-  created datetime
+CREATE TABLE "ditag_feature" (
+  "ditag_feature_id" INTEGER PRIMARY KEY NOT NULL,
+  "ditag_id" INT(10) NOT NULL DEFAULT 0,
+  "ditag_pair_id" INT(10) NOT NULL DEFAULT 0,
+  "seq_region_id" INT(10) NOT NULL DEFAULT 0,
+  "seq_region_start" INT(10) NOT NULL DEFAULT 0,
+  "seq_region_end" INT(10) NOT NULL DEFAULT 0,
+  "seq_region_strand" TINYINT(1) NOT NULL DEFAULT 0,
+  "analysis_id" SMALLINT(5) NOT NULL DEFAULT 0,
+  "hit_start" INT(10) NOT NULL DEFAULT 0,
+  "hit_end" INT(10) NOT NULL DEFAULT 0,
+  "hit_strand" TINYINT(1) NOT NULL DEFAULT 0,
+  "cigar_line" TINYTEXT(255) NOT NULL,
+  "ditag_side" ENUM(1) NOT NULL
 );
+
+
 
+
 --
--- Table: mapping_set
+-- Table: "intron_supporting_evidence"
 --
-CREATE TABLE mapping_set (
-  mapping_set_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-  internal_schema_build varchar(20) NOT NULL,
-  external_schema_build varchar(20) NOT NULL
+CREATE TABLE "intron_supporting_evidence" (
+  "intron_supporting_evidence_id" INTEGER PRIMARY KEY NOT NULL,
+  "analysis_id" SMALLINT(5) NOT NULL,
+  "seq_region_id" INT(10) NOT NULL,
+  "seq_region_start" INT(10) NOT NULL,
+  "seq_region_end" INT(10) NOT NULL,
+  "seq_region_strand" TINYINT(2) NOT NULL,
+  "hit_name" VARCHAR(100) NOT NULL,
+  "score" DECIMAL(10,3),
+  "score_type" ENUM(5) DEFAULT 'NONE',
+  "is_splice_canonical" TINYINT(1) NOT NULL DEFAULT 0
 );
+
 
-CREATE UNIQUE INDEX mapping_idx ON mapping_set (internal_schema_build, external_schema_build);
+
+--
+-- Table: "map"
+--
+CREATE TABLE "map" (
+  "map_id" INTEGER PRIMARY KEY NOT NULL,
+  "map_name" VARCHAR(30) NOT NULL
+);
 
 --
--- Table: marker
+-- Table: "marker"
 --
-CREATE TABLE marker (
-  marker_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-  display_marker_synonym_id integer,
-  left_primer varchar(100) NOT NULL DEFAULT '',
-  right_primer varchar(100) NOT NULL DEFAULT '',
-  min_primer_dist integer NOT NULL DEFAULT 0,
-  max_primer_dist integer NOT NULL DEFAULT 0,
-  priority integer,
-  type enum
+CREATE TABLE "marker" (
+  "marker_id" INTEGER PRIMARY KEY NOT NULL,
+  "display_marker_synonym_id" INT(10),
+  "left_primer" VARCHAR(100) NOT NULL,
+  "right_primer" VARCHAR(100) NOT NULL,
+  "min_primer_dist" INT(10) NOT NULL,
+  "max_primer_dist" INT(10) NOT NULL,
+  "priority" int(11),
+  "type" ENUM(14)
 );
+
 
+
 --
--- Table: marker_feature
+-- Table: "marker_feature"
 --
-CREATE TABLE marker_feature (
-  marker_feature_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-  marker_id integer NOT NULL DEFAULT 0,
-  seq_region_id integer NOT NULL DEFAULT 0,
-  seq_region_start integer NOT NULL DEFAULT 0,
-  seq_region_end integer NOT NULL DEFAULT 0,
-  analysis_id integer NOT NULL DEFAULT 0,
-  map_weight integer
+CREATE TABLE "marker_feature" (
+  "marker_feature_id" INTEGER PRIMARY KEY NOT NULL,
+  "marker_id" INT(10) NOT NULL,
+  "seq_region_id" INT(10) NOT NULL,
+  "seq_region_start" INT(10) NOT NULL,
+  "seq_region_end" INT(10) NOT NULL,
+  "analysis_id" SMALLINT(5) NOT NULL,
+  "map_weight" INT(10)
 );
+
 
+
 --
--- Table: marker_map_location
+-- Table: "marker_map_location"
 --
-CREATE TABLE marker_map_location (
-  marker_id integer NOT NULL DEFAULT 0,
-  map_id integer NOT NULL DEFAULT 0,
-  chromosome_name varchar(15) NOT NULL DEFAULT '',
-  marker_synonym_id integer NOT NULL DEFAULT 0,
-  position varchar(15) NOT NULL DEFAULT '',
-  lod_score double precision,
-  PRIMARY KEY (marker_id, map_id)
+CREATE TABLE "marker_map_location" (
+  "marker_id" INT(10) NOT NULL,
+  "map_id" INT(10) NOT NULL,
+  "chromosome_name" VARCHAR(15) NOT NULL,
+  "marker_synonym_id" INT(10) NOT NULL,
+  "position" VARCHAR(15) NOT NULL,
+  "lod_score" DOUBLE,
+  PRIMARY KEY ("marker_id", "map_id")
 );
+
 
 --
--- Table: marker_synonym
+-- Table: "marker_synonym"
 --
-CREATE TABLE marker_synonym (
-  marker_synonym_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-  marker_id integer NOT NULL DEFAULT 0,
-  source varchar(20),
-  name varchar(30)
+CREATE TABLE "marker_synonym" (
+  "marker_synonym_id" INTEGER PRIMARY KEY NOT NULL,
+  "marker_id" INT(10) NOT NULL,
+  "source" VARCHAR(20),
+  "name" VARCHAR(50)
 );
 
+
+
 --
--- Table: meta
+-- Table: "misc_attrib"
 --
-CREATE TABLE meta (
-  meta_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-  species_id integer DEFAULT 1,
-  meta_key varchar(40) NOT NULL,
-  meta_value varchar(255) NOT NULL
+CREATE TABLE "misc_attrib" (
+  "misc_feature_id" INT(10) NOT NULL DEFAULT 0,
+  "attrib_type_id" SMALLINT(5) NOT NULL DEFAULT 0,
+  "value" TEXT(65535) NOT NULL
 );
+
 
-CREATE UNIQUE INDEX species_key_value_idx ON meta (species_id, meta_key, meta_value);
 
+
+
 --
--- Table: meta_coord
+-- Table: "misc_feature"
 --
-CREATE TABLE meta_coord (
-  table_name varchar(40) NOT NULL DEFAULT '',
-  coord_system_id integer NOT NULL DEFAULT 0,
-  max_length integer
+CREATE TABLE "misc_feature" (
+  "misc_feature_id" INTEGER PRIMARY KEY NOT NULL,
+  "seq_region_id" INT(10) NOT NULL DEFAULT 0,
+  "seq_region_start" INT(10) NOT NULL DEFAULT 0,
+  "seq_region_end" INT(10) NOT NULL DEFAULT 0,
+  "seq_region_strand" TINYINT(4) NOT NULL DEFAULT 0
 );
 
-CREATE UNIQUE INDEX cs_table_name_idx ON meta_coord (coord_system_id, table_name);
 
 --
--- Table: misc_attrib
+-- Table: "misc_feature_misc_set"
 --
-CREATE TABLE misc_attrib (
-  misc_feature_id integer NOT NULL DEFAULT 0,
-  attrib_type_id smallint NOT NULL DEFAULT 0,
-  value text NOT NULL
+CREATE TABLE "misc_feature_misc_set" (
+  "misc_feature_id" INT(10) NOT NULL DEFAULT 0,
+  "misc_set_id" SMALLINT(5) NOT NULL DEFAULT 0,
+  PRIMARY KEY ("misc_feature_id", "misc_set_id")
 );
 
-CREATE UNIQUE INDEX misc_attribx ON misc_attrib (misc_feature_id, attrib_type_id, value);
 
 --
--- Table: misc_feature
+-- Table: "misc_set"
 --
-CREATE TABLE misc_feature (
-  misc_feature_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-  seq_region_id integer NOT NULL DEFAULT 0,
-  seq_region_start integer NOT NULL DEFAULT 0,
-  seq_region_end integer NOT NULL DEFAULT 0,
-  seq_region_strand tinyint NOT NULL DEFAULT 0
+CREATE TABLE "misc_set" (
+  "misc_set_id" INTEGER PRIMARY KEY NOT NULL,
+  "code" VARCHAR(25) NOT NULL DEFAULT '',
+  "name" VARCHAR(255) NOT NULL DEFAULT '',
+  "description" TEXT(65535) NOT NULL,
+  "max_length" int(10) NOT NULL
 );
 
+
 --
--- Table: misc_feature_misc_set
+-- Table: "prediction_exon"
 --
-CREATE TABLE misc_feature_misc_set (
-  misc_feature_id integer NOT NULL DEFAULT 0,
-  misc_set_id smallint NOT NULL DEFAULT 0,
-  PRIMARY KEY (misc_feature_id, misc_set_id)
+CREATE TABLE "prediction_exon" (
+  "prediction_exon_id" INTEGER PRIMARY KEY NOT NULL,
+  "prediction_transcript_id" INT(10) NOT NULL,
+  "exon_rank" SMALLINT(5) NOT NULL,
+  "seq_region_id" INT(10) NOT NULL,
+  "seq_region_start" INT(10) NOT NULL,
+  "seq_region_end" INT(10) NOT NULL,
+  "seq_region_strand" TINYINT(4) NOT NULL,
+  "start_phase" TINYINT(4) NOT NULL,
+  "score" DOUBLE,
+  "p_value" DOUBLE
 );
+
 
+
 --
--- Table: misc_set
+-- Table: "prediction_transcript"
 --
-CREATE TABLE misc_set (
-  misc_set_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-  code varchar(25) NOT NULL DEFAULT '',
-  name varchar(255) NOT NULL DEFAULT '',
-  description text NOT NULL,
-  max_length integer NOT NULL DEFAULT 0
+CREATE TABLE "prediction_transcript" (
+  "prediction_transcript_id" INTEGER PRIMARY KEY NOT NULL,
+  "seq_region_id" INT(10) NOT NULL,
+  "seq_region_start" INT(10) NOT NULL,
+  "seq_region_end" INT(10) NOT NULL,
+  "seq_region_strand" TINYINT(4) NOT NULL,
+  "analysis_id" SMALLINT(5) NOT NULL,
+  "display_label" VARCHAR(255)
 );
+
 
-CREATE UNIQUE INDEX code_idx02 ON misc_set (code);
 
 --
--- Table: object_xref
+-- Table: "repeat_consensus"
 --
-CREATE TABLE object_xref (
-  object_xref_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-  ensembl_id integer NOT NULL DEFAULT 0,
-  ensembl_object_type enum NOT NULL DEFAULT 'RawContig',
-  xref_id integer NOT NULL,
-  linkage_annotation varchar(255),
-  analysis_id smallint NOT NULL
+CREATE TABLE "repeat_consensus" (
+  "repeat_consensus_id" INTEGER PRIMARY KEY NOT NULL,
+  "repeat_name" VARCHAR(255) NOT NULL,
+  "repeat_class" VARCHAR(100) NOT NULL,
+  "repeat_type" VARCHAR(40) NOT NULL,
+  "repeat_consensus" TEXT(65535)
 );
+
+
+
 
-CREATE UNIQUE INDEX xref_idx ON object_xref (xref_id, ensembl_object_type, ensembl_id, analysis_id);
 
 --
--- Table: ontology_xref
+-- Table: "repeat_feature"
 --
-CREATE TABLE ontology_xref (
-  object_xref_id integer NOT NULL DEFAULT 0,
-  linkage_type varchar(3),
-  source_xref_id integer
+CREATE TABLE "repeat_feature" (
+  "repeat_feature_id" INTEGER PRIMARY KEY NOT NULL,
+  "seq_region_id" INT(10) NOT NULL,
+  "seq_region_start" INT(10) NOT NULL,
+  "seq_region_end" INT(10) NOT NULL,
+  "seq_region_strand" TINYINT(1) NOT NULL DEFAULT 1,
+  "repeat_start" INT(10) NOT NULL,
+  "repeat_end" INT(10) NOT NULL,
+  "repeat_consensus_id" INT(10) NOT NULL,
+  "analysis_id" SMALLINT(5) NOT NULL,
+  "score" DOUBLE
 );
 
-CREATE UNIQUE INDEX object_source_type_idx ON ontology_xref (object_xref_id, source_xref_id, linkage_type);
 
+
+
 --
--- Table: operon
+-- Table: "simple_feature"
 --
-CREATE TABLE operon (
-  operon_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-  seq_region_id integer NOT NULL,
-  seq_region_start integer NOT NULL,
-  seq_region_end integer NOT NULL,
-  seq_region_strand tinyint NOT NULL,
-  display_label varchar(255),
-  analysis_id smallint NOT NULL,
-  stable_id varchar(128),
-  version smallint,
-  created_date datetime,
-  modified_date datetime
+CREATE TABLE "simple_feature" (
+  "simple_feature_id" INTEGER PRIMARY KEY NOT NULL,
+  "seq_region_id" INT(10) NOT NULL,
+  "seq_region_start" INT(10) NOT NULL,
+  "seq_region_end" INT(10) NOT NULL,
+  "seq_region_strand" TINYINT(1) NOT NULL,
+  "display_label" VARCHAR(255) NOT NULL,
+  "analysis_id" SMALLINT(5) NOT NULL,
+  "score" DOUBLE
 );
+
+
+
 
 --
--- Table: operon_transcript
+-- Table: "transcript_intron_supporting_evidence"
 --
-CREATE TABLE operon_transcript (
-  operon_transcript_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-  seq_region_id integer NOT NULL,
-  seq_region_start integer NOT NULL,
-  seq_region_end integer NOT NULL,
-  seq_region_strand tinyint NOT NULL,
-  operon_id integer NOT NULL,
-  display_label varchar(255),
-  analysis_id smallint NOT NULL,
-  stable_id varchar(128),
-  version smallint,
-  created_date datetime,
-  modified_date datetime
+CREATE TABLE "transcript_intron_supporting_evidence" (
+  "transcript_id" INT(10) NOT NULL,
+  "intron_supporting_evidence_id" INT(10) NOT NULL,
+  "previous_exon_id" INT(10) NOT NULL,
+  "next_exon_id" INT(10) NOT NULL,
+  PRIMARY KEY ("intron_supporting_evidence_id", "transcript_id")
 );
 
+
 --
--- Table: operon_transcript_gene
+-- Table: "gene_archive"
 --
-CREATE TABLE operon_transcript_gene (
-  operon_transcript_id integer,
-  gene_id integer
+CREATE TABLE "gene_archive" (
+  "gene_stable_id" VARCHAR(128) NOT NULL,
+  "gene_version" SMALLINT(6) NOT NULL DEFAULT 1,
+  "transcript_stable_id" VARCHAR(128) NOT NULL,
+  "transcript_version" SMALLINT(6) NOT NULL DEFAULT 1,
+  "translation_stable_id" VARCHAR(128),
+  "translation_version" SMALLINT(6) NOT NULL DEFAULT 1,
+  "peptide_archive_id" INT(10),
+  "mapping_session_id" INT(10) NOT NULL
 );
+
+
+
+
 
 --
--- Table: peptide_archive
+-- Table: "mapping_session"
 --
-CREATE TABLE peptide_archive (
-  peptide_archive_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-  md5_checksum varchar(32),
-  peptide_seq mediumtext NOT NULL
+CREATE TABLE "mapping_session" (
+  "mapping_session_id" INTEGER PRIMARY KEY NOT NULL,
+  "old_db_name" VARCHAR(80) NOT NULL DEFAULT '',
+  "new_db_name" VARCHAR(80) NOT NULL DEFAULT '',
+  "old_release" VARCHAR(5) NOT NULL DEFAULT '',
+  "new_release" VARCHAR(5) NOT NULL DEFAULT '',
+  "old_assembly" VARCHAR(80) NOT NULL DEFAULT '',
+  "new_assembly" VARCHAR(80) NOT NULL DEFAULT '',
+  "created" DATETIME NOT NULL
 );
 
 --
--- Table: prediction_exon
+-- Table: "peptide_archive"
 --
-CREATE TABLE prediction_exon (
-  prediction_exon_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-  prediction_transcript_id integer NOT NULL DEFAULT 0,
-  exon_rank smallint NOT NULL DEFAULT 0,
-  seq_region_id integer NOT NULL DEFAULT 0,
-  seq_region_start integer NOT NULL DEFAULT 0,
-  seq_region_end integer NOT NULL DEFAULT 0,
-  seq_region_strand tinyint NOT NULL DEFAULT 0,
-  start_phase tinyint NOT NULL DEFAULT 0,
-  score double precision,
-  p_value double precision
+CREATE TABLE "peptide_archive" (
+  "peptide_archive_id" INTEGER PRIMARY KEY NOT NULL,
+  "md5_checksum" VARCHAR(32),
+  "peptide_seq" MEDIUMTEXT(16777215) NOT NULL
 );
 
+
 --
--- Table: prediction_transcript
+-- Table: "mapping_set"
 --
-CREATE TABLE prediction_transcript (
-  prediction_transcript_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-  seq_region_id integer NOT NULL DEFAULT 0,
-  seq_region_start integer NOT NULL DEFAULT 0,
-  seq_region_end integer NOT NULL DEFAULT 0,
-  seq_region_strand tinyint NOT NULL DEFAULT 0,
-  analysis_id integer,
-  display_label varchar(255)
+CREATE TABLE "mapping_set" (
+  "mapping_set_id" INTEGER PRIMARY KEY NOT NULL,
+  "internal_schema_build" VARCHAR(20) NOT NULL,
+  "external_schema_build" VARCHAR(20) NOT NULL
 );
+
 
 --
--- Table: protein_align_feature
+-- Table: "stable_id_event"
 --
-CREATE TABLE protein_align_feature (
-  protein_align_feature_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-  seq_region_id integer NOT NULL DEFAULT 0,
-  seq_region_start integer NOT NULL DEFAULT 0,
-  seq_region_end integer NOT NULL DEFAULT 0,
-  seq_region_strand tinyint NOT NULL DEFAULT 1,
-  hit_start integer NOT NULL DEFAULT 0,
-  hit_end integer NOT NULL DEFAULT 0,
-  hit_name varchar(40) NOT NULL DEFAULT '',
-  analysis_id integer NOT NULL DEFAULT 0,
-  score double precision,
-  evalue double precision,
-  perc_ident float,
-  cigar_line text,
-  external_db_id smallint,
-  hcoverage double precision
+CREATE TABLE "stable_id_event" (
+  "old_stable_id" VARCHAR(128),
+  "old_version" SMALLINT(6),
+  "new_stable_id" VARCHAR(128),
+  "new_version" SMALLINT(6),
+  "mapping_session_id" INT(10) NOT NULL DEFAULT 0,
+  "type" ENUM(11) NOT NULL,
+  "score" FLOAT NOT NULL DEFAULT 0
 );
+
+
 
+
 --
--- Table: protein_feature
+-- Table: "seq_region_mapping"
 --
-CREATE TABLE protein_feature (
-  protein_feature_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-  translation_id integer NOT NULL DEFAULT 0,
-  seq_start integer NOT NULL DEFAULT 0,
-  seq_end integer NOT NULL DEFAULT 0,
-  hit_start integer NOT NULL DEFAULT 0,
-  hit_end integer NOT NULL DEFAULT 0,
-  hit_name varchar(40) NOT NULL DEFAULT '',
-  analysis_id integer NOT NULL DEFAULT 0,
-  score double precision NOT NULL DEFAULT 0,
-  evalue double precision,
-  perc_ident float,
-  external_data text,
-  hit_description text
+CREATE TABLE "seq_region_mapping" (
+  "external_seq_region_id" INT(10) NOT NULL,
+  "internal_seq_region_id" INT(10) NOT NULL,
+  "mapping_set_id" INT(10) NOT NULL
 );
+
 
-CREATE UNIQUE INDEX aln_idx ON protein_feature (translation_id, hit_name, seq_start, seq_end, hit_start, hit_end, analysis_id);
 
 --
--- Table: repeat_consensus
+-- Table: "associated_group"
 --
-CREATE TABLE repeat_consensus (
-  repeat_consensus_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-  repeat_name varchar(255) NOT NULL DEFAULT '',
-  repeat_class varchar(100) NOT NULL DEFAULT '',
-  repeat_type varchar(40) NOT NULL DEFAULT '',
-  repeat_consensus text
+CREATE TABLE "associated_group" (
+  "associated_group_id" INTEGER PRIMARY KEY NOT NULL,
+  "description" VARCHAR(128) DEFAULT NULL
 );
 
 --
--- Table: repeat_feature
+-- Table: "associated_xref"
 --
-CREATE TABLE repeat_feature (
-  repeat_feature_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-  seq_region_id integer NOT NULL DEFAULT 0,
-  seq_region_start integer NOT NULL DEFAULT 0,
-  seq_region_end integer NOT NULL DEFAULT 0,
-  seq_region_strand tinyint NOT NULL DEFAULT 1,
-  repeat_start integer NOT NULL DEFAULT 0,
-  repeat_end integer NOT NULL DEFAULT 0,
-  repeat_consensus_id integer NOT NULL DEFAULT 0,
-  analysis_id integer NOT NULL DEFAULT 0,
-  score double precision
+CREATE TABLE "associated_xref" (
+  "associated_xref_id" INTEGER PRIMARY KEY NOT NULL,
+  "object_xref_id" INT(10) NOT NULL DEFAULT 0,
+  "xref_id" INT(10) NOT NULL DEFAULT 0,
+  "source_xref_id" INT(10) DEFAULT NULL,
+  "condition_type" VARCHAR(128) DEFAULT NULL,
+  "associated_group_id" INT(10) DEFAULT NULL,
+  "rank" INT(10) DEFAULT 0
 );
+
+
+
 
+
+
 --
--- Table: seq_region
+-- Table: "dependent_xref"
 --
-CREATE TABLE seq_region (
-  seq_region_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-  name varchar(255) NOT NULL,
-  coord_system_id integer NOT NULL DEFAULT 0,
-  length integer NOT NULL DEFAULT 0
+CREATE TABLE "dependent_xref" (
+  "object_xref_id" INTEGER PRIMARY KEY NOT NULL,
+  "master_xref_id" INT(10) NOT NULL,
+  "dependent_xref_id" INT(10) NOT NULL
 );
 
-CREATE UNIQUE INDEX name_cs_idx ON seq_region (name, coord_system_id);
 
+
 --
--- Table: seq_region_attrib
+-- Table: "external_db"
 --
-CREATE TABLE seq_region_attrib (
-  seq_region_id integer NOT NULL DEFAULT 0,
-  attrib_type_id smallint NOT NULL DEFAULT 0,
-  value text NOT NULL
+CREATE TABLE "external_db" (
+  "external_db_id" INTEGER PRIMARY KEY NOT NULL,
+  "db_name" VARCHAR(100) NOT NULL,
+  "db_release" VARCHAR(255),
+  "status" ENUM(9) NOT NULL,
+  "priority" int(11) NOT NULL,
+  "db_display_name" VARCHAR(255),
+  "type" ENUM(18) NOT NULL,
+  "secondary_db_name" VARCHAR(255) DEFAULT NULL,
+  "secondary_db_table" VARCHAR(255) DEFAULT NULL,
+  "description" TEXT(65535)
 );
 
-CREATE UNIQUE INDEX region_attribx ON seq_region_attrib (seq_region_id, attrib_type_id, value);
 
 --
--- Table: seq_region_mapping
+-- Table: "biotype"
 --
-CREATE TABLE seq_region_mapping (
-  external_seq_region_id integer NOT NULL,
-  internal_seq_region_id integer NOT NULL,
-  mapping_set_id integer NOT NULL
+CREATE TABLE "biotype" (
+  "biotype_id" INTEGER PRIMARY KEY NOT NULL,
+  "name" VARCHAR(64) NOT NULL,
+  "object_type" ENUM(10) NOT NULL DEFAULT 'gene',
+  "db_type" varchar(19) NOT NULL DEFAULT 'core',
+  "attrib_type_id" int(11) DEFAULT NULL,
+  "description" TEXT(65535),
+  "biotype_group" ENUM(10) DEFAULT NULL,
+  "so_acc" VARCHAR(64),
+  "so_term" VARCHAR(1023)
 );
 
+
 --
--- Table: seq_region_synonym
+-- Table: "external_synonym"
 --
-CREATE TABLE seq_region_synonym (
-  seq_region_synonym_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-  seq_region_id integer NOT NULL,
-  synonym varchar(250) NOT NULL,
-  external_db_id smallint
+CREATE TABLE "external_synonym" (
+  "xref_id" INT(10) NOT NULL,
+  "synonym" VARCHAR(100) NOT NULL,
+  PRIMARY KEY ("xref_id", "synonym")
 );
 
-CREATE UNIQUE INDEX syn_idx ON seq_region_synonym (synonym, seq_region_id);
 
 --
--- Table: simple_feature
+-- Table: "identity_xref"
 --
-CREATE TABLE simple_feature (
-  simple_feature_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-  seq_region_id integer NOT NULL DEFAULT 0,
-  seq_region_start integer NOT NULL DEFAULT 0,
-  seq_region_end integer NOT NULL DEFAULT 0,
-  seq_region_strand tinyint NOT NULL DEFAULT 0,
-  display_label varchar(40) NOT NULL DEFAULT '',
-  analysis_id integer NOT NULL DEFAULT 0,
-  score double precision
+CREATE TABLE "identity_xref" (
+  "object_xref_id" INTEGER PRIMARY KEY NOT NULL,
+  "xref_identity" INT(5),
+  "ensembl_identity" INT(5),
+  "xref_start" int(11),
+  "xref_end" int(11),
+  "ensembl_start" int(11),
+  "ensembl_end" int(11),
+  "cigar_line" TEXT(65535),
+  "score" DOUBLE,
+  "evalue" DOUBLE
 );
 
 --
--- Table: stable_id_event
+-- Table: "interpro"
 --
-CREATE TABLE stable_id_event (
-  old_stable_id varchar(128),
-  old_version smallint,
-  new_stable_id varchar(128),
-  new_version smallint,
-  mapping_session_id integer NOT NULL DEFAULT 0,
-  type enum NOT NULL DEFAULT 'gene',
-  score float NOT NULL DEFAULT 0
+CREATE TABLE "interpro" (
+  "interpro_ac" VARCHAR(40) NOT NULL,
+  "id" VARCHAR(40) NOT NULL
 );
+
 
-CREATE UNIQUE INDEX uni_idx ON stable_id_event (mapping_session_id, old_stable_id, old_version, new_stable_id, new_version, type);
 
 --
--- Table: supporting_feature
+-- Table: "object_xref"
 --
-CREATE TABLE supporting_feature (
-  exon_id integer NOT NULL DEFAULT 0,
-  feature_type enum,
-  feature_id integer NOT NULL DEFAULT 0
+CREATE TABLE "object_xref" (
+  "object_xref_id" INTEGER PRIMARY KEY NOT NULL,
+  "ensembl_id" INT(10) NOT NULL,
+  "ensembl_object_type" ENUM(16) NOT NULL,
+  "xref_id" INT(10) NOT NULL,
+  "linkage_annotation" VARCHAR(255) DEFAULT NULL,
+  "analysis_id" SMALLINT(5)
 );
 
-CREATE UNIQUE INDEX all_idx02 ON supporting_feature (exon_id, feature_type, feature_id);
 
+
+
 --
--- Table: transcript
+-- Table: "ontology_xref"
 --
-CREATE TABLE transcript (
-  transcript_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-  gene_id integer,
-  analysis_id smallint NOT NULL,
-  seq_region_id integer NOT NULL,
-  seq_region_start integer NOT NULL,
-  seq_region_end integer NOT NULL,
-  seq_region_strand tinyint NOT NULL,
-  display_xref_id integer,
-  source varchar(40) NOT NULL DEFAULT 'ensembl',
-  biotype varchar(40) NOT NULL,
-  status enum,
-  description text,
-  is_current tinyint NOT NULL DEFAULT 1,
-  canonical_translation_id integer,
-  stable_id varchar(128),
-  version smallint,
-  created_date datetime,
-  modified_date datetime
+CREATE TABLE "ontology_xref" (
+  "object_xref_id" INT(10) NOT NULL DEFAULT 0,
+  "source_xref_id" INT(10) DEFAULT NULL,
+  "linkage_type" VARCHAR(3) DEFAULT NULL
 );
 
-CREATE UNIQUE INDEX canonical_translation_idx ON transcript (canonical_translation_id);
 
+
+
 --
--- Table: transcript_attrib
+-- Table: "unmapped_object"
 --
-CREATE TABLE transcript_attrib (
-  transcript_id integer NOT NULL DEFAULT 0,
-  attrib_type_id smallint NOT NULL DEFAULT 0,
-  value text NOT NULL
+CREATE TABLE "unmapped_object" (
+  "unmapped_object_id" INTEGER PRIMARY KEY NOT NULL,
+  "type" ENUM(6) NOT NULL,
+  "analysis_id" SMALLINT(5) NOT NULL,
+  "external_db_id" int(10),
+  "identifier" VARCHAR(255) NOT NULL,
+  "unmapped_reason_id" INT(10) NOT NULL,
+  "query_score" DOUBLE,
+  "target_score" DOUBLE,
+  "ensembl_id" INT(10) DEFAULT 0,
+  "ensembl_object_type" ENUM(11) DEFAULT 'RawContig',
+  "parent" VARCHAR(255) DEFAULT NULL
 );
+
 
-CREATE UNIQUE INDEX transcript_attribx ON transcript_attrib (transcript_id, attrib_type_id, value);
 
+
+
+--
+-- Table: "unmapped_reason"
+--
+CREATE TABLE "unmapped_reason" (
+  "unmapped_reason_id" INTEGER PRIMARY KEY NOT NULL,
+  "summary_description" VARCHAR(255),
+  "full_description" VARCHAR(255)
+);
+
 --
--- Table: transcript_intron_supporting_evidence
+-- Table: "xref"
 --
-CREATE TABLE transcript_intron_supporting_evidence (
-  transcript_id integer NOT NULL,
-  intron_supporting_evidence_id integer NOT NULL,
-  previous_exon_id integer NOT NULL,
-  next_exon_id integer NOT NULL,
-  PRIMARY KEY (intron_supporting_evidence_id, transcript_id)
+CREATE TABLE "xref" (
+  "xref_id" INTEGER PRIMARY KEY NOT NULL,
+  "external_db_id" int(10) NOT NULL,
+  "dbprimary_acc" VARCHAR(512) NOT NULL,
+  "display_label" VARCHAR(512) NOT NULL,
+  "version" VARCHAR(10) DEFAULT NULL,
+  "description" TEXT(65535),
+  "info_type" ENUM(18) NOT NULL DEFAULT 'NONE',
+  "info_text" VARCHAR(255) NOT NULL DEFAULT ''
 );
+
+
+
 
 --
--- Table: transcript_supporting_feature
+-- Table: "operon"
 --
-CREATE TABLE transcript_supporting_feature (
-  transcript_id integer NOT NULL DEFAULT 0,
-  feature_type enum,
-  feature_id integer NOT NULL DEFAULT 0
+CREATE TABLE "operon" (
+  "operon_id" INTEGER PRIMARY KEY NOT NULL,
+  "seq_region_id" INT(10) NOT NULL,
+  "seq_region_start" INT(10) NOT NULL,
+  "seq_region_end" INT(10) NOT NULL,
+  "seq_region_strand" TINYINT(2) NOT NULL,
+  "display_label" VARCHAR(255) DEFAULT NULL,
+  "analysis_id" SMALLINT(5) NOT NULL,
+  "stable_id" VARCHAR(128) DEFAULT NULL,
+  "version" SMALLINT(5) DEFAULT NULL,
+  "created_date" DATETIME DEFAULT NULL,
+  "modified_date" DATETIME DEFAULT NULL
 );
 
-CREATE UNIQUE INDEX all_idx03 ON transcript_supporting_feature (transcript_id, feature_type, feature_id);
 
+
+
 --
--- Table: translation
+-- Table: "operon_transcript"
 --
-CREATE TABLE translation (
-  translation_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-  transcript_id integer NOT NULL,
-  seq_start integer NOT NULL,
-  start_exon_id integer NOT NULL,
-  seq_end integer NOT NULL,
-  end_exon_id integer NOT NULL,
-  stable_id varchar(128),
-  version smallint,
-  created_date datetime,
-  modified_date datetime
+CREATE TABLE "operon_transcript" (
+  "operon_transcript_id" INTEGER PRIMARY KEY NOT NULL,
+  "seq_region_id" INT(10) NOT NULL,
+  "seq_region_start" INT(10) NOT NULL,
+  "seq_region_end" INT(10) NOT NULL,
+  "seq_region_strand" TINYINT(2) NOT NULL,
+  "operon_id" INT(10) NOT NULL,
+  "display_label" VARCHAR(255) DEFAULT NULL,
+  "analysis_id" SMALLINT(5) NOT NULL,
+  "stable_id" VARCHAR(128) DEFAULT NULL,
+  "version" SMALLINT(5) DEFAULT NULL,
+  "created_date" DATETIME DEFAULT NULL,
+  "modified_date" DATETIME DEFAULT NULL
 );
+
+
+
 
 --
--- Table: translation_attrib
+-- Table: "operon_transcript_gene"
 --
-CREATE TABLE translation_attrib (
-  translation_id integer NOT NULL DEFAULT 0,
-  attrib_type_id smallint NOT NULL DEFAULT 0,
-  value text NOT NULL
+CREATE TABLE "operon_transcript_gene" (
+  "operon_transcript_id" INT(10),
+  "gene_id" INT(10)
 );
 
-CREATE UNIQUE INDEX translation_attribx ON translation_attrib (translation_id, attrib_type_id, value);
 
 --
--- Table: unmapped_object
+-- Table: "rnaproduct"
 --
-CREATE TABLE unmapped_object (
-  unmapped_object_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-  type enum NOT NULL,
-  analysis_id integer NOT NULL,
-  external_db_id integer,
-  identifier varchar(255) NOT NULL,
-  unmapped_reason_id integer NOT NULL,
-  query_score double precision,
-  target_score double precision,
-  ensembl_id integer DEFAULT 0,
-  ensembl_object_type enum DEFAULT 'RawContig',
-  parent varchar(255)
+CREATE TABLE "rnaproduct" (
+  "rnaproduct_id" INTEGER PRIMARY KEY NOT NULL,
+  "rnaproduct_type_id" SMALLINT(5) NOT NULL,
+  "transcript_id" INT(10) NOT NULL,
+  "seq_start" INT(10) NOT NULL,
+  -- relative to transcript start
+  "start_exon_id" INT(10),
+  "seq_end" INT(10) NOT NULL,
+  -- relative to transcript start
+  "end_exon_id" INT(10),
+  "stable_id" VARCHAR(128) DEFAULT NULL,
+  "version" SMALLINT(5) DEFAULT NULL,
+  "created_date" DATETIME DEFAULT NULL,
+  "modified_date" DATETIME DEFAULT NULL
 );
 
-CREATE UNIQUE INDEX unique_unmapped_obj_idx ON unmapped_object (ensembl_id, ensembl_object_type, identifier, unmapped_reason_id, parent, external_db_id);
 
+
 --
--- Table: unmapped_reason
+-- Table: "rnaproduct_attrib"
 --
-CREATE TABLE unmapped_reason (
-  unmapped_reason_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-  summary_description varchar(255),
-  full_description varchar(255)
+CREATE TABLE "rnaproduct_attrib" (
+  "rnaproduct_id" INT(10) NOT NULL DEFAULT 0,
+  "attrib_type_id" SMALLINT(5) NOT NULL DEFAULT 0,
+  "value" TEXT(65535) NOT NULL
 );
+
+
+
+
 
 --
--- Table: xref
+-- Table: "rnaproduct_type"
 --
-CREATE TABLE xref (
-  xref_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-  external_db_id integer NOT NULL,
-  dbprimary_acc varchar(512) NOT NULL,
-  display_label varchar(512) NOT NULL,
-  version varchar(10),
-  description text,
-  info_type enum NOT NULL DEFAULT 'NONE',
-  info_text varchar(255) NOT NULL DEFAULT ''
+CREATE TABLE "rnaproduct_type" (
+  "rnaproduct_type_id" INTEGER PRIMARY KEY NOT NULL,
+  "code" VARCHAR(20) NOT NULL DEFAULT '',
+  "name" VARCHAR(255) NOT NULL DEFAULT '',
+  "description" TEXT(65535)
 );
 
-CREATE UNIQUE INDEX id_index ON xref (dbprimary_acc, external_db_id, info_type, info_text, version);
 
 COMMIT;

--- a/modules/t/test-genome-DBs/homo_sapiens/patch/external_db.txt
+++ b/modules/t/test-genome-DBs/homo_sapiens/patch/external_db.txt
@@ -108,7 +108,7 @@
 3800	CCDS		KNOWN	240	CCDS	MISC	\N	\N	\N
 3900	PUBMED		KNOWN	5	Sequence Publications	LIT	\N	\N	\N
 4000	MEDLINE		KNOWN	5	MEDLINE	LIT	\N	\N	\N
-4100	UniGene	25 Apr 2013 \	, UniGene Build #236 Homo 	KNOWN	5	UniGene	MISC	\N	\N	\N
+4100	UniGene	"25 Apr 2013 \	, UniGene Build #236 Homo "	KNOWN	5	UniGene	MISC	\N	\N	\N
 4200	RFAM		XREF	190	RFAM	MISC	\N	\N	\N
 4400	Xenopus_Jamboree		KNOWN	1	Jamboree	MISC	\N	\N	\N
 4500	Tiffin		XREF	1	Tiffin DNA motifs	MISC	\N	\N	\N
@@ -494,9 +494,9 @@
 50681	Ens_Ac_transcript		XREF	40	Ensembl Anole Lizard Transcript	MISC	\N	\N	\N
 50682	BGI_Gene	1	XREF	50	BGI_2005_indica_Gene	MISC	\N	\N	BGI gene identifier
 50683	GeneIndex	1	XREF	50	GeneIndex	MISC	\N	\N	\N
-50684	EO	1	XREF	0	Environment Ontology	MISC	\N	\N	Plant environmental conditions ontology terms.\
+50684	EO	1	XREF	0	Environment Ontology	MISC	\N	\N	"Plant environmental conditions ontology terms.\
 More information in there:\
-http://www.gramene.org/plant_ontology/ontology_browse.html#eo
+http://www.gramene.org/plant_ontology/ontology_browse.html#eo"
 50685	Ens_Rn_transcript		XREF	5	Ensembl Rat Transcript	MISC	\N	\N	\N
 50686	Ens_Rn_translation		XREF	5	Ensembl Rat Translation	MISC	\N	\N	\N
 50687	Uppsala University		KNOWN	5	Uppsala University	MISC	\N	\N	\N
@@ -543,8 +543,8 @@ http://www.gramene.org/plant_ontology/ontology_browse.html#eo
 50731	Turkey Genome Consortium		KNOWN	5	Turkey Genome Consortium	MISC	\N	\N	Turkey Genome Consortium
 50732	Yutaka_Satou_Kyoto_Universi		KNOWN	5	Yutaka Satou Kyoto University	MISC	\N	\N	Yutaka Satou Kyoto University
 50733	Chicken_Genome_Consortium		KNOWN	5	International Chicken Genome Consortium	MISC	\N	\N	\N
-50734	TAIR_TRANSLATION	1	XREF	1	TAIR Translation identifiers	MISC	\N	\N	TAIR identifiers to link to Ensembl Translation identifiers.\
-The main requirement behind this entry, is to be able to link TAIR GO annotations to Ensembl Translations.
+50734	TAIR_TRANSLATION	1	XREF	1	TAIR Translation identifiers	MISC	\N	\N	"TAIR identifiers to link to Ensembl Translation identifiers.\
+The main requirement behind this entry, is to be able to link TAIR GO annotations to Ensembl Translations."
 50735	AGI_GENE	1	XREF	1	AGI Gene	MISC	\N	\N	annotation provided by Arizona Genome Institute
 50736	AGI_TRANSCRIPT	1	XREF	1	AGI Transcript	MISC	\N	\N	annotation provided by Arizona Genome Institute
 50737	CGNC		KNOWNXREF	100	CGNC Symbol	PRIMARY_DB_SYNONYM	\N	\N	\N

--- a/travisci/MultiTestDB.conf.travisci.SQLite
+++ b/travisci/MultiTestDB.conf.travisci.SQLite
@@ -1,0 +1,5 @@
+{
+  'driver' => 'SQLite',
+  'dbdir'  => '/var/tmp/MultiTestDB',
+  'user'   => 'travis',
+}

--- a/travisci/harness.sh
+++ b/travisci/harness.sh
@@ -3,15 +3,15 @@
 export PERL5LIB=$PWD/bioperl-live-bioperl-release-1-2-3:$PWD/ensembl-test/modules:$PWD/ensembl/modules:$PWD/modules:$PWD/ensembl-variation/modules:$DEPS/Bio-HTS/blib/lib/:$DEPS/Bio-HTS/blib/arch:$PERL5LIB
 
 
-# if [ "$DB" = 'mysql' ]; then
-#     (cd modules/t && ln -sf MultiTestDB.conf.mysql MultiTestDB.conf)
+if [ "$DB" = 'mysql' ]; then
+   (cd modules/t && ln -sf MultiTestDB.conf.mysql MultiTestDB.conf)
 # elif [ "$DB" = 'sqlite' ]; then
 #     (cd modules/t && ln -sf MultiTestDB.conf.SQLite MultiTestDB.conf)
 #     SKIP_TESTS="--skip dbConnection.t,schema.t,schemaPatches.t"
-# else
-#     echo "Don't know about DB '$DB'"
-#     exit 1;
-# fi
+else
+   echo "Don't know about DB '$DB'"
+   exit 1;
+fi
 
 echo "Running test suite"
 if [ "$COVERALLS" = 'true' ]; then

--- a/travisci/harness.sh
+++ b/travisci/harness.sh
@@ -5,9 +5,9 @@ export PERL5LIB=$PWD/bioperl-live-bioperl-release-1-2-3:$PWD/ensembl-test/module
 
 if [ "$DB" = 'mysql' ]; then
    (cd modules/t && ln -sf MultiTestDB.conf.mysql MultiTestDB.conf)
-# elif [ "$DB" = 'sqlite' ]; then
-#     (cd modules/t && ln -sf MultiTestDB.conf.SQLite MultiTestDB.conf)
-#     SKIP_TESTS="--skip dbConnection.t,schema.t,schemaPatches.t"
+ elif [ "$DB" = 'sqlite' ]; then
+     (cd modules/t && ln -sf MultiTestDB.conf.SQLite MultiTestDB.conf)
+     SKIP_TESTS="--skip dbConnection.t,schema.t,schemaPatches.t"
 else
    echo "Don't know about DB '$DB'"
    exit 1;


### PR DESCRIPTION
## Description

Fixing failing Travis branch builds for changes/PRs targeting a `release/xxx` branch.
Bumped up Perl versions for Travis: using 5.26 and 5.30.
Restored SQLite testing environment.

## Use case

In some cases changes need to be applied to a `release/xxx` branch; a PR is created against `release/xxx` from a new branch based on `release/xxx`, and Travis build fails at branch level (it succeeds at PR level though).
This happens because the dependent repos `ensembl`, `ensembl-test` and `ensembl-variation` are on their `main` branch, instead of being on `release/xxx`.

Also, bumped up Perl versions for CI pipeline.

### Limitation

To make this work, the new branch name must contain "fix-xxx",  "xxx" being the Ensembl release number.

## Benefits

Minimise Build failures, and avoid merging PRs which failed on Travis.

## Possible Drawbacks

None

## Testing

Manually tested.
