### PR TITLE
Added new 'gencode_primary' attrib

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: trusty
+dist: xenial
 
 language: "perl"
 
@@ -12,21 +12,20 @@ cache:
 
 perl:
   - "5.26"
-  - "5.14"
-#  - "5.12"
-#  - "5.10"
+  - "5.30"
 
-# env:
-#  - COVERALLS=true  DB=mysql
-  # - COVERALLS=false DB=mysql
-#  - COVERALLS=false DB=sqlite
+env:
+  matrix:
+  - COVERALLS=true  DB=mysql
+  - COVERALLS=false DB=mysql
+  - COVERALLS=false DB=sqlite
 
 addons:
   apt:
     packages:
       - unzip
       - apache2
-      - libpng12-dev
+      - libpng-dev
       - libssl-dev
       - openssl
 
@@ -34,9 +33,12 @@ services:
   - mysql
 
 before_install:
-    - git clone --branch master --depth 1 https://github.com/Ensembl/ensembl-test.git
-    - git clone --branch master --depth 1 https://github.com/Ensembl/ensembl.git
-    - git clone --branch master --depth 1 https://github.com/Ensembl/ensembl-variation.git
+    - export ENSEMBL_BRANCH='main'
+    - export ENSEMBL_VER=$(echo $TRAVIS_BRANCH | grep -P -o '(?<=version[\W_]|fix[\W_]|release[\W_])(\d+)')
+    - if [[ $ENSEMBL_VER =~ [0-9]+ ]]; then ENSEMBL_BRANCH="release/$ENSEMBL_VER"; fi
+    - git clone --branch $ENSEMBL_BRANCH --depth 1 https://github.com/Ensembl/ensembl-test.git
+    - git clone --branch $ENSEMBL_BRANCH --depth 1 https://github.com/Ensembl/ensembl.git
+    - git clone --branch $ENSEMBL_BRANCH --depth 1 https://github.com/Ensembl/ensembl-variation.git
     - export CWD=$PWD
     - export DEPS=$HOME/dependencies
     - mkdir -p $DEPS
@@ -57,31 +59,21 @@ install:
     - cd $CWD
     - cpanm -v --installdeps --with-recommends --notest --cpanfile ensembl/cpanfile .
     - cpanm -v --installdeps --notest .
-    - cpanm Bio::DB::HTS
     - cpanm -n Devel::Cover::Report::Coveralls
-    - cpanm -n DBD::SQLite
-    - cpanm JSON
-    - cpanm URI::Escape
+    - cpanm -n Bio::DB::HTS DBD::SQLite JSON URI::Escape
     - mysql -u root -h localhost -e 'GRANT ALL PRIVILEGES ON *.* TO "travis"@"%"'
-    - cp travisci/MultiTestDB.conf.travisci.mysql  modules/t/MultiTestDB.conf
-#    - cp travisci/MultiTestDB.conf.travisci.SQLite modules/t/MultiTestDB.conf.SQLite
+    - cp travisci/MultiTestDB.conf.travisci.mysql  modules/t/MultiTestDB.conf.mysql
+    - cp travisci/MultiTestDB.conf.travisci.SQLite modules/t/MultiTestDB.conf.SQLite
 
 script: "./travisci/harness.sh"
 
-# Get the matrix to only build coveralls support when on 5.10
-# matrix:
-#   exclude:
-#     - perl: "5.10"
-#       env: COVERALLS=false DB=mysql
-#     - perl: "5.12"
-#       env: COVERALLS=false DB=sqlite
-#     - perl: "5.12"
-#       env: COVERALLS=true  DB=mysql
-#     - perl: "5.14"
-#       env: COVERALLS=false DB=sqlite
-#     - perl: "5.14"
-#       env: COVERALLS=true  DB=mysql
-#
+# Get the matrix to only build coveralls support when on 5.26
+jobs:
+  exclude:
+    - perl: "5.30"
+      env: COVERALLS=true DB=mysql
+    - perl: "5.26"
+      env: COVERALLS=false DB=mysql
 
 notifications:
   slack:

--- a/modules/Bio/EnsEMBL/IO/Translator/Feature.pm
+++ b/modules/Bio/EnsEMBL/IO/Translator/Feature.pm
@@ -372,11 +372,12 @@ sub gtf_attributes {
 	    if ( $object->isa('Bio::EnsEMBL::Transcript') ) {
 	      $transcript = $object;
 
-	      foreach my $tag (qw/cds_end_NF cds_start_NF mRNA_end_NF mRNA_start_NF gencode_basic/) {
+	      foreach my $tag (qw/cds_end_NF cds_start_NF mRNA_end_NF mRNA_start_NF gencode_basic gencode_primary/) {
 		      my $attributes = $transcript->get_all_Attributes($tag);
 		      if(@{$attributes}) {
 		        my $value = $tag;
 		        $value = "basic" if $tag eq "gencode_basic";
+		        $value = "primary" if $tag eq "gencode_primary";
 		        $self->add_attr($attrs, 'tag', $value);
 		      }
 	      }

--- a/modules/Bio/EnsEMBL/IO/Translator/Feature.pm
+++ b/modules/Bio/EnsEMBL/IO/Translator/Feature.pm
@@ -372,12 +372,13 @@ sub gtf_attributes {
 	    if ( $object->isa('Bio::EnsEMBL::Transcript') ) {
 	      $transcript = $object;
 
-	      foreach my $tag (qw/cds_end_NF cds_start_NF mRNA_end_NF mRNA_start_NF gencode_basic gencode_primary/) {
+	      foreach my $tag (qw/cds_end_NF cds_start_NF mRNA_end_NF mRNA_start_NF gencode_basic gencode_primary MANE_Select is_canonical MANE_Plus_Clinical/) {
 		      my $attributes = $transcript->get_all_Attributes($tag);
 		      if(@{$attributes}) {
 		        my $value = $tag;
 		        $value = "basic" if $tag eq "gencode_basic";
 		        $value = "primary" if $tag eq "gencode_primary";
+                $value = "Ensembl_canonical" if $tag eq "is_canonical";
 		        $self->add_attr($attrs, 'tag', $value);
 		      }
 	      }
@@ -407,7 +408,6 @@ sub gtf_attributes {
 	    $attrs->{transcript_biotype} = $transcript->biotype();
 	    $attrs->{havana_transcript} = $transcript->havana_transcript()->display_id if $transcript->havana_transcript();
 	    $attrs->{havana_version} = $transcript->havana_transcript()->version if $transcript->havana_transcript();
-	    $self->add_attr($attrs, 'tag', 'basic') if $transcript->gencode_basic();
 	    $attrs->{transcript_support_level} = $transcript->tsl() if $transcript->tsl();
 
 	    $gene = $object->get_Gene();

--- a/modules/Bio/EnsEMBL/Utils/IO/GTFSerializer.pm
+++ b/modules/Bio/EnsEMBL/Utils/IO/GTFSerializer.pm
@@ -487,11 +487,12 @@ sub _print_attribs {
   }
 
   if($transcript && $transcript->isa('Bio::EnsEMBL::Transcript')) {
-    foreach my $tag (qw/cds_end_NF cds_start_NF mRNA_end_NF mRNA_start_NF gencode_basic/) {
+    foreach my $tag (qw/cds_end_NF cds_start_NF mRNA_end_NF mRNA_start_NF gencode_basic gencode_primary/) {
       my $attributes = $transcript->get_all_Attributes($tag);
       if(@{$attributes}) {
         my $value = $tag;
         $value = "basic" if $tag eq "gencode_basic";
+        $value = "primary" if $tag eq "gencode_primary";
         print $fh qq{ tag "${value}";};
       }
     }

--- a/modules/Bio/EnsEMBL/Utils/IO/GTFSerializer.pm
+++ b/modules/Bio/EnsEMBL/Utils/IO/GTFSerializer.pm
@@ -487,12 +487,13 @@ sub _print_attribs {
   }
 
   if($transcript && $transcript->isa('Bio::EnsEMBL::Transcript')) {
-    foreach my $tag (qw/cds_end_NF cds_start_NF mRNA_end_NF mRNA_start_NF gencode_basic gencode_primary/) {
+    foreach my $tag (qw/cds_end_NF cds_start_NF mRNA_end_NF mRNA_start_NF gencode_basic gencode_primary MANE_Select is_canonical MANE_Plus_Clinical/) {
       my $attributes = $transcript->get_all_Attributes($tag);
       if(@{$attributes}) {
         my $value = $tag;
         $value = "basic" if $tag eq "gencode_basic";
         $value = "primary" if $tag eq "gencode_primary";
+        $value = "Ensembl_canonical" if $tag eq "is_canonical";
         print $fh qq{ tag "${value}";};
       }
     }


### PR DESCRIPTION
## Description

A new transcript attribute "gencode_primary" has being introduced (for human).
This attribute is meant to eventually - i.e. in the long run - replace GENCODE basic.

This change is necessary to support the displaying of the new attribute on the web site, as well as having it available in the published annotation files.

This PR goes alongside PR #694 in Ensembl/ensembl repository

## Use case

Adds the ability to dump the new transcript attribute in files.

## Benefits

It's a must have to properly handle the new attribute.

## Possible Drawbacks

None

## Testing

TBC
