### PR TITLE
Release 110 - Patch test databases to allow null meta_value and extend the meta_key varchar length

### DIFF
--- a/modules/t/test-genome-DBs/homo_sapiens/core/meta.txt
+++ b/modules/t/test-genome-DBs/homo_sapiens/core/meta.txt
@@ -127,3 +127,4 @@
 194	\N	patch	patch_109_110_a.sql|schema_version
 195	\N	patch	patch_109_110_b.sql|Add IS_PAR relationship to link X- and Y-PAR genes
 196	\N	patch	patch_109_110_c.sql|Allow gene id to belong to multiple alt allele groups
+197	\N	patch	patch_109_110_d.sql|Extend meta_key length to 64 - allow NULL in meta_value

--- a/modules/t/test-genome-DBs/homo_sapiens/core/table.sql
+++ b/modules/t/test-genome-DBs/homo_sapiens/core/table.sql
@@ -485,12 +485,12 @@ CREATE TABLE `marker_synonym` (
 CREATE TABLE `meta` (
   `meta_id` int(11) NOT NULL AUTO_INCREMENT,
   `species_id` int(10) unsigned DEFAULT '1',
-  `meta_key` varchar(40) NOT NULL,
-  `meta_value` varchar(255) NOT NULL,
+  `meta_key` varchar(64) NOT NULL,
+  `meta_value` varchar(255) DEFAULT NULL,
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`),
   KEY `species_value_idx` (`species_id`,`meta_value`)
-) ENGINE=MyISAM AUTO_INCREMENT=197 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
+) ENGINE=MyISAM AUTO_INCREMENT=198 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `meta_coord` (
   `table_name` varchar(40) COLLATE latin1_bin NOT NULL DEFAULT '',

--- a/modules/t/test-genome-DBs/homo_sapiens/empty/meta.txt
+++ b/modules/t/test-genome-DBs/homo_sapiens/empty/meta.txt
@@ -127,3 +127,4 @@
 176	\N	patch	patch_109_110_a.sql|schema_version
 177	\N	patch	patch_109_110_b.sql|Add IS_PAR relationship to link X- and Y-PAR genes
 178	\N	patch	patch_109_110_c.sql|Allow gene id to belong to multiple alt allele groups
+179	\N	patch	patch_109_110_d.sql|Extend meta_key length to 64 - allow NULL in meta_value

--- a/modules/t/test-genome-DBs/homo_sapiens/empty/table.sql
+++ b/modules/t/test-genome-DBs/homo_sapiens/empty/table.sql
@@ -485,12 +485,12 @@ CREATE TABLE `marker_synonym` (
 CREATE TABLE `meta` (
   `meta_id` int(11) NOT NULL AUTO_INCREMENT,
   `species_id` int(10) unsigned DEFAULT '1',
-  `meta_key` varchar(40) NOT NULL,
-  `meta_value` varchar(255) NOT NULL,
+  `meta_key` varchar(64) NOT NULL,
+  `meta_value` varchar(255) DEFAULT NULL,
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`),
   KEY `species_value_idx` (`species_id`,`meta_value`)
-) ENGINE=MyISAM AUTO_INCREMENT=179 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
+) ENGINE=MyISAM AUTO_INCREMENT=180 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `meta_coord` (
   `table_name` varchar(40) COLLATE latin1_bin NOT NULL DEFAULT '',

--- a/modules/t/test-genome-DBs/homo_sapiens/patch/meta.txt
+++ b/modules/t/test-genome-DBs/homo_sapiens/patch/meta.txt
@@ -132,3 +132,4 @@
 2139	\N	patch	patch_109_110_a.sql|schema_version
 2140	\N	patch	patch_109_110_b.sql|Add IS_PAR relationship to link X- and Y-PAR genes
 2141	\N	patch	patch_109_110_c.sql|Allow gene id to belong to multiple alt allele groups
+2142	\N	patch	patch_109_110_d.sql|Extend meta_key length to 64 - allow NULL in meta_value

--- a/modules/t/test-genome-DBs/homo_sapiens/patch/table.sql
+++ b/modules/t/test-genome-DBs/homo_sapiens/patch/table.sql
@@ -485,12 +485,12 @@ CREATE TABLE `marker_synonym` (
 CREATE TABLE `meta` (
   `meta_id` int(11) NOT NULL AUTO_INCREMENT,
   `species_id` int(10) unsigned DEFAULT '1',
-  `meta_key` varchar(40) NOT NULL,
-  `meta_value` varchar(255) NOT NULL,
+  `meta_key` varchar(64) NOT NULL,
+  `meta_value` varchar(255) DEFAULT NULL,
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`),
   KEY `species_value_idx` (`species_id`,`meta_value`)
-) ENGINE=MyISAM AUTO_INCREMENT=2142 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
+) ENGINE=MyISAM AUTO_INCREMENT=2143 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `meta_coord` (
   `table_name` varchar(40) COLLATE latin1_bin NOT NULL DEFAULT '',


### PR DESCRIPTION
Updates to ensembl-io repo based on changes brought in for PR https://github.com/Ensembl/ensembl/pull/680