### PR TITLE
Tidying up TravisCI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: xenial
+dist: focal
 
 language: "perl"
 
@@ -16,14 +16,13 @@ perl:
 
 env:
   matrix:
-  - COVERALLS=true  DB=mysql
+  - COVERALLS=true  DB=mysql COVERALLS_REPO_TOKEN=${{secret.COVERALLS_REPO_TOKEN}}
   - COVERALLS=false DB=mysql
   - COVERALLS=false DB=sqlite
 
 addons:
   apt:
     packages:
-      - unzip
       - apache2
       - libpng-dev
       - libssl-dev
@@ -53,14 +52,12 @@ install:
     - export HTSLIB_DIR=$DEPS/htslib
     - export MACHTYPE=$(uname -m)
     - export CFLAGS="-fPIC"
-    - export PERL5LIB=$DEPS/bioperl-live-release-1-6-924:$PERL5LIB
+    - export PERL5LIB=$DEPS/bioperl-live:$PERL5LIB
     - cd $DEPS
     - $CWD/travisci/build_c.sh
     - cd $CWD
-    - cpanm -v --installdeps --with-recommends --notest --cpanfile ensembl/cpanfile .
-    - cpanm -v --installdeps --notest .
-    - cpanm -n Devel::Cover::Report::Coveralls
-    - cpanm -n Bio::DB::HTS DBD::SQLite JSON URI::Escape
+    - cpanm -v --installdeps --with-all-features --notest --cpanfile ensembl/cpanfile .
+    - cpanm -v --installdeps .
     - mysql -u root -h localhost -e 'GRANT ALL PRIVILEGES ON *.* TO "travis"@"%"'
     - cp travisci/MultiTestDB.conf.travisci.mysql  modules/t/MultiTestDB.conf.mysql
     - cp travisci/MultiTestDB.conf.travisci.SQLite modules/t/MultiTestDB.conf.SQLite
@@ -71,7 +68,7 @@ script: "./travisci/harness.sh"
 jobs:
   exclude:
     - perl: "5.30"
-      env: COVERALLS=true DB=mysql
+      env: COVERALLS=true DB=mysql COVERALLS_REPO_TOKEN=${{secret.COVERALLS_REPO_TOKEN}}
     - perl: "5.26"
       env: COVERALLS=false DB=mysql
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,6 +66,7 @@ install:
     - cpanm -v --sudo --installdeps --with-all-features --notest --cpanfile ensembl/cpanfile .
     - cpanm -v --sudo --installdeps .
     - mysql -u root -h localhost -e 'GRANT ALL PRIVILEGES ON *.* TO "travis"@"%"'
+    - mysql -u root -h localhost -e 'SET GLOBAL local_infile=1'
     - cp travisci/MultiTestDB.conf.travisci.mysql  modules/t/MultiTestDB.conf.mysql
     - cp travisci/MultiTestDB.conf.travisci.SQLite modules/t/MultiTestDB.conf.SQLite
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ cache:
 
 perl:
   - "5.26"
-  - "5.30"
+  - "5.32"
 
 env:
   matrix:
@@ -75,7 +75,7 @@ script: "./travisci/harness.sh"
 # Get the matrix to only build coveralls support when on 5.26
 jobs:
   exclude:
-    - perl: "5.30"
+    - perl: "5.32"
       env: COVERALLS=true DB=mysql COVERALLS_REPO_TOKEN=${{secret.COVERALLS_REPO_TOKEN}}
     - perl: "5.26"
       env: COVERALLS=false DB=mysql

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,11 @@ addons:
   apt:
     packages:
       - apache2
+      - libbz2-dev
+      - libcurl4-gnutls-dev
+      - libexpat1-dev
+      - liblzma-dev
+      - libmysqlclient-dev
       - libpng-dev
       - libssl-dev
       - openssl
@@ -32,12 +37,14 @@ services:
   - mysql
 
 before_install:
+    - git clone --depth 1 https://github.com/Ensembl/ensembl-git-tools.git
+    - export PATH=$PWD/ensembl-git-tools/bin:$PATH
     - export ENSEMBL_BRANCH='main'
     - export ENSEMBL_VER=$(echo $TRAVIS_BRANCH | grep -P -o '(?<=version[\W_]|fix[\W_]|release[\W_])(\d+)')
     - if [[ $ENSEMBL_VER =~ [0-9]+ ]]; then ENSEMBL_BRANCH="release/$ENSEMBL_VER"; fi
     - git clone --branch $ENSEMBL_BRANCH --depth 1 https://github.com/Ensembl/ensembl-test.git
     - git clone --branch $ENSEMBL_BRANCH --depth 1 https://github.com/Ensembl/ensembl.git
-    - git clone --branch $ENSEMBL_BRANCH --depth 1 https://github.com/Ensembl/ensembl-variation.git
+    - git-ensembl --clone --branch $ENSEMBL_BRANCH --secondary_branch main --depth 1 https://github.com/Ensembl/ensembl-variation.git
     - export CWD=$PWD
     - export DEPS=$HOME/dependencies
     - mkdir -p $DEPS

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,8 +63,8 @@ install:
     - cd $DEPS
     - $CWD/travisci/build_c.sh
     - cd $CWD
-    - cpanm -v --installdeps --with-all-features --notest --cpanfile ensembl/cpanfile .
-    - cpanm -v --installdeps .
+    - cpanm -v --sudo --installdeps --with-all-features --notest --cpanfile ensembl/cpanfile .
+    - cpanm -v --sudo --installdeps .
     - mysql -u root -h localhost -e 'GRANT ALL PRIVILEGES ON *.* TO "travis"@"%"'
     - cp travisci/MultiTestDB.conf.travisci.mysql  modules/t/MultiTestDB.conf.mysql
     - cp travisci/MultiTestDB.conf.travisci.SQLite modules/t/MultiTestDB.conf.SQLite

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ before_install:
     - if [[ $ENSEMBL_VER =~ [0-9]+ ]]; then ENSEMBL_BRANCH="release/$ENSEMBL_VER"; fi
     - git clone --branch $ENSEMBL_BRANCH --depth 1 https://github.com/Ensembl/ensembl-test.git
     - git clone --branch $ENSEMBL_BRANCH --depth 1 https://github.com/Ensembl/ensembl.git
-    - git-ensembl --clone --branch $ENSEMBL_BRANCH --secondary_branch main --depth 1 https://github.com/Ensembl/ensembl-variation.git
+    - git-ensembl --clone --branch $ENSEMBL_BRANCH --secondary_branch main --depth 1 ensembl-variation
     - export CWD=$PWD
     - export DEPS=$HOME/dependencies
     - mkdir -p $DEPS

--- a/cpanfile
+++ b/cpanfile
@@ -1,3 +1,4 @@
 requires 'Bio::DB::BigFile';
 requires 'Bio::DB::HTS';
 requires 'Try::Tiny';
+

--- a/cpanfile
+++ b/cpanfile
@@ -1,2 +1,3 @@
 requires 'Bio::DB::BigFile';
+requires 'Bio::DB::HTS';
 requires 'Try::Tiny';

--- a/cpanfile
+++ b/cpanfile
@@ -1,4 +1,12 @@
 requires 'Bio::DB::BigFile';
 requires 'Bio::DB::HTS';
 requires 'Try::Tiny';
+requires 'DBD::SQLite';
+requires 'JSON';
 
+test_requires 'Devel::Cover';
+test_requires 'Devel::Cover::Report::Coveralls';
+test_requires 'Test::Exception';
+test_requires 'Moose';
+test_requires 'Devel::Cycle';
+test_requires 'Test::Warnings';

--- a/travisci/build_c.sh
+++ b/travisci/build_c.sh
@@ -16,7 +16,9 @@ export MYSQLLIBS=`mysql_config --libs`
 
 # Build kent src
 cd kent-335_base/src/lib
-echo 'CFLAGS="-fPIC"' > ../inc/localEnvironment.mk
+sed -i "s/CC=gcc/CC=gcc -fPIC/g" ../inc/common.mk
+sed -i "1109s/my_bool/bool/" ../hg/lib/jksql.c
+sed -i "1110s/MYSQL_OPT_SSL_VERIFY_SERVER_CERT/CLIENT_SSL_VERIFY_SERVER_CERT/" ../hg/lib/jksql.c
 make
 cd ../jkOwnLib
 make

--- a/travisci/get_dependencies.sh
+++ b/travisci/get_dependencies.sh
@@ -7,7 +7,7 @@ fi
 
 echo 'Getting HTSlib'
 if [ ! -d htslib ]; then
-  git clone --branch 1.13 --depth 1 https://github.com/samtools/htslib.git
+  git clone --branch 1.13 --recurse-submodules --shallow-submodules https://github.com/samtools/htslib.git
 fi
 
 echo 'Getting jksrc'

--- a/travisci/get_dependencies.sh
+++ b/travisci/get_dependencies.sh
@@ -1,14 +1,13 @@
 #!/bin/bash
 
 echo 'Getting BioPerl'
-if [ ! -f release-1-6-924.zip ]; then
-  wget -O release-1-6-924.zip https://github.com/bioperl/bioperl-live/archive/release-1-6-924.zip
-  unzip -q release-1-6-924.zip
+if [ ! -d bioperl-live ]; then
+  git clone -b release-1-6-924 --depth 1 https://github.com/bioperl/bioperl-live.git
 fi
 
 echo 'Getting HTSlib'
 if [ ! -d htslib ]; then
-  git clone --branch 1.3.2 --depth 1 https://github.com/samtools/htslib.git
+  git clone --branch 1.13 --depth 1 https://github.com/samtools/htslib.git
 fi
 
 echo 'Getting jksrc'

--- a/travisci/harness.sh
+++ b/travisci/harness.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-export PERL5LIB=$PWD/bioperl-live-bioperl-release-1-2-3:$PWD/ensembl-test/modules:$PWD/ensembl/modules:$PWD/modules:$PWD/ensembl-variation/modules:$DEPS/Bio-HTS/blib/lib/:$DEPS/Bio-HTS/blib/arch:$PERL5LIB
+export PERL5LIB=$PWD/bioperl-live:$PWD/ensembl-test/modules:$PWD/ensembl/modules:$PWD/modules:$PWD/ensembl-variation/modules:$PERL5LIB
 
 
 if [ "$DB" = 'mysql' ]; then

--- a/travisci/harness.sh
+++ b/travisci/harness.sh
@@ -2,7 +2,6 @@
 
 export PERL5LIB=$PWD/bioperl-live:$PWD/ensembl-test/modules:$PWD/ensembl/modules:$PWD/modules:$PWD/ensembl-variation/modules:$PERL5LIB
 
-
 if [ "$DB" = 'mysql' ]; then
    (cd modules/t && ln -sf MultiTestDB.conf.mysql MultiTestDB.conf)
  elif [ "$DB" = 'sqlite' ]; then


### PR DESCRIPTION
- Moved Perl deps from `.travis.yml` to `cpanfile`
- Updated htslib version from `1.3.2` to `1.13`
- Bumped up TravisCI image to `focal`
- Added COVERALLS repo token
- Harmonised max Perl version to core `ensembl` repo (5.32)
- Added logic for Variation cloning to default to its `main` branch, if `release/xxx` is missing