### PR TITLE
Avoid warnings in GTF attributes ending with a space after delimiter

### DIFF
--- a/modules/Bio/EnsEMBL/IO/Parser/GTF.pm
+++ b/modules/Bio/EnsEMBL/IO/Parser/GTF.pm
@@ -118,6 +118,8 @@ sub get_attributes {
   my %attributes;
   foreach my $attr (split(';',$self->get_raw_attributes)) {
     my ($key, $value) = split(' ',$attr, 2);
+    next unless $key;
+
     $value =~ s/"//g if $value;
     $key =~ s/^\s+//;
     $key =~ s/\s+$//;

--- a/modules/t/gtf.t
+++ b/modules/t/gtf.t
@@ -79,7 +79,7 @@ is( $parser->get_attribute_by_name('transcript_source'),
 ## Second record
 ok( $parser->next(), "Loading second record" );
 $expected_raw_attributes =
-'gene_id "ENSGALG00000014638"; gene_version "4"; gene_name "ASH1L"; gene_source "ensembl"; gene_biotype "protein_coding";';
+'gene_id "ENSGALG00000014638"; gene_version "4"; gene_name "ASH1L"; gene_source "ensembl"; gene_biotype "protein_coding"; ';
 $expected_attributes = {
     gene_id      => 'ENSGALG00000014638',
     gene_version => '4',

--- a/modules/t/input/data.gtf
+++ b/modules/t/input/data.gtf
@@ -4,4 +4,4 @@
 #!genome-build-accession NCBI:GCA_000002315.2
 #!genebuild-last-updated 2013-12
 1	ensembl	CDS	144373415	144373470	.	-	2	gene_id "ENSGALG00000016887"; gene_version "3"; transcript_id "ENSGALT00000027289"; transcript_version "3"; exon_number "21"; gene_source "ensembl"; gene_biotype "protein_coding"; transcript_source "ensembl"; transcript_biotype "protein_coding"; protein_id "ENSGALP00000027238"; protein_version "3";
-25	ensembl	gene	1386032	1419314	7	+	.	gene_id "ENSGALG00000014638"; gene_version "4"; gene_name "ASH1L"; gene_source "ensembl"; gene_biotype "protein_coding";
+25	ensembl	gene	1386032	1419314	7	+	.	gene_id "ENSGALG00000014638"; gene_version "4"; gene_name "ASH1L"; gene_source "ensembl"; gene_biotype "protein_coding"; 


### PR DESCRIPTION
When running VEP with a GTF whose attributes end with delimiter and a space `; ` (like [some examples from NCBI](https://ftp.ncbi.nlm.nih.gov/genomes/all/GCF/000/001/405/GCF_000001405.25_GRCh37.p13/GCF_000001405.25_GRCh37.p13_genomic.gtf.gz)), the parser returns the following warnings:

```
Use of uninitialized value $key in substitution (s///) at /opt/vep/src/ensembl-vep/Bio/EnsEMBL/IO/Parser/GTF.pm line 122, <$fh> line 131.
Use of uninitialized value $key in substitution (s///) at /opt/vep/src/ensembl-vep/Bio/EnsEMBL/IO/Parser/GTF.pm line 123, <$fh> line 131.
Use of uninitialized value $key in hash element at /opt/vep/src/ensembl-vep/Bio/EnsEMBL/IO/Parser/GTF.pm line 124, <$fh> line 131.
```

This PR fixes that issue. Also updated the unit tests to contemplate this case.

## Testing

Run the updated unit test file `modules/t/gtf.t`:
- without the change in `modules/Bio/EnsEMBL/IO/Parser/GTF.pm`: should return the warning stated above.
- with the change: should complete without issues.