### PR TITLE
Fix ensembl-rest issue 610: close on unblessed ref in TabixParser

### DIFF
--- a/modules/Bio/EnsEMBL/IO/Parser/BCF.pm
+++ b/modules/Bio/EnsEMBL/IO/Parser/BCF.pm
@@ -124,7 +124,9 @@ sub read_block {
 sub close {
   my $self = shift;
 
-  $self->{iterator}->close if $self->{iterator};
+  if ($self->{iterator} and UNIVERSAL::isa($self->{iterator}, 'Bio::DB::HTS::VCF::Iterator')) {
+    $self->{iterator}->close();
+  }
   my $report = $self->{bcf_file}->DESTROY;
 
   return (defined $report) ? 0 : 1;

--- a/modules/Bio/EnsEMBL/IO/TabixParser.pm
+++ b/modules/Bio/EnsEMBL/IO/TabixParser.pm
@@ -118,7 +118,11 @@ sub read_block {
 
 sub close {
   my $self = shift;
-  $self->{iterator}->close if $self->{iterator};
+
+  if ($self->{iterator} and UNIVERSAL::isa($self->{iterator}, 'Bio::DB::HTS::Tabix::Iterator')) {
+    $self->{iterator}->close();
+  }
+
   my $report = $self->{tabix_file}->DESTROY;
   return (defined $report) ? 0 : 1;
 }


### PR DESCRIPTION
A user reported an error for the REST API in
https://github.com/Ensembl/ensembl-rest/issues/610.
This originates in the TabixParser, where we try to close something
that's not our Tabix iterator. This was fixed for another case in sub
seek in the same file a few years ago. The root cause is still unknown.

Same fix applied for BCF.