### PR TITLE
Reset PSL parser at end of validation

### DIFF
--- a/modules/Bio/EnsEMBL/IO/Parser/Psl.pm
+++ b/modules/Bio/EnsEMBL/IO/Parser/Psl.pm
@@ -611,6 +611,9 @@ sub validate {
       last;
     }
 
+    $self->reset;
+    $self->next_block() if ($self->{'filename'});  # pre-load peek buffer
+
     return $valid;
 }
 

--- a/modules/t/psl.t
+++ b/modules/t/psl.t
@@ -53,7 +53,9 @@ ok ($B->[0] eq 171, 'QStarts');
 my $C = $parser->get_tStarts();
 ok ($C->[0] eq 34674832, 'TStarts');
 ok ($parser->next(), "Loading second record");
+ok ($parser->get_tEnd() eq 13073747, "TEnd of second record");
 ok ($parser->next(), "Loading third record");
+ok ($parser->get_tEnd() eq 13073748, "TEnd of third record");
 ok (!$parser->next(), "Reaching end of file");
 ok ($parser->close(), "Closing file");
 

--- a/modules/t/psl.t
+++ b/modules/t/psl.t
@@ -24,6 +24,7 @@ use FindBin;
 my $test_file = $FindBin::Bin . '/input/data.psl';
 
 my $parser = Bio::EnsEMBL::IO::Parser::Psl->open($test_file);
+ok ($parser->validate(), "Validating psl format");
 ok ($parser->next(), "Loading first record");
 my $test_desc = 'Fish BLAT';
 is_deeply($parser->get_metadata_value('description'), $test_desc, "Test track description");


### PR DESCRIPTION
This PR would reset the PSL Parser on completion of validation, addressing an issue whereby parsed PSL data, if validated, lacks one of its records.

This change would make its behaviour more consistent with validation of other column-based parsers (e.g. [line 290 of ColumnBasedParser](https://github.com/Ensembl/ensembl-io/blob/25061d3be5b2d65d1111fcbc01f5b871e203ad5e/modules/Bio/EnsEMBL/IO/ColumnBasedParser.pm#L290) ).

The change would also update `psl.t` to call the `Bio::EnsEMBL::IO::Parser::Psl::validate` method.

See also: [ensembl-webcode PR 1152](https://github.com/Ensembl/ensembl-webcode/pull/1152)

---

The effect of the change is most easily illustrated by uploading custom data to the Ensembl website.

The following examples use the example PSL file at: https://www.ensembl.org/info/website/upload/sample_files/example.psl

Before:
1. With the `example.psl` file downloaded, go to the region corresponding to the first PSL record: https://www.ensembl.org/Homo_sapiens/Location/View?r=19:7117070-7293902;db=core
2. Click on on "Custom tracks" and upload the `example.psl` file.
3. On successful upload, the modal window indicates that the nearest region with data is: 15:99250898-99500491

After:
1. With the same `example.psl` file as before, go to the region corresponding to the first PSL record: http://wp-np2-35.ebi.ac.uk:5092/Homo_sapiens/Location/View?r=19:7117070-7293902;db=core
2. Click on on "Custom tracks" and upload the `example.psl` file.
3. On successful upload, the modal window indicates that the nearest region with data is: 19:7117070-7293902
