### PR TITLE
Bug fix: Handling multiple tag values

### DIFF
--- a/modules/Bio/EnsEMBL/IO/Parser/GTF.pm
+++ b/modules/Bio/EnsEMBL/IO/Parser/GTF.pm
@@ -166,3 +166,4 @@ sub create_object {
 }
 
 1;
+

--- a/modules/Bio/EnsEMBL/IO/Parser/GTF.pm
+++ b/modules/Bio/EnsEMBL/IO/Parser/GTF.pm
@@ -121,7 +121,15 @@ sub get_attributes {
     $value =~ s/"//g if $value;
     $key =~ s/^\s+//;
     $key =~ s/\s+$//;
-    $attributes{$key} = $value ? $self->decode_string($value) : $value;
+    $value = $self->decode_string($value) if $value;
+
+    if (defined($attributes{$key})) {
+      my @values = (ref($attributes{$key}) eq 'ARRAY' ? @{$attributes{$key}} : ($attributes{$key}));
+      push(@values, $value);
+      $attributes{$key} = \@values;
+    } else {
+      $attributes{$key} = $value;
+    }
   }
   return \%attributes;
 }


### PR DESCRIPTION
A bug was discovered in the GTF parser which doesn't handle multiple "tag" values. The GTF files might contain multiple parameters with the key "tag" (in the 9th column), and when read by the parser, each was overwritten by the next ending up with only 1 tag value. This change fixes that and instead creates an array of values if the key occurs more than once.

Note: The GFF3 files have the tags as a comma-separated list so the parser returns it that way. This change might not be completely compatible with GFF3 but I think an array displays the idea of multiple values in a clearer way.